### PR TITLE
EDIT_SAV_FILE can add new files to baldur.sav

### DIFF
--- a/README-WeiDU-Changes.txt
+++ b/README-WeiDU-Changes.txt
@@ -41,6 +41,7 @@ Version 239:
   * Document EDIT_SAV_FILE.
   * TP2 precedence order is now MyMod/MyMod.tp2, MyMod/Setup-MyMod.tp2,
     MyMod.tp2, Setup-MyMod.tp2.
+  * Allow EDIT_SAV_FILE to add wholly new files to SAV files.
 
 Version 238:
   * Add output_path option to HANDLE_AUDIO and HANDLE_TILESETS.

--- a/doc/base.tex
+++ b/doc/base.tex
@@ -4914,7 +4914,8 @@ or & \DEFSYN{INNER!ACTION} \t{BEGIN} \ttref{TP2 Action} \Slist \t{END} &
   \t{COPY!EXISTING ~foo.2da~}. More formally, if the inner action and the
   outer action both modify the same file, the results are undefined.}\\
 
-or & \DEFINE{EDIT!SAV!FILE} level \t{BEGIN} \ttref{TP2 Patch} \Slist \t{END} &
+or & \DEFINE{EDIT!SAV!FILE} level \Ob \t{ADD!IF!MISSING} \Oe filename \Slist
+\t{BEGIN} \ttref{TP2 Patch} \Slist \t{END} &
 
   The current file should be a \t{SAV} file. \ttref{EDIT!SAV!FILE}
   will iterate over the files contained within the \t{SAV} file, set
@@ -4923,7 +4924,13 @@ or & \DEFINE{EDIT!SAV!FILE} level \t{BEGIN} \ttref{TP2 Patch} \Slist \t{END} &
   \t{SAV!FILE}. The file contents are then recompressed into the
   \t{SAV} file using the specified compression level. level can be 0
   to 9, where 0 means no compression, 1 is the fastest compression and
-  9 is the best compression.\\
+  9 is the best compression.
+  
+  If the list of filenames is non-empty, only files whose name appear
+  in that list are patched (the comparison is case-insensitive, variables and arrays
+  are parsed if using \ttref{EVALUATE!BUFFER} or \ttref{AUTO!EVAL!STRINGS}).
+  If the optional \t{ADD!IF!MISSING} is provided, the patches are applied to the empty string,
+  and the resulting file will be added to the SAV itself.  \\
 
 or & \DEFINE{DECOMPRESS!REPLACE!FILE} start length uncompressedlength &
 	Decompress (ZLIB) the \verb/start...start+length-1/ portion of the current
@@ -10274,3 +10281,4 @@ See the file
 for a description of how WeiDU
 has changed over time.
 \end{document}
+

--- a/doc/base.tex
+++ b/doc/base.tex
@@ -5148,7 +5148,9 @@ evaluates to 0 (``no difference''). You may use
 or & \ttref{String} \DEFINE{STRING!CONTAINS!REGEXP} \ttref{String} &
 As \ttref{STRING!MATCHES!REGEXP}, but it evaluates to 0 if the first string
 contains the second \ttref{regexp}. Thus \t{"AR1005" STRING!CONTAINS!REGEXP
-"[w-z]"} evaluates to 1 (``mismatch''). \\
+"[w-z]"} evaluates to 1 (``mismatch'').
+
+{\em Be warned that this does the exact opposite of what the name suggests.} \\
 
 or & \DEFINE{GAME!IS} \ttref{String} & Returns true if the IE game variant
 is one of the entries in String, otherwise it returns false. String is a list of

--- a/src/tp.ml
+++ b/src/tp.ml
@@ -381,7 +381,7 @@ and tp_patch =
   | TP_PatchVerbose
 
 
-  | TP_PatchSavFile of tp_patchexp * (tp_patch list)
+  | TP_PatchSavFile of tp_patchexp * bool * (tp_pe_string list) * (tp_patch list)
   | TP_Add_Map_Note of tp_add_map_note
   | TP_Patch_Gam of string * string * tp_patchexp * tp_patchexp
   | TP_Add_Cre_Item of tp_add_cre_item

--- a/src/tppatch.ml
+++ b/src/tppatch.ml
@@ -1609,11 +1609,12 @@ let rec process_patch2_real process_action tp patch_filename game buff p =
     | TP_PatchSavFile(lvl,create,files,pl ) ->
         let sav = Sav.sav_of_str buff in
         let nsav = Queue.create () in
+        let allFiles = List.is_empty files in
         let files = ref files in
         while not (Queue.is_empty sav) do
           let current = Queue.pop sav in
           Var.set_string "SAV_FILE" current.Sav.filename;
-          if (List.is_empty !files) then begin
+          if allFiles then begin
             let result = List.fold_left (fun acc elt ->
               process_patch2 patch_filename game acc elt)
                 current.Sav.contents pl in

--- a/src/tppatch.ml
+++ b/src/tppatch.ml
@@ -1606,18 +1606,50 @@ let rec process_patch2_real process_action tp patch_filename game buff p =
           (Cre.string_of_cre {cre with Cre.memorized_info = !memorized_info})
           (TP_Add_Known_Spell(spell,level,stype))
 
-    | TP_PatchSavFile(lvl,pl) ->
+    | TP_PatchSavFile(lvl,create,files,pl ) ->
         let sav = Sav.sav_of_str buff in
         let nsav = Queue.create () in
+        let files = ref files in
         while not (Queue.is_empty sav) do
           let current = Queue.pop sav in
           Var.set_string "SAV_FILE" current.Sav.filename;
-          let result = List.fold_left (fun acc elt ->
-            process_patch2 patch_filename game acc elt)
-              current.Sav.contents pl in
-          Queue.push {Sav.filename = current.Sav.filename;
-                      Sav.contents = result}  nsav;
+          if (List.is_empty !files) then begin
+            let result = List.fold_left (fun acc elt ->
+              process_patch2 patch_filename game acc elt)
+                current.Sav.contents pl in
+            Queue.push {Sav.filename = current.Sav.filename;
+                        Sav.contents = result}  nsav;
+          end else begin
+            let cur_file = String.uppercase current.Sav.filename in
+            let new_files, found = List.fold_left (
+              fun (files, found) file ->
+                let maybe_file = String.uppercase (eval_pe_str file) in
+                if maybe_file = cur_file then (files, true)
+                  else (file :: files, found)
+            ) ([], false) !files in
+            if (found) then begin
+              files := new_files;
+              let result = List.fold_left (fun acc elt ->
+                process_patch2 patch_filename game acc elt)
+                  current.Sav.contents pl in
+              Queue.push {Sav.filename = current.Sav.filename;
+                          Sav.contents = result}  nsav;
+            end else begin
+              Queue.push current nsav;
+            end
+          end
         done;
+        if (create) then begin
+          List.iter (fun file ->
+            let file = String.uppercase(eval_pe_str file) in
+            Var.set_string "SAV_FILE" file;
+            let result = List.fold_left (fun acc elt ->
+                process_patch2 patch_filename game acc elt)
+                  "" pl in
+              Queue.push {Sav.filename = file;
+                          Sav.contents = result}  nsav;
+          ) !files;
+        end;
         let b = Sav.str_of_sav (eval_pe buff game lvl) nsav in
         if !debug_ocaml then log_and_print "done PatchSavFile\n";
         b

--- a/src/trealparserin.in
+++ b/src/trealparserin.in
@@ -297,6 +297,11 @@ nonterm(bool) Optional_Plus {
 	-> PLUS [ false ]
 }
 
+nonterm(bool) Optional_Add_If_Missing {
+	-> [ false ]
+	-> ADD_IF_MISSING [ true ]
+}
+
 nonterm(bool) Optional_Equip {
 	-> [ false ]
 	-> EQUIP [ true ]
@@ -1253,7 +1258,7 @@ nonterm (Tp.tp_patch) Tp_Patch {
 	-> SET_2DA_ENTRY_LATER e1:STRING e2:Patch_Exp e3:Patch_Exp e4:Patch_Exp
 			[ Tp.TP_Patch2DALater(e1,e2,e3,e4) ]
 	-> SET_2DA_ENTRIES_NOW e1:STRING e2:Patch_Exp [ Tp.TP_Patch2DANow(e1,e2) ]
-	-> EDIT_SAV_FILE e1:Patch_Exp BEGIN e2:Tp_Patch_List END [ Tp.TP_PatchSavFile(e1,e2) ]
+	-> EDIT_SAV_FILE e1:Patch_Exp e2:Optional_Add_If_Missing e3:Patch_String_Right_List BEGIN e4:Tp_Patch_List END [ Tp.TP_PatchSavFile(e1,e2,e3,e4) ]
 	-> ADD_MAP_NOTE e1:String_Ref_Or_Pe e2:String_Ref_Or_Pe e3:STRING e4:Lse
 			{ Tp.TP_Add_Map_Note(
 				{Tp.xcoord = e1 ;


### PR DESCRIPTION
- Add a warning to STRING_CONTAINS_REGEXP's documentation (the return code is the opposite from what you'd expect from the command name).
- Changes to EDIT_SAV_FILE:
  - can specify the list of files to operate onto, rather than relying on PATCH_IF SAVE_FILE STRING_EQUALS taerom.sto:
```
EDIT_SAV_FILE 9 taerom.sto ribald.sto BEGIN
    ADD_STORE_ITEM <snip>
END
```
  - Can add entirely new files to the SAV file:
```
EDIT_SAV_FILE 9 ADD_IF_MISSING something.sto BEGIN
    PATCH_IF BUFFER_LENGTH = 0 THEN BEGIN
      // somehow initialize the store file from the empty string
    END
    // now that we're sure that the file is non-empty, we can actually do our patches
    ADD_STORE_ITEM
END
```
The second feature is useful for storing the death counter in a text file in the SAV file for my [save reading utilty](https://github.com/vbigiani/save-reader), in case you're wondering about the use-case.