### PR TITLE
Removed deprecated warnings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,10 @@ all : weidu
 # Debugging. Set ECHO= to debug this Makefile
 # ECHO := @
 
+# fix:
+# Error: This expression has type string but an expression was expected of type bytes 
+export OCAMLPARAM = safe-string=0,_
+
 RELEASE    := 1
 NATIVECAML := 1
 # UNSAFE     := 1

--- a/scripts/make_gr.ml
+++ b/scripts/make_gr.ml
@@ -1,5 +1,5 @@
 let is_valid x =
-  x <> "" && String.uppercase x = x && x.[String.length x - 1] <> '"' && x.[0] <> '"'
+  x <> "" && String.uppercase_ascii x = x && x.[String.length x - 1] <> '"' && x.[0] <> '"'
     && x.[0] <> '.' && (try string_of_int (int_of_string x) <> x with _ -> true) &&
   x <> "EOF" && x <> "_" && x <> "STRING" && x <> "SOUND" && x <> "INLINED_FILE" && x <> "TRANS_REF"
     && x <> "STRING_REF" && x <> "FORCED_STRING_REF" && x <> "START_FROM_TP" && x <> "START_FROM_TPP"

--- a/scripts/make_tph.ml
+++ b/scripts/make_tph.ml
@@ -30,7 +30,7 @@ let main () =
   let file_include = Sys.readdir "src/tph/include" in
   List.iter (fun (dir, files) ->
     Array.iter (fun file ->
-      let file = String.lowercase file in
+      let file = String.lowercase_ascii file in
       let ext = Str.global_replace (Str.regexp ".*\\.") "" file in
       if ext = "tpa" || ext = "tpp" then begin
         let contents = load_file ("src/tph/" ^ dir ^ "/" ^ file) in
@@ -39,7 +39,7 @@ let main () =
   output_string o "]\n";
   Printf.fprintf o "let %s = [" includes_symbol ;
   Array.iter (fun file ->
-    let file = Printf.sprintf "%s%s" namespace (String.lowercase file) in
+    let file = Printf.sprintf "%s%s" namespace (String.lowercase_ascii file) in
     let ext = Str.global_replace (Str.regexp ".*\\.") "" file in
     if ext = "tpa" || ext = "tpp" then Printf.fprintf o "\t\"%s\";\n" file) file_include;
   output_string o "]\n";

--- a/src/arch_legacy_osx.ml
+++ b/src/arch_legacy_osx.ml
@@ -66,7 +66,7 @@ let cd_regexp = Str.regexp "\\(CD[0-9]\\)"
 let is_weidu_executable f =
   try
     let i = Case_ins.perv_open_in_bin f in
-    let buff = String.create 4 in
+    let buff = Bytes.create 4 in
     let signature = input i buff 0 4 in
     Str.string_match (Str.regexp_case_fold "setup-.*") f 0 && buff = "\xfe\xed\xfa\xce"
   with _ -> false

--- a/src/arch_mingw.ml
+++ b/src/arch_mingw.ml
@@ -108,7 +108,7 @@ let get_user_dir game_path =
   get_user_personal_dir ()
 
 let game_path_by_type name =
-  match String.lowercase name with
+  match String.lowercase_ascii name with
   | "bg2"  -> registry_path ()
   | "bg1"
   | "bg"   -> bg_registry_path ()

--- a/src/arch_osx.ml
+++ b/src/arch_osx.ml
@@ -55,7 +55,7 @@ let cd_regexp = Str.regexp "^[CH]D[0-9]+.*=\\([^\r\n]*\\)"
 let is_weidu_executable f =
   try
     let i = Case_ins.perv_open_in_bin f in
-    let buff = String.create 4 in
+    let buff = Bytes.create 4 in
     let signature = input i buff 0 4 in
     Str.string_match (Str.regexp_case_fold "setup-.*") f 0 && buff = "\xfe\xed\xfa\xce"
   with _ -> false

--- a/src/arch_unix.ml
+++ b/src/arch_unix.ml
@@ -39,7 +39,7 @@ let handle_view_command s skip =
     end) [Str.regexp_case_fold "^VIEW[ \t]*" ; Str.regexp_case_fold "^NOTEPAD[ \t]*" ;
           Str.regexp_case_fold "^EXPLORER[ \t]*"];
   if skip && (s <> !result) then result := "";
-  let s = String.lowercase !result in
+  let s = String.lowercase_ascii !result in
   s
 
 let glob str fn = failwith "no globbing support"
@@ -53,7 +53,7 @@ let cd_regexp = Str.regexp "^[CH]D[0-9]+.*=\\([^\r\n]*\\)"
 let is_weidu_executable f =
   try
     let i = Case_ins.perv_open_in_bin f in
-    let buff = String.create 4 in
+    let buff = Bytes.create 4 in
     let signature = input i buff 0 4 in
     Str.string_match (Str.regexp_case_fold "setup-.*") f 0 && buff = "\x7fELF"
   with _ -> false

--- a/src/automate.ml
+++ b/src/automate.ml
@@ -18,7 +18,7 @@ let process file game min o =
       end
   in
   let _,ext = split file in
-  let ext = String.uppercase ext in
+  let ext = String.uppercase_ascii ext in
   try begin
     match ext with
     | "SPL"

--- a/src/baflexer.mll
+++ b/src/baflexer.mll
@@ -74,7 +74,7 @@ let blank = [' ' '\012' '\r']
   adj lexbuf ;
   try Hashtbl.find lexicon (string_of lexbuf)
   with _ -> begin
-    try Hashtbl.find lexicon (String.uppercase (string_of lexbuf))
+    try Hashtbl.find lexicon (String.uppercase_ascii (string_of lexbuf))
     with _ -> SYMBOL(string_of lexbuf)
   end }
 | ['-']?("0x")?['0'-'9']+ { adj lexbuf ;

--- a/src/bafparser.mly
+++ b/src/bafparser.mly
@@ -63,7 +63,7 @@ let get_next_point argl =
   | _ -> failwith "get_next_point"
 
 let valid_var_area s =
-  let s = String.uppercase s in
+  let s = String.uppercase_ascii s in
   if Modder.enabled "AREA_VARIABLES" then
     let ans = (s = "GLOBAL" || s = "LOCALS" || s = "KAPUTZ" || s = "MYAREA" ||
     s = "" || ( Str.string_match (Str.regexp "AR[0-9][0-9][0-9][0-9]") s 0) ||

--- a/src/bcs.ml
+++ b/src/bcs.ml
@@ -527,7 +527,7 @@ let make_ids_map il =
     (* log_and_print "IDS: %ld %s\n" ids.i_num ids.i_name ;  *)
     Hashtbl.add from_int ids.i_num ids ;
     Hashtbl.add from_sym ids.i_name ids ;
-    Hashtbl.add from_uppercase_sym (String.uppercase ids.i_name) ids) il ;
+    Hashtbl.add from_uppercase_sym (String.uppercase_ascii ids.i_name) ids) il ;
   { from_int = from_int ;
     from_sym = from_sym ;
     from_uppercase_sym = from_uppercase_sym ; }
@@ -543,7 +543,7 @@ let clear_ids_map game =
        *)
 
 let get_ids_map game ids_filename =
-  let ids_filename = String.uppercase ids_filename in
+  let ids_filename = String.uppercase_ascii ids_filename in
   try
     let ids_state = Hashtbl.find all_games_ids_state game.Load.game_path in
     Hashtbl.find ids_state ids_filename
@@ -590,38 +590,38 @@ let five_quotes_string s =
 let five_quotes res = {res with i_name = five_quotes_string res.i_name}
 
 let ids_of_int game ids_file i =
-  let ids_file = String.uppercase ids_file in
+  let ids_file = String.uppercase_ascii ids_file in
   let ids_map : ids_map = get_ids_map game ids_file in
   let res = (Hashtbl.find ids_map.from_int i) in
   five_quotes res
 
 
 let ids_of_sym game ids_file sym =
-  let ids_file = String.uppercase ids_file in
+  let ids_file = String.uppercase_ascii ids_file in
   let ids_map : ids_map = get_ids_map game ids_file in
   try
     (Hashtbl.find ids_map.from_sym sym)
   with Not_found ->
-    let a = (Hashtbl.find ids_map.from_uppercase_sym (String.uppercase sym)) in
+    let a = (Hashtbl.find ids_map.from_uppercase_sym (String.uppercase_ascii sym)) in
 (*    let msg = Printf.sprintf "[%s] should be [%s] (note case)\n"
       sym a.i_name in
       (try input_error "PARSE" msg with _ -> () ) ; *)
     a
 
 let every_ids_of_int game ids_file i =
-  let ids_file = String.uppercase ids_file in
+  let ids_file = String.uppercase_ascii ids_file in
   let ids_map : ids_map = get_ids_map game ids_file in
   List.map five_quotes (Hashtbl.find_all ids_map.from_int i)
 
 let int_of_sym game ids_file sym =
-  let ids_file = String.uppercase ids_file in
+  let ids_file = String.uppercase_ascii ids_file in
   let ids = ids_of_sym game ids_file sym in
   ids.i_num
 
 let sym_of_int game ids_file i =
-  let ids_file = String.uppercase ids_file in
+  let ids_file = String.uppercase_ascii ids_file in
   try
-    let ids_map : ids_map = get_ids_map game (String.uppercase ids_file ) in
+    let ids_map : ids_map = get_ids_map game (String.uppercase_ascii ids_file ) in
     five_quotes_string ((Hashtbl.find ids_map.from_int i).i_name)
   with _ ->
     (* log_or_print "WARNING: %d (0x%x) not found in %s.IDS\n" i i ids_file ; *)
@@ -903,7 +903,7 @@ let get_first_of_type argl tau =
     failwith "cannot find an argument of the right type"
 
 let formal_arg_is_strref arg =
-  let up = String.uppercase arg.arg_comment in
+  let up = String.uppercase_ascii arg.arg_comment in
   up = "STRREF" || up = "STRINGREF"
 
 let print_script_text game how what comments strhandle =
@@ -1112,9 +1112,9 @@ let print_script_text game how what comments strhandle =
     bcs_printf "\n"
   and print_trigger_list tr compiling_to_dlg or_count =
     match tr with
-    | t :: [] when not compiling_to_dlg && String.lowercase ((best_ids_of_trigger game t).i_name) = "nexttriggerobject" ->
+    | t :: [] when not compiling_to_dlg && String.lowercase_ascii ((best_ids_of_trigger game t).i_name) = "nexttriggerobject" ->
       failwith "NextTriggerObject() without a next trigger (broken TriggerOverride)"
-    | t :: t1 :: tl when not compiling_to_dlg && String.lowercase ((best_ids_of_trigger game t).i_name) = "nexttriggerobject" ->
+    | t :: t1 :: tl when not compiling_to_dlg && String.lowercase_ascii ((best_ids_of_trigger game t).i_name) = "nexttriggerobject" ->
       let indent = 2 + if !or_count > 0 then (decr or_count ; 2) else 0 in
       bcs_printf "%*s" indent " " ;
       bcs_printf "%sTriggerOverride(" (if t1.negated then "!" else "");
@@ -1145,7 +1145,7 @@ let print_script_text game how what comments strhandle =
     if comments then begin
       print_trigger_comment game t ;
     end ;
-    if String.uppercase ids.i_name = "OR" then
+    if String.uppercase_ascii ids.i_name = "OR" then
       (Int32.to_int t.t_1)
     else 0
   and print_trigger_comment game t =
@@ -1393,7 +1393,7 @@ let is_invalid_for_ict1 action =
   | _, 256 (* CreateItemGlobal(S:Global,S:Area,S:ResRef) *)
   | _, 268 (* RealSetGlobalTimer(S:Name,S:Area,I:TimeGTimes) *)
   | _, 335 (* SetTokenGlobal(S:GLOBAL,S:Area,S:Token) *)
-    -> let check s = String.uppercase (snd (split6 s)) = "LOCALS" in
+    -> let check s = String.uppercase_ascii (snd (split6 s)) = "LOCALS" in
     List.exists check [action.a_8; action.a_9]
   | _ -> false in
   ans && action.a_1.o_name = ""

--- a/src/biff.ml
+++ b/src/biff.ml
@@ -50,7 +50,7 @@ let save_biff key filename keyname components =
         let a,b = split (Case_ins.filename_basename file) in
         try
           let tau = key_of_ext false b in
-          [ (size,file,String.uppercase a,String.uppercase b,tau) ]
+          [ (size,file,String.uppercase_ascii a,String.uppercase_ascii b,tau) ]
         with _ ->
           log_only "WARNING: Not including [%s]: unknown resource type\n"
             file ; []
@@ -96,7 +96,7 @@ let save_biff key filename keyname components =
                 ) files ;
     Array.iteri (fun i (s,f,a,b,t) ->
       let in_fd = Case_ins.unix_openfile f [Unix.O_RDONLY] 0 in
-      let header = String.create 24 in
+      let header = Bytes.create 24 in
       my_read 24 in_fd header f ;
       (try
         Unix.close in_fd ;
@@ -122,7 +122,7 @@ let save_biff key filename keyname components =
     my_write buff_size out_fd buff filename ;
 
     let chunk_size = 10240 in
-    let chunk = String.create chunk_size in
+    let chunk = Bytes.create chunk_size in
 
     let copy_over in_fd in_name size =
       let sofar = ref 0 in
@@ -146,7 +146,7 @@ let save_biff key filename keyname components =
     Array.iteri (fun i (s,f,a,b,t) ->
       log_only "[%s] incorporating [%s]\n" filename f ;
       let in_fd = Case_ins.unix_openfile f [Unix.O_RDONLY] 0 in
-      let istis = String.create 8 in
+      let istis = Bytes.create 8 in
       my_read 8 in_fd istis f ;
       (try
         Unix.close in_fd ;
@@ -155,7 +155,7 @@ let save_biff key filename keyname components =
         raise e) ;
       let in_fd = Case_ins.unix_openfile f [Unix.O_RDONLY] 0 in
       if istis = "TIS V1  " then begin
-        let istis = String.create 24 in
+        let istis = Bytes.create 24 in
         (* have it skip the first 24 bytes *)
         my_read 24 in_fd istis f ;
         copy_over in_fd f (s - 24) ;
@@ -242,7 +242,7 @@ let read_compressed_biff_internal fd filename start size chunk_fun =
 
   let finished = ref false in
   let found_it = ref false in
-  let sizes_buff = String.create 8 in
+  let sizes_buff = Bytes.create 8 in
   while not !finished do
     (* now we're looking at one block *)
     let _ = Unix.lseek fd !cmp_offset Unix.SEEK_SET in
@@ -267,7 +267,7 @@ let read_compressed_biff_internal fd filename start size chunk_fun =
     end else begin
       (* read this block *)
       let _ = Unix.lseek fd (!cmp_offset+8) Unix.SEEK_SET in
-      let cmp_buff = String.create cmplen in
+      let cmp_buff = Bytes.create cmplen in
       my_read cmplen fd cmp_buff filename ;
       let uncmp = Cbif.uncompress cmp_buff 0 cmplen uncmplen in
       (*
@@ -356,7 +356,7 @@ let load_normal_biff filename size fd buff =
     let offset_tileset_entry = (num_file_entry * 16) in
     let table_len = (num_file_entry * 16) +
         (num_tileset_entry * 20) in
-    let buff = String.create table_len in
+    let buff = Bytes.create table_len in
     let _ = Unix.lseek fd offset_file_entry Unix.SEEK_SET in
     my_read table_len fd buff filename ;
     let result =
@@ -394,7 +394,7 @@ let load_biff filename =
     let stats = Case_ins.unix_stat filename in
     let size = stats.Unix.st_size in
     let fd = Case_ins.unix_openfile filename [Unix.O_RDONLY] 0 in
-    let buff = String.create 20 in
+    let buff = Bytes.create 20 in
     let _ = Unix.read fd buff 0 20 in
     if String.length buff < 8 then begin
       failwith "not a valid BIFF file (wrong sig)"
@@ -434,7 +434,7 @@ let extract_file biff i ign =
       read_compressed_biff biff.fd biff.filename this.res_offset size
     end else begin
       let _ = Unix.lseek biff.fd this.res_offset Unix.SEEK_SET in
-      let buff = String.create size in
+      let buff = Bytes.create size in
       my_read size biff.fd buff biff.filename ;
       buff
     end
@@ -453,12 +453,12 @@ let extract_tis biff i ign =
         read_compressed_biff biff.fd biff.filename this.tis_offset size
       end else begin
         let _ = Unix.lseek biff.fd this.tis_offset Unix.SEEK_SET in
-        let buff = String.create size in
+        let buff = Bytes.create size in
         my_read size biff.fd buff biff.filename;
         buff
       end
     in
-    let header = String.create 0x18 in
+    let header = Bytes.create 0x18 in
     String.blit "TIS V1  " 0 header 0 8;
     let str = str_of_int this.tis_number_of_tiles in
     String.blit str 0 header 0x08 4 ;
@@ -478,7 +478,7 @@ let copy_file biff i oc is_tis =
   let size,offset = if is_tis then begin
     check_tile biff i false;
     let this = biff.tilesets.(i) in
-    let header = String.create 0x18 in
+    let header = Bytes.create 0x18 in
     String.blit "TIS V1  " 0 header 0 8;
     let str = str_of_int this.tis_number_of_tiles in
     String.blit str 0 header 0x08 4 ;
@@ -506,7 +506,7 @@ let copy_file biff i oc is_tis =
     end else begin
       let _ = Unix.lseek biff.fd offset Unix.SEEK_SET in
       let chunk_size = 10240 in
-      let chunk = String.create chunk_size in
+      let chunk = Bytes.create chunk_size in
       let sofar = ref 0 in
       while !sofar < size do
         let chunk_size = min (size - !sofar) chunk_size in
@@ -525,7 +525,7 @@ let bifc2biff source dest =
   let out = Case_ins.perv_open_out_bin dest in
   let fd = Case_ins.unix_openfile source [Unix.O_RDONLY] 0 in
   let read len =
-    let buff = String.create len in
+    let buff = Bytes.create len in
     ignore (my_read len fd buff source) ;
     buff in
   let header = read 12 in

--- a/src/case_ins_linux.ml
+++ b/src/case_ins_linux.ml
@@ -7,24 +7,24 @@ let backslash_to_slash s =
   let s = Str.global_replace (Str.regexp "\\\\") "/" s in
 				s
 
-let perv_open_out s = open_out (String.lowercase (backslash_to_slash s)) ;;
-let perv_open_out_gen m i s = open_out_gen m i (String.lowercase (backslash_to_slash s)) ;;
-let perv_open_out_bin s = open_out_bin (String.lowercase (backslash_to_slash s)) ;;
-let perv_open_in s = open_in (String.lowercase (backslash_to_slash s)) ;;
-let perv_open_in_gen m i s = open_in_gen m i (String.lowercase (backslash_to_slash s)) ;;
-let perv_open_in_bin s = open_in_bin (String.lowercase (backslash_to_slash s)) ;;
+let perv_open_out s = open_out (String.lowercase_ascii (backslash_to_slash s)) ;;
+let perv_open_out_gen m i s = open_out_gen m i (String.lowercase_ascii (backslash_to_slash s)) ;;
+let perv_open_out_bin s = open_out_bin (String.lowercase_ascii (backslash_to_slash s)) ;;
+let perv_open_in s = open_in (String.lowercase_ascii (backslash_to_slash s)) ;;
+let perv_open_in_gen m i s = open_in_gen m i (String.lowercase_ascii (backslash_to_slash s)) ;;
+let perv_open_in_bin s = open_in_bin (String.lowercase_ascii (backslash_to_slash s)) ;;
 
-let unix_openfile s a b = Unix.openfile (String.lowercase (backslash_to_slash s)) a b ;;
-let unix_stat s = Unix.stat (String.lowercase (backslash_to_slash s)) ;;
-let unix_stat64 s = Unix.LargeFile.stat (String.lowercase (backslash_to_slash s)) ;;
-let unix_chmod s p = Unix.chmod (String.lowercase (backslash_to_slash s)) p ;;
-let unix_unlink s = Unix.unlink (String.lowercase (backslash_to_slash s)) ;;
-let unix_mkdir s p = Unix.mkdir (String.lowercase (backslash_to_slash s)) p ;;
-let unix_opendir s = Unix.opendir (String.lowercase (backslash_to_slash s)) ;;
-let unix_rename s d = Unix.rename (String.lowercase (backslash_to_slash s)) (String.lowercase (backslash_to_slash d));;
-let unix_rmdir s = Unix.rmdir (String.lowercase (backslash_to_slash s));;
+let unix_openfile s a b = Unix.openfile (String.lowercase_ascii (backslash_to_slash s)) a b ;;
+let unix_stat s = Unix.stat (String.lowercase_ascii (backslash_to_slash s)) ;;
+let unix_stat64 s = Unix.LargeFile.stat (String.lowercase_ascii (backslash_to_slash s)) ;;
+let unix_chmod s p = Unix.chmod (String.lowercase_ascii (backslash_to_slash s)) p ;;
+let unix_unlink s = Unix.unlink (String.lowercase_ascii (backslash_to_slash s)) ;;
+let unix_mkdir s p = Unix.mkdir (String.lowercase_ascii (backslash_to_slash s)) p ;;
+let unix_opendir s = Unix.opendir (String.lowercase_ascii (backslash_to_slash s)) ;;
+let unix_rename s d = Unix.rename (String.lowercase_ascii (backslash_to_slash s)) (String.lowercase_ascii (backslash_to_slash d));;
+let unix_rmdir s = Unix.rmdir (String.lowercase_ascii (backslash_to_slash s));;
 
-let sys_readdir s = Sys.readdir (String.lowercase (backslash_to_slash s));;
+let sys_readdir s = Sys.readdir (String.lowercase_ascii (backslash_to_slash s));;
 
 let weidu_executable = "weidu" ;;
 
@@ -36,4 +36,4 @@ let filename_chop_suffix s = Filename.chop_suffix (backslash_to_slash s) ;;
 let filename_dirname s = Filename.dirname (backslash_to_slash s) ;;
 let filename_is_implicit s = Filename.is_implicit (backslash_to_slash s) ;;
 
-let fix_name s = String.lowercase (backslash_to_slash s);;
+let fix_name s = String.lowercase_ascii (backslash_to_slash s);;

--- a/src/changelog.ml
+++ b/src/changelog.ml
@@ -57,8 +57,8 @@ let process_log log file_list game =
         List.iter (fun line ->
           let parts = split_log_line line in
           let (src, dst) = match parts with
-          | s :: d :: _ -> (String.uppercase s, String.uppercase d)
-          | s :: [] -> (String.uppercase s, "")
+          | s :: d :: _ -> (String.uppercase_ascii s, String.uppercase_ascii d)
+          | s :: [] -> (String.uppercase_ascii s, "")
           | [] -> failwith "Empty line in backup file" in
           let src_file =
             Str.global_replace (Str.regexp "^OVERRIDE[/\\]") "" src in
@@ -140,7 +140,7 @@ let prepare_result file_list backup_lists game =
       Hashtbl.find backup_lists file
     with Not_found -> [] in
   List.map (fun file1 ->
-    let file1 = String.uppercase file1 in
+    let file1 = String.uppercase_ascii file1 in
     let file = if Case_ins.filename_check_suffix file1 ".EXE" ||
     Case_ins.filename_check_suffix file1 ".KEY" then file1
     else "OVERRIDE/" ^ file1 in
@@ -174,7 +174,7 @@ let prepare_result file_list backup_lists game =
 
 let changelog file_list game =
   ignore (Parsewrappers.load_log ()) ;
-  let file_list = List.map String.uppercase file_list in
+  let file_list = List.map String.uppercase_ascii file_list in
   let backup_lists = process_log !Tp.the_log file_list game in
   let result = prepare_result file_list backup_lists game in
   List.map (fun ((text: string), (files: (string * string) list)) ->

--- a/src/cre.ml
+++ b/src/cre.ml
@@ -75,7 +75,7 @@ let cre_of_string buff =
   let known_spells = ref [] in
   for i = 0 to known_cnt - 1 do
     let this_buff = String.sub buff (known_off + i * 0xc) 0xc in
-    let name = String.uppercase (get_string_of_size this_buff 0 8) in
+    let name = String.uppercase_ascii (get_string_of_size this_buff 0 8) in
     let level = short_of_str_off this_buff 8 in
     let spell_type = short_of_str_off this_buff 0xa in
     known_spells := (name,level,spell_type) :: !known_spells ;
@@ -96,7 +96,7 @@ let cre_of_string buff =
     while !mlist_i < mlist_cnt do
       let this_buff = String.sub buff
           (mlist_off + (mlist_idx + !mlist_i) * 0xc) 0xc in
-      let name = String.uppercase (get_string_of_size this_buff 0 8) in
+      let name = String.uppercase_ascii (get_string_of_size this_buff 0 8) in
       let memorized = 0 <> (int_of_str_off this_buff 8) in
       incr mlist_i ;
       mlist := (name, memorized) :: !mlist
@@ -117,7 +117,7 @@ let cre_of_string buff =
   for i = 0 to items_cnt - 1 do
     let slots = ref [] in
     let this_buff = String.sub buff (items_off +i * 0x14) 0x14 in
-    let name = String.uppercase (get_string_of_size this_buff 0 8) in
+    let name = String.uppercase_ascii (get_string_of_size this_buff 0 8) in
     let unknown = short_of_str_off this_buff 0x8 in
     let q1 = short_of_str_off this_buff 0xa in
     let q2 = short_of_str_off this_buff 0xc in
@@ -307,7 +307,7 @@ let string_to_slots str =
     | Load.BG2
     | Load.IWD1
     | Load.NONE ->
-        List.map (fun str -> match String.uppercase str with
+        List.map (fun str -> match String.uppercase_ascii str with
         | "HELMET"    -> 0
         | "ARMOR"     -> 1
         | "SHIELD"    -> 2
@@ -349,10 +349,10 @@ let string_to_slots str =
             (try assert false with Assert_failure(file,line,col) ->
               set_errors file line) ;
             log_and_print "WARNING: ADD_CRE_ITEM: Unknown slot %s.  Default to INV15 for placement.\n"
-              (String.uppercase str) ;
+              (String.uppercase_ascii str) ;
             35) (Str.split many_whitespace_regexp item_slot)
     | Load.IWD2 ->
-        List.map (fun str -> match String.uppercase str with
+        List.map (fun str -> match String.uppercase_ascii str with
         | "HELMET"    -> 0
         | "ARMOR"     -> 1
               (* | "SHIELD"    -> 2 *)
@@ -406,10 +406,10 @@ let string_to_slots str =
             (try assert false with Assert_failure(file,line,col) ->
               set_errors file line) ;
             log_and_print "WARNING: ADD_CRE_ITEM: Unknown slot %s.  Default to INV23 for placement.\n"
-              (String.uppercase str) ;
+              (String.uppercase_ascii str) ;
             47) (Str.split many_whitespace_regexp item_slot)
     | Load.PST ->
-        List.map (fun str -> match String.uppercase str with
+        List.map (fun str -> match String.uppercase_ascii str with
         | "EARRING1"   -> 0
         | "ARMOR"      -> 1
         | "TATTOO1"    -> 2
@@ -459,7 +459,7 @@ let string_to_slots str =
             (try assert false with Assert_failure(file,line,col) ->
               set_errors file line) ;
             log_and_print "WARNING: ADD_CRE_ITEM: Unknown slot %s.  Default to INV19 for placement.\n"
-              (String.uppercase str) ;
+              (String.uppercase_ascii str) ;
             43) (Str.split many_whitespace_regexp item_slot)
   in
   possible_slots

--- a/src/dc.ml
+++ b/src/dc.ml
@@ -569,7 +569,7 @@ let preprocess_action2 game a = match a with
   -> List.iter (fun n -> make_available (action_to_str a) game n false) nl
 | Alter_Trans (n,_,_,l) ->
     make_available (action_to_str a) game n false;
-    List.iter (fun (b,c) -> if String.uppercase b = "EPILOGUE" then begin
+    List.iter (fun (b,c) -> if String.uppercase_ascii b = "EPILOGUE" then begin
       match c with
       | Alter_Trans_String c -> begin
           let parts = Str.split (Str.regexp " ") c in
@@ -638,7 +638,7 @@ let rec process_action game a = match a with
       let regexp_list = List.map (fun n -> Str.regexp_case_fold n) nl in
       let matches = Key.search_key_resources game.Load.key true
           (fun poss ->
-            let b,e = split (String.uppercase poss) in
+            let b,e = split (String.uppercase_ascii poss) in
             let ans = e = "DLG" &&
               (List.exists (fun regexp -> Str.string_match regexp b 0)
                  regexp_list) in
@@ -673,7 +673,7 @@ let rec process_action game a = match a with
       let regexp = Str.regexp_case_fold n in
       let matches = Key.search_key_resources game.Load.key true
           (fun poss ->
-            let b,e = split (String.uppercase poss) in
+            let b,e = split (String.uppercase_ascii poss) in
             let ans = e = "DLG" &&
               Str.string_match regexp b 0 in
             if ans then make_available (action_to_str a) game b false;
@@ -864,8 +864,8 @@ let rec process_action game a = match a with
           let get_next s =
             let parts = Str.split (Str.regexp " ") s in
             match parts with
-            | [a;b;c] -> Dlg.Symbolic(String.uppercase b,c,false)
-            | [a;b] -> Dlg.Symbolic(String.uppercase n,b,false)
+            | [a;b;c] -> Dlg.Symbolic(String.uppercase_ascii b,c,false)
+            | [a;b] -> Dlg.Symbolic(String.uppercase_ascii n,b,false)
             | [a] -> Dlg.Exit
             | _ -> failwith "unknown transition in ALTER_STRING"
           in
@@ -873,7 +873,7 @@ let rec process_action game a = match a with
           | Alter_Trans_Lse s -> single_string_of_tlk_string game s
           | Alter_Trans_String s -> s
           in
-          match String.uppercase what with
+          match String.uppercase_ascii what with
           | "TRIGGER" -> trans.Dlg.trans_trigger <- some_or_none intos intos
           | "ACTION" -> trans.Dlg.action <- some_or_none intos intos
           | "REPLY" -> trans.Dlg.trans_str <- some_or_none (get_lse(into)) intos
@@ -1024,7 +1024,7 @@ end
               | Some(a1),Some(a2) ->
                   let aa1 = Str.global_replace (Str.regexp "[ \t\n\r]+") "" a1 in
                   let aa2 = Str.global_replace (Str.regexp "[ \t\n\r]+") "" a2 in
-                  if String.uppercase aa1 = String.uppercase aa2 then None else begin try
+                  if String.uppercase_ascii aa1 = String.uppercase_ascii aa2 then None else begin try
                     let a2_init = Str.string_before a2 (Str.search_forward one_newline_or_cr_regexp a2 0) in
                     let a2_after = Str.global_replace (Str.regexp "[ \t\n\r]+") "" (Str.string_after a2 (Str.search_forward one_newline_or_cr_regexp a2 0)) in
                     if Str.string_match (Str.regexp "SetGlobal(\"[^\"]*\",\"GLOBAL\",1)") a2_init 0 then begin

--- a/src/dlg.ml
+++ b/src/dlg.ml
@@ -93,7 +93,7 @@ let from_ht = Hashtbl.create 511
 
 let load_dlg name buff = begin
   let result = Stats.time "unmarshal DLG" (fun () ->
-    let name = let a,b = split name in String.uppercase a in
+    let name = let a,b = split name in String.uppercase_ascii a in
     try
       if String.sub buff 0 8 <> "DLG V1.0" then begin
         failwith "not a valid DLG file (wrong sig)"
@@ -168,11 +168,11 @@ let load_dlg name buff = begin
                 then Some(dos2unix (get_action index_action)) else None ;
                 next = if flags land 8 <> 0 then Exit
                 else
-                  let dest = String.uppercase next_dlg in
+                  let dest = String.uppercase_ascii next_dlg in
                   (* create "from: " lists *)
                   if !emit_from then begin
                     Hashtbl.add from_ht (dest, index_state)
-                      (String.uppercase name,i,t) ;
+                      (String.uppercase_ascii name,i,t) ;
                   end ;
                   (Absolute(dest,index_state)) ;
               } , off)

--- a/src/dparser.mly
+++ b/src/dparser.mly
@@ -214,23 +214,23 @@ action_list :           { [] }
     ;
 
 begin_prologue :
-  BEGIN STRING             { current_unit := Some(String.uppercase $2); (String.uppercase $2,0) }
-| BEGIN STRING STRING       { current_unit := Some(String.uppercase $2); (String.uppercase $2,my_int_of_string $3) }
+  BEGIN STRING             { current_unit := Some(String.uppercase_ascii $2); (String.uppercase_ascii $2,0) }
+| BEGIN STRING STRING       { current_unit := Some(String.uppercase_ascii $2); (String.uppercase_ascii $2,my_int_of_string $3) }
     ;
 
 append_prologue : APPEND STRING       
-  { current_unit := Some(String.uppercase $2) ;
-    (String.uppercase $2,false) } ;
+  { current_unit := Some(String.uppercase_ascii $2) ;
+    (String.uppercase_ascii $2,false) } ;
 | APPEND IF_FILE_EXISTS STRING
-    { current_unit := Some(String.uppercase $3) ;
-      (String.uppercase $3,true) } ;
+    { current_unit := Some(String.uppercase_ascii $3) ;
+      (String.uppercase_ascii $3,true) } ;
 
 append_safe_prologue : APPEND_EARLY STRING
-  { current_unit := Some(String.uppercase $2) ;
-    (String.uppercase $2,false) } ;
+  { current_unit := Some(String.uppercase_ascii $2) ;
+    (String.uppercase_ascii $2,false) } ;
 | APPEND_EARLY IF_FILE_EXISTS STRING
-    { current_unit := Some(String.uppercase $3) ;
-      (String.uppercase $3,true) } ;
+    { current_unit := Some(String.uppercase_ascii $3) ;
+      (String.uppercase_ascii $3,true) } ;
 
 
 string_list :            { [] }
@@ -253,7 +253,7 @@ alter_trans_list :            { [] }
     in
     result
   in
-  match String.uppercase $1 with
+  match String.uppercase_ascii $1 with
   | "TRIGGER" -> handle (fun s -> Dc.Alter_Trans_String (verify_trigger_list s))
   | "ACTION" -> handle (fun s -> Dc.Alter_Trans_String (verify_action_list s))
   | "REPLY" | "JOURNAL" | "SOLVED_JOURNAL" | "UNSOLVED_JOURNAL" ->
@@ -283,7 +283,7 @@ int_list:   { [] }
     ;
 
 upper_string_list :            { [] }
-| STRING upper_string_list  { (String.uppercase $1) :: $2 }
+| STRING upper_string_list  { (String.uppercase_ascii $1) :: $2 }
     ;
 
 when_list : { [] }
@@ -292,11 +292,11 @@ when_list : { [] }
 	
 extend_prologue :
   EXTEND_TOP STRING string_list hash_int_option 
-  { current_unit := Some(String.uppercase $2) ;
-    (true,String.uppercase $2,$3,$4) }
+  { current_unit := Some(String.uppercase_ascii $2) ;
+    (true,String.uppercase_ascii $2,$3,$4) }
 | EXTEND_BOTTOM STRING string_list hash_int_option
-    { current_unit := Some(String.uppercase $2) ;
-      (false,String.uppercase $2,$3,$4) }
+    { current_unit := Some(String.uppercase_ascii $2) ;
+      (false,String.uppercase_ascii $2,$3,$4) }
     ; 
 
 hash_int_option :             { 0 }
@@ -304,12 +304,12 @@ hash_int_option :             { 0 }
     ;
 
 replace_prologue : REPLACE STRING 
-  { current_unit := Some(String.uppercase $2); (String.uppercase $2) }
+  { current_unit := Some(String.uppercase_ascii $2); (String.uppercase_ascii $2) }
   ; 
 replace_state_trigger_prologue : REPLACE_STATE_TRIGGER STRING STRING STRING 
   string_list
-  { current_unit := Some(String.uppercase $2); 
-    (String.uppercase $2,$3 :: $5,$4) }
+  { current_unit := Some(String.uppercase_ascii $2); 
+    (String.uppercase_ascii $2,$3 :: $5,$4) }
   ; 
 
 opt_do_string_list :    { [] }
@@ -318,48 +318,48 @@ opt_do_string_list :    { [] }
 
 add_trans_trigger_prologue : ADD_TRANS_TRIGGER STRING STRING STRING string_list
   opt_do_string_list 
-  { current_unit := Some(String.uppercase $2); 
-    (String.uppercase $2,$3 :: $5,$4,$6) }
+  { current_unit := Some(String.uppercase_ascii $2); 
+    (String.uppercase_ascii $2,$3 :: $5,$4,$6) }
   ; 
 add_state_trigger_prologue : ADD_STATE_TRIGGER STRING STRING STRING string_list
-  { current_unit := Some(String.uppercase $2); 
-    (String.uppercase $2,$3 :: $5,$4) 
+  { current_unit := Some(String.uppercase_ascii $2); 
+    (String.uppercase_ascii $2,$3 :: $5,$4) 
   }
   ;
 
 chain3_prologue : CHAIN3 optional_weighted_condition STRING STRING
-  { current_unit := Some(String.uppercase $3); ($2,String.uppercase $3,$4,false) }
+  { current_unit := Some(String.uppercase_ascii $3); ($2,String.uppercase_ascii $3,$4,false) }
 | CHAIN3 optional_weighted_condition IF_FILE_EXISTS STRING STRING
-    { current_unit := Some(String.uppercase $4); ($2,String.uppercase $4,$5,true) }
+    { current_unit := Some(String.uppercase_ascii $4); ($2,String.uppercase_ascii $4,$5,true) }
     ;
 
 interject_prologue : INTERJECT STRING STRING STRING
-  { current_unit := Some(String.uppercase $2); (String.uppercase $2,false,$3,$4,false,false) }
+  { current_unit := Some(String.uppercase_ascii $2); (String.uppercase_ascii $2,false,$3,$4,false,false) }
   ;
 | INTERJECT IF_FILE_EXISTS STRING STRING STRING
-  { current_unit := Some(String.uppercase $3); (String.uppercase $3,true,$4,$5,false,false) }
+  { current_unit := Some(String.uppercase_ascii $3); (String.uppercase_ascii $3,true,$4,$5,false,false) }
   ;
 
 interject_copy_trans_prologue :
   /* first boolean = enable don't copy actions a la ICT2; second boolean: add all transitions a la
   ICT3 */
   INTERJECT_COPY_TRANS optional_safe STRING STRING STRING
-  { current_unit := Some(String.uppercase $3); (String.uppercase $3,false,$4,$5,false,false,$2) }
+  { current_unit := Some(String.uppercase_ascii $3); (String.uppercase_ascii $3,false,$4,$5,false,false,$2) }
 | INTERJECT_COPY_TRANS2 optional_safe STRING STRING STRING
-    { current_unit := Some(String.uppercase $3); (String.uppercase $3,false,$4,$5,true,false,$2) }
+    { current_unit := Some(String.uppercase_ascii $3); (String.uppercase_ascii $3,false,$4,$5,true,false,$2) }
 | INTERJECT_COPY_TRANS3 optional_safe STRING STRING STRING
-    { current_unit := Some(String.uppercase $3); (String.uppercase $3,false,$4,$5,false,true,$2) }
+    { current_unit := Some(String.uppercase_ascii $3); (String.uppercase_ascii $3,false,$4,$5,false,true,$2) }
 | INTERJECT_COPY_TRANS4 optional_safe STRING STRING STRING
-    { current_unit := Some(String.uppercase $3); (String.uppercase $3,false,$4,$5,true,true,$2) }
+    { current_unit := Some(String.uppercase_ascii $3); (String.uppercase_ascii $3,false,$4,$5,true,true,$2) }
     ;
 | INTERJECT_COPY_TRANS optional_safe IF_FILE_EXISTS STRING STRING STRING
-  { current_unit := Some(String.uppercase $4); (String.uppercase $4,true,$5,$6,false,false,$2) }
+  { current_unit := Some(String.uppercase_ascii $4); (String.uppercase_ascii $4,true,$5,$6,false,false,$2) }
 | INTERJECT_COPY_TRANS2 optional_safe IF_FILE_EXISTS STRING STRING STRING
-    { current_unit := Some(String.uppercase $4); (String.uppercase $4,true,$5,$6,true,false,$2) }
+    { current_unit := Some(String.uppercase_ascii $4); (String.uppercase_ascii $4,true,$5,$6,true,false,$2) }
 | INTERJECT_COPY_TRANS3 optional_safe IF_FILE_EXISTS STRING STRING STRING
-    { current_unit := Some(String.uppercase $4); (String.uppercase $4,true,$5,$6,false,true,$2) }
+    { current_unit := Some(String.uppercase_ascii $4); (String.uppercase_ascii $4,true,$5,$6,false,true,$2) }
 | INTERJECT_COPY_TRANS4 optional_safe IF_FILE_EXISTS STRING STRING STRING
-    { current_unit := Some(String.uppercase $4); (String.uppercase $4,true,$5,$6,true,true,$2) }
+    { current_unit := Some(String.uppercase_ascii $4); (String.uppercase_ascii $4,true,$5,$6,true,true,$2) }
     ;
 
   action : 
@@ -375,15 +375,15 @@ interject_copy_trans_prologue :
     { let top,ext_unit,ext_label,number = $1 in
     current_unit := None ; 
     if top then 
-      Dc.Extend_Top( String.uppercase ext_unit, ext_label, number, $2 )
+      Dc.Extend_Top( String.uppercase_ascii ext_unit, ext_label, number, $2 )
     else
-      Dc.Extend_Bottom( String.uppercase ext_unit, ext_label, number, $2 ) 
+      Dc.Extend_Bottom( String.uppercase_ascii ext_unit, ext_label, number, $2 ) 
     } 
 | replace_prologue state_list END 
     { current_unit := None ;
       Dc.Replace($1, $2) }
 | REPLACE_SAY STRING STRING lse
-    { Dc.Replace_Say(String.uppercase $2,$3,$4) } 
+    { Dc.Replace_Say(String.uppercase_ascii $2,$3,$4) } 
 | replace_state_trigger_prologue when_list
     { let f,s,t = $1 in 
     let verified_t = verify_trigger_list t in 
@@ -400,22 +400,22 @@ interject_copy_trans_prologue :
     current_unit := None ; 
     Dc.Add_Trans_Trigger(f,s,verified_t,tl,$2) } 
 | ADD_TRANS_ACTION STRING BEGIN string_list END BEGIN int_list END STRING when_list
-    { current_unit := Some(String.uppercase $2);
+    { current_unit := Some(String.uppercase_ascii $2);
       let verified_a = verify_action_list $9 in
       current_unit := None ; 
-      Dc.Add_Trans_Action(String.uppercase $2,$4,$7,verified_a,$10) }
+      Dc.Add_Trans_Action(String.uppercase_ascii $2,$4,$7,verified_a,$10) }
 | ALTER_TRANS STRING BEGIN string_list END BEGIN int_list END BEGIN alter_trans_list END when_list
-    { Dc.Alter_Trans(String.uppercase $2,$4,$7,$10) }
+    { Dc.Alter_Trans(String.uppercase_ascii $2,$4,$7,$10) }
 | REPLACE_TRANS_ACTION STRING BEGIN string_list END BEGIN int_list END STRING STRING when_list
-    { current_unit := Some(String.uppercase $2);
+    { current_unit := Some(String.uppercase_ascii $2);
       current_unit := None ; 
-      Dc.Replace_Trans_Action(String.uppercase $2,$4,$7,$9,$10,$11) }
+      Dc.Replace_Trans_Action(String.uppercase_ascii $2,$4,$7,$9,$10,$11) }
 | REPLACE_TRANS_TRIGGER STRING BEGIN string_list END BEGIN int_list END STRING STRING when_list
-    { current_unit := Some(String.uppercase $2);
+    { current_unit := Some(String.uppercase_ascii $2);
       current_unit := None ;
-      Dc.Replace_Trans_Trigger(String.uppercase $2,$4,$7,$9,$10,$11) }
+      Dc.Replace_Trans_Trigger(String.uppercase_ascii $2,$4,$7,$9,$10,$11) }
 | SET_WEIGHT STRING STRING STRING_REF
-    { Dc.Set_Weight(String.uppercase $2,$3,$4) }
+    { Dc.Set_Weight(String.uppercase_ascii $2,$3,$4) }
 | chain3_prologue chain3_list compound_chain3_list chain3_epilogue
     { let (entry_weight,entry_cond),file,state,ifexist = $1 in
     let first_part = List.map (fun (cond,says,action) ->
@@ -475,17 +475,17 @@ interject_copy_trans_prologue :
      }
     }
 | REPLACE_TRIGGER_TEXT STRING STRING STRING when_list
-    { Dc.Replace_Trigger_Text(String.uppercase $2,$3,$4,false,$5) }
+    { Dc.Replace_Trigger_Text(String.uppercase_ascii $2,$3,$4,false,$5) }
 | REPLACE_TRIGGER_TEXT_REGEXP STRING STRING STRING when_list
-    { Dc.Replace_Trigger_Text(String.uppercase $2,$3,$4,true,$5) }
+    { Dc.Replace_Trigger_Text(String.uppercase_ascii $2,$3,$4,true,$5) }
 | REPLACE_ACTION_TEXT STRING STRING STRING upper_string_list when_list
-    { Dc.Replace_Action_Text(String.uppercase $2 :: $5,$3,$4,false,$6) }
+    { Dc.Replace_Action_Text(String.uppercase_ascii $2 :: $5,$3,$4,false,$6) }
 | REPLACE_ACTION_TEXT_PROCESS STRING STRING STRING upper_string_list when_list
-    { Dc.Replace_Action_Text(String.uppercase $2 :: $5,$3,verify_action_list $4,false,$6) }
+    { Dc.Replace_Action_Text(String.uppercase_ascii $2 :: $5,$3,verify_action_list $4,false,$6) }
 | REPLACE_ACTION_TEXT_REGEXP STRING STRING STRING upper_string_list when_list
-    { Dc.Replace_Action_Text(String.uppercase $2 :: $5,$3,$4,true,$6) }
+    { Dc.Replace_Action_Text(String.uppercase_ascii $2 :: $5,$3,$4,true,$6) }
 | REPLACE_ACTION_TEXT_PROCESS_REGEXP STRING STRING STRING upper_string_list when_list
-    { Dc.Replace_Action_Text(String.uppercase $2 :: $5,$3,verify_action_list $4,true,$6) }
+    { Dc.Replace_Action_Text(String.uppercase_ascii $2 :: $5,$3,verify_action_list $4,true,$6) }
     ;
 
   chain3_list : optional_condition lse optional_action     { [($1,$2,$3)] }
@@ -510,17 +510,17 @@ interject_copy_trans_prologue :
 	
   chain3_epilogue: 
 | END STRING STRING
-    { let next = Dlg.Symbolic(String.uppercase $2,$3,false) in
+    { let next = Dlg.Symbolic(String.uppercase_ascii $2,$3,false) in
     [| Dlg.make_trans_of_next next |] }
 | EXTERN STRING STRING
-    { let next = Dlg.Symbolic(String.uppercase $2,$3,false) in
+    { let next = Dlg.Symbolic(String.uppercase_ascii $2,$3,false) in
     [| Dlg.make_trans_of_next next |] }
 | COPY_TRANS optional_safe STRING STRING
-    { let next = Dlg.Copy(String.uppercase $3,$4,$2) in
+    { let next = Dlg.Copy(String.uppercase_ascii $3,$4,$2) in
 	let trans = [| Dlg.make_trans_of_next next |] in
 	trans }
 | COPY_TRANS_LATE optional_safe STRING STRING
-    { let next = Dlg.Copy_Late(String.uppercase $3,$4,$2) in
+    { let next = Dlg.Copy_Late(String.uppercase_ascii $3,$4,$2) in
 	let trans = [| Dlg.make_trans_of_next next |] in
 	trans }
 | EXIT
@@ -540,7 +540,7 @@ interject_copy_trans_prologue :
 
   compound_chain3_list :                  { [] }
 | EQUALSEQUALS STRING chain3_list compound_chain3_list
-    { let this_speaker = String.uppercase $2 in
+    { let this_speaker = String.uppercase_ascii $2 in
     let first_part = List.map (fun (cond,says,action) ->
       { Dc.c3du_speaker = this_speaker ;
         Dc.c3du_condition = cond ;
@@ -552,7 +552,7 @@ interject_copy_trans_prologue :
     first_part @ $4
     }
 | EQUALSEQUALS IF_FILE_EXISTS STRING chain3_list compound_chain3_list
-    { let this_speaker = String.uppercase $3 in
+    { let this_speaker = String.uppercase_ascii $3 in
     let first_part = List.map (fun (cond,says,action) ->
       { Dc.c3du_speaker = this_speaker ;
         Dc.c3du_condition = cond ;
@@ -645,10 +645,10 @@ interject_copy_trans_prologue :
         (file,s) :: convert tl extern_guy
     in 
     extra_actions := (Dc.Chain(
-		      { Dc.entry_file = String.uppercase $2 ;
+		      { Dc.entry_file = String.uppercase_ascii $2 ;
 			Dc.entry_label = $3 ;
 			Dc.dialogue = convert $4 true;
-			Dc.exit_file = String.uppercase $6 ;
+			Dc.exit_file = String.uppercase_ascii $6 ;
 			Dc.exit_label = $7 ;
 		      } )) :: !extra_actions ;
     []  
@@ -656,7 +656,7 @@ interject_copy_trans_prologue :
     ;
 
   appendi_prologue : APPENDI STRING 
-    { let what = String.uppercase $2 in  
+    { let what = String.uppercase_ascii $2 in  
     let old = !current_unit in current_unit := Some(what); (old, what) } 
     ; 
 
@@ -764,7 +764,7 @@ interject_copy_trans_prologue :
       Dlg.action = None ;
       Dlg.journal_str = None;
       Dlg.unknown_flags = 0 ;
-      Dlg.next = Dlg.Copy(String.uppercase $3,$4,$2) ;
+      Dlg.next = Dlg.Copy(String.uppercase_ascii $3,$4,$2) ;
     }
     }
 | COPY_TRANS_LATE optional_safe STRING STRING
@@ -775,15 +775,15 @@ interject_copy_trans_prologue :
       Dlg.action = None ;
       Dlg.journal_str = None;
       Dlg.unknown_flags = 0 ;
-      Dlg.next = Dlg.Copy_Late(String.uppercase $3,$4,$2) ;
+      Dlg.next = Dlg.Copy_Late(String.uppercase_ascii $3,$4,$2) ;
     }
     }
     ;
 
   next : GOTO STRING     { Dlg.Symbolic(get_current_unit () ,$2,false) }
 | PLUS STRING     { Dlg.Symbolic(get_current_unit () ,$2,false) }
-| EXTERN STRING STRING { Dlg.Symbolic(String.uppercase $2,$3,false) }
-| EXTERN IF_FILE_EXISTS STRING STRING { Dlg.Symbolic(String.uppercase $3,$4,true) }
+| EXTERN STRING STRING { Dlg.Symbolic(String.uppercase_ascii $2,$3,false) }
+| EXTERN IF_FILE_EXISTS STRING STRING { Dlg.Symbolic(String.uppercase_ascii $3,$4,true) }
 | EXIT                 { Dlg.Exit }
     ;
 

--- a/src/key.ml
+++ b/src/key.ml
@@ -100,7 +100,7 @@ let ext_of_key key =
     Printf.sprintf "0x%X" key
 
 let key_of_ext warn ext =
-  let ext = String.uppercase ext in
+  let ext = String.uppercase_ascii ext in
   try
     Hashtbl.find key_ext_ht ext
   with e ->
@@ -174,7 +174,7 @@ let load_key filename buff =
         let len_file = short_of_str_off buff (off + 8) in
         {
          length = int_of_str_off buff off ;
-         filename = String.uppercase
+         filename = String.uppercase_ascii
            (get_string_of_size buff off_file len_file) ;
          locations = short_of_str_off buff (off + 10) ;
        }) ;
@@ -182,7 +182,7 @@ let load_key filename buff =
         let off = offset_resource + (i * 14) in
         let bitfield = int32_of_str_off buff (off + 10) in
         let res = {
-          res_name = String.uppercase (get_string_of_size buff off 8) ;
+          res_name = String.uppercase_ascii (get_string_of_size buff off 8) ;
           res_type = short_of_str_off buff (off + 8) ;
           other_index = Int32.to_int
             (Int32.logand bitfield (Int32.of_int 16383)) ;
@@ -205,7 +205,7 @@ let find_resource key name ext =
   with Not_found ->
     begin
       Hashtbl.find key.resfind
-        (String.uppercase name,String.uppercase ext)
+        (String.uppercase_ascii name,String.uppercase_ascii ext)
     end
 
 let resource_exists key name ext =
@@ -228,8 +228,8 @@ let bif_of_resource key name ext =
 let bif_exists_in_key key name =
   let result = ref false in
   Array.iter (fun b ->
-    let b = String.uppercase b.filename in
-    if String.compare (String.uppercase name) b = 0 then
+    let b = String.uppercase_ascii b.filename in
+    if String.compare (String.uppercase_ascii name) b = 0 then
       result := true) key.biff ;
   !result
 
@@ -241,7 +241,7 @@ let list_biff key o =
 let list_biff_contents key o bl =
   Array.iter (fun r ->
     let biff = key.biff.(r.bif_index) in
-    let up_name = String.uppercase biff.filename in
+    let up_name = String.uppercase_ascii biff.filename in
     if List.mem up_name bl then
       o (Printf.sprintf "[%s] contains %8s.%3s at index %d\n"
            biff.filename r.res_name ( ext_of_key r.res_type )
@@ -255,12 +255,12 @@ let list_key key o =
 
 let list_of_key_resources : key -> bool -> string list =
   (fun key use_override ->
-    let from_key = List.map String.uppercase
+    let from_key = List.map String.uppercase_ascii
         (Array.to_list (Array.map (fun r ->
           Printf.sprintf "%s.%s" r.res_name
             (ext_of_key r.res_type)) key.resource)) in
     if use_override then begin
-      let from_override = List.map String.uppercase
+      let from_override = List.map String.uppercase_ascii
           (Array.to_list (Sys.readdir "override")) in
       List.sort_unique compare (from_key @ from_override)
     end else from_key)
@@ -270,9 +270,9 @@ let search_key_resources key use_override search_func =
 
 let remove_biff key filename =
   let idx = ref None in
-  let filename = String.uppercase filename in
+  let filename = String.uppercase_ascii filename in
   Array.iteri (fun i b ->
-    if (String.uppercase b.filename) = filename then
+    if (String.uppercase_ascii b.filename) = filename then
       idx := Some(i)) key.biff ;
   let i = match !idx with
   | Some(i) -> i

--- a/src/load.ml
+++ b/src/load.ml
@@ -38,10 +38,10 @@ let allow_missing = ref []
 let cbifs_to_rem = Queue.create ()
 
 let ok_missing file =
-  let file = String.uppercase file in
+  let file = String.uppercase_ascii file in
   let rec check lst = match lst with
   | [] -> false
-  | hd :: tl -> if (String.uppercase hd) = file then true else
+  | hd :: tl -> if (String.uppercase_ascii hd) = file then true else
     check tl
   in check !allow_missing
 
@@ -298,7 +298,7 @@ let load_ee_dialogs game_path =
   let lang_path = game_path ^ "/lang" in
   let lang_dirs =
     (List.fast_sort compare
-       (List.map String.lowercase
+       (List.map String.lowercase_ascii
           (List.filter (fun dir ->
             let dir = Arch.native_separator (lang_path ^ "/" ^ dir) in
             (is_directory dir) &&
@@ -401,7 +401,7 @@ let read_cd_paths gp =
           while true do
             let s = Unix.readdir s_d_h in
             let base,ext = split s in
-            if (String.uppercase ext) = "INI" then begin
+            if (String.uppercase_ascii ext) = "INI" then begin
               let buff = load_file (gp ^ "/" ^ s) in
               (try
                 let cd_regexp = Arch.cd_regexp in
@@ -616,7 +616,7 @@ let copy_resource game name ext oc =
 let load_resource for_what game override_allowed name ext =
   let skip_this_error = !skip_next_load_error in
   skip_next_load_error := false ;
-  let ext_up = String.uppercase ext in
+  let ext_up = String.uppercase_ascii ext in
   let full = name ^ "." ^ ext in
   let a,b =
     if (Case_ins.filename_is_implicit name) then begin
@@ -675,7 +675,7 @@ let exists_in_overrides game res ext =
   List.fold_left (fun acc dir ->
     if file_exists (dir ^ "/" ^ res ^ "." ^ ext) then
       true
-    else acc) false (if (String.uppercase ext) = "IDS" then
+    else acc) false (if (String.uppercase_ascii ext) = "IDS" then
       game.ids_path_list else game.override_path_list)
 
 let resource_exists_legacy_check name =

--- a/src/main.ml
+++ b/src/main.ml
@@ -46,7 +46,7 @@ type output_info = {
       | ".", _ -> if !debug_ocaml then log_and_print "--out a_file: %s\n"  theout.file
       | _ -> if !debug_ocaml then log_and_print "You're a pervert, decide where to put your stuff!\n"
       end ;
-      let ext_chop = List.map String.uppercase ext_chop in
+      let ext_chop = List.map String.uppercase_ascii ext_chop in
       let directory,(name,ext) = (Case_ins.filename_dirname file,split(Case_ins.filename_basename file)) in
       let fullname = match theout.dir, theout.file with
       | ".", "" -> file
@@ -60,7 +60,7 @@ type output_info = {
       in
       let base,ext = split fullname in
       let result =
-        if List.mem (String.uppercase ext) ext_chop then
+        if List.mem (String.uppercase_ascii ext) ext_chop then
           Case_ins.filename_chop_extension fullname
         else
           fullname
@@ -113,7 +113,7 @@ let forceify_file forceify game =
   (match forceify with
     Some(file) -> begin
       try
-        let name,ext = split (String.uppercase file) in
+        let name,ext = split (String.uppercase_ascii file) in
         Dlg.local_string_ht := Some([]) ;
         begin
           match ext with
@@ -383,7 +383,7 @@ let cmp_bcs_file bcmp_dest bcmp_src game =
           print_theout "<<<<<<<< %s\n%s>>>>>>>>\n" out_name res;
           print_theout "// TP2 patch to turn %s into %s. For example using:\n" s d;
           if bcmp_src = None then
-            if String.uppercase e = "BS" then
+            if String.uppercase_ascii e = "BS" then
               print_theout "COPY ~scripts/%s~ ~scripts~\n" s
             else
               print_theout "COPY_EXISTING ~%s~ ~override~\n" s
@@ -406,7 +406,7 @@ let rcmp_file game rcmp_src rcmp_dest =
       let load file =
         let a,b = split (Filename.basename file) in
         let buff = try load_file file with e -> fst (Load.load_resource "--rcmp" game true a b) in
-        match String.uppercase b with
+        match String.uppercase_ascii b with
         | "DLG" -> buff
         | "BCS"
         | "BS" -> buff
@@ -469,8 +469,8 @@ let cmp_tlk_file tlkcmp_src tlkcmp_dest tlkcmp_strings user_min user_max =
       | None -> (min (Array.length stlk) (Array.length dtlk)) - 1
       in
       print_theout "<<<<<<<< .../tlkcmp.tra\n" ;
-      let stlk_cmp = Array.map (fun entry -> {entry with Tlk.sound_name = String.uppercase entry.Tlk.sound_name}) stlk in
-      let dtlk_cmp = Array.map (fun entry -> {entry with Tlk.sound_name = String.uppercase entry.Tlk.sound_name}) dtlk in
+      let stlk_cmp = Array.map (fun entry -> {entry with Tlk.sound_name = String.uppercase_ascii entry.Tlk.sound_name}) stlk in
+      let dtlk_cmp = Array.map (fun entry -> {entry with Tlk.sound_name = String.uppercase_ascii entry.Tlk.sound_name}) dtlk in
       for i = my_min to my_max do
         if (stlk_cmp.(i).Tlk.text <> dtlk_cmp.(i).Tlk.text) ||
         (stlk_cmp.(i).Tlk.sound_name <> dtlk_cmp.(i).Tlk.sound_name) then
@@ -668,7 +668,7 @@ let biff_get bg_list game =
   let files_in_chitin = Key.list_of_key_resources game.Load.key false in
   let try_to_load str = begin
     try begin
-      let base,ext = split (String.uppercase str) in
+      let base,ext = split (String.uppercase_ascii str) in
       let path = theout.dir ^ "/" ^ str in
       let out = open_for_writing path true in
       if ext <> "IDS" && ext <> "2DA" then begin
@@ -853,7 +853,7 @@ let traify_file game traify traify_num traify_comment traify_old_tra =
   (match traify with
   | Some(file) -> begin
       try
-        let name,ext = split (String.uppercase file) in
+        let name,ext = split (String.uppercase_ascii file) in
 
         let buf = ref (load_file file) in
 
@@ -861,7 +861,7 @@ let traify_file game traify traify_num traify_comment traify_old_tra =
             ["d"; "tra"; "tp2"; "baf"; "tpa"; "tpp"; "tph"] in
         if !debug_ocaml then
           log_and_print "I'm trying to save to %s.%s and %s.tra\n\n"
-            base (String.lowercase ext) base ;
+            base (String.lowercase_ascii ext) base ;
         let transout_name = base ^ ".tra" in
         let dout_name = base ^ "." ^ ext in
 
@@ -1155,9 +1155,9 @@ let do_script process_script pause_at_end game =
     Tp.specified_specific_components := true;
     let toproc = ref [] in
     Array.iteri (fun i s -> if i > 1 then begin
-      match String.uppercase s with
+      match String.uppercase_ascii s with
       | "U"
-      | "I" -> action := String.uppercase s
+      | "I" -> action := String.uppercase_ascii s
       | _ -> begin
           let num = int_of_string s in
           match !action with
@@ -1207,7 +1207,7 @@ let decompile_bcs bcs_list game =
     try
       let buff, _ =
         if file_exists str then (load_file str),"" else
-        Load.load_resource "decompile BCS command" game true b (String.uppercase e)
+        Load.load_resource "decompile BCS command" game true b (String.uppercase_ascii e)
       in
       let script = handle_script_buffer str buff in
       let base = Case_ins.filename_basename b in
@@ -1229,7 +1229,7 @@ let decompile_bcs bcs_list game =
 let merge_tlk tlk_merge game =
   if_bgee_check_lang_or_fail game ;
   List.iter (fun str ->
-    let name,ext = split (String.uppercase str) in
+    let name,ext = split (String.uppercase_ascii str) in
     let tlk = Tlk.load_tlk str in
     let dialog = Load.get_active_dialog game in
     let max =
@@ -1360,7 +1360,7 @@ let main () =
 
   let ee_use_lang = ref None in
 
-  let argv0_base, argv0_ext = split (String.uppercase (Case_ins.filename_basename Sys.argv.(0))) in
+  let argv0_base, argv0_ext = split (String.uppercase_ascii (Case_ins.filename_basename Sys.argv.(0))) in
 
   let auto () = begin
     pause_at_end := true ;
@@ -1381,7 +1381,7 @@ let main () =
         log_and_print "ERROR: Cannot perform auto-update, going ahead anyway!\n\t%s\n"
           (printexc_to_string e) ;
       end ) ;
-    if List.exists (fun arg -> let a,b = split arg in (String.uppercase b) = "TP2")
+    if List.exists (fun arg -> let a,b = split arg in (String.uppercase_ascii b) = "TP2")
         (Array.to_list Sys.argv) then
       () (* setup-solaufein.exe foo.tp2
           * runs foo.tp2, not setup-solaufein.tp2 *)
@@ -1412,7 +1412,7 @@ let main () =
     "--search-ids", Myarg.String Load.add_ids_path, "X\tlook in X for input IDS files (cumulative)" ;
     "--tlkin", Myarg.String Load.set_dialog_tlk_path,"X\tuse X as DIALOG.TLK" ;
     "--ftlkin", Myarg.String Load.set_dialogf_tlk_path,"X\tuse X as DIALOGF.TLK";
-    "--use-lang", Myarg.String (fun s -> ee_use_lang := Some (String.lowercase s)), "X\ton games with multiple languages, use files in lang/X/";
+    "--use-lang", Myarg.String (fun s -> ee_use_lang := Some (String.lowercase_ascii s)), "X\ton games with multiple languages, use files in lang/X/";
     "--tlkmerge", Myarg.String (fun s -> tlk_merge := !tlk_merge @ [s]; test_output_tlk_p := true),
     "X\tmerge X into loaded DIALOG.TLK" ;
     "--yes", Myarg.Set Tp.always_yes,"\tanswer all TP2 questions with 'Yes'";
@@ -1470,7 +1470,7 @@ let main () =
     "--modder", Myarg.List (Myarg.TwoStrings (fun a b -> Modder.set_modder [a, b, 10])), "\tX Y... enables the MODDER mode and sets the MODDER option X to Y (cumulative)";
     "--clear-memory", Myarg.Set Tpstate.clear_memory,"\tcalls CLEAR_MEMORY after every action evaluation.";
     "--script-style", Myarg.String (fun s ->
-      let n = match String.uppercase s with
+      let n = match String.uppercase_ascii s with
       | "BG"
       | "BG2" -> Load.BG2
       | "BG1" -> Load.BG1
@@ -1522,7 +1522,7 @@ let main () =
 
     "--list-biffs", Myarg.Set list_biff, "\tenumerate all BIFF files in CHITIN.KEY" ;
     "--list-files", Myarg.Set list_files, "\tenumerate all resource files in CHITIN.KEY";
-    "--biff", Myarg.String (fun s -> bc_list := (String.uppercase s) :: !bc_list), "X\tenumerate contents of BIFF file X (cumulative)" ;
+    "--biff", Myarg.String (fun s -> bc_list := (String.uppercase_ascii s) :: !bc_list), "X\tenumerate contents of BIFF file X (cumulative)" ;
     "--biff-type", Myarg.String (fun s -> bs_type_list := s :: !bs_type_list), "X\texamine all BIFF resources of extension X ... (cumulative)" ;
     "--biff-str", Myarg.String (fun s -> bs_str_list := s :: !bs_str_list), "X\t... and list those containing X (cumulative, regexp allowed)" ;
     "--biff-name", Myarg.Int (fun i -> Load.content_name_offset := Some(i)),
@@ -1581,7 +1581,7 @@ let main () =
     exit (return_value StatusArgumentInvalid)
   in
   let handleArg str = begin
-    let base,ext = split (String.uppercase str) in
+    let base,ext = split (String.uppercase_ascii str) in
     match ext with
     | "D" -> test_output_tlk_p := true ; d_list := str :: !d_list
     | "DLG" -> dlg_list := (base,ext) :: !dlg_list

--- a/src/modder.ml
+++ b/src/modder.ml
@@ -9,7 +9,7 @@ type modder_level =
   | None
 
 let level_of_string s2 =
-  match String.uppercase s2 with
+  match String.uppercase_ascii s2 with
   | "NONE" -> None
   | "WARN" -> Warn
   | "FAIL" -> Fail
@@ -36,7 +36,7 @@ let set_modder str_l =
   end ;
   List.iter (fun (s1,s2,prio) ->
     let s2 = level_of_string s2 in
-    let s1 = String.uppercase s1 in
+    let s1 = String.uppercase_ascii s1 in
     let old_prio = try
       snd (Hashtbl.find mode s1) ;
     with
@@ -50,7 +50,7 @@ let set_modder str_l =
     if prio <= old_prio then Hashtbl.replace mode s1 (s2, prio)) str_l
 
 let get x = if !debug_modder then try
-  fst (Hashtbl.find mode (String.uppercase x))
+  fst (Hashtbl.find mode (String.uppercase_ascii x))
 with _ -> Warn else None
 
 let handle_deb test str =

--- a/src/parsewrappers.ml
+++ b/src/parsewrappers.ml
@@ -9,7 +9,7 @@ let load_log () =
     let result = parse_file true (File Tp.log_name) "parsing .log files"
         (Dparser.log_file Dlexer.initial) in
     Tp.the_log := List.map (fun (a,b,c,d) ->
-      ((String.uppercase a),b,c,d,Tp.Installed)) result
+      ((String.uppercase_ascii a),b,c,d,Tp.Installed)) result
   with e ->
     log_or_print "WARNING: parsing log [%s]: %s\n" Tp.log_name
       (printexc_to_string e) ;
@@ -32,7 +32,7 @@ let compile_baf_filename game filename =
        filename (printexc_to_string e) ; raise e)
 
 let handle_script_buffer filename buffer =
-  match split (String.uppercase filename) with
+  match split (String.uppercase_ascii filename) with
   | _,"BAF" -> parse_file true (String(filename,buffer)) "parsing .baf files"
         (Bafparser.baf_file Baflexer.initial)
   | _,_ -> parse_file true (String(filename,buffer)) "parsing .bcs files"

--- a/src/parsing.ml
+++ b/src/parsing.ml
@@ -85,10 +85,10 @@ external parse_engine :
 	  = "caml_parse_engine"
 
 let make_env () = 
-  { s_stack = Array.create 100 0;
-    v_stack = Array.create 100 (Obj.repr ());
-    symb_start_stack = Array.create 100 dummy_pos;
-    symb_end_stack = Array.create 100 dummy_pos;
+  { s_stack = Array.make 100 0;
+    v_stack = Array.make 100 (Obj.repr ());
+    symb_start_stack = Array.make 100 dummy_pos;
+    symb_end_stack = Array.make 100 dummy_pos;
     stacksize = 100;
     stackbase = 0;
     curr_char = 0;
@@ -110,10 +110,10 @@ let grow_stacks() =
   let env = henv () in 
   let oldsize = env.stacksize in
   let newsize = oldsize * 2 in
-  let new_s = Array.create newsize 0
-  and new_v = Array.create newsize (Obj.repr ())
-  and new_start = Array.create newsize dummy_pos
-  and new_end = Array.create newsize dummy_pos in
+  let new_s = Array.make newsize 0
+  and new_v = Array.make newsize (Obj.repr ())
+  and new_start = Array.make newsize dummy_pos
+  and new_end = Array.make newsize dummy_pos in
   Array.blit env.s_stack 0 new_s 0 oldsize;
   env.s_stack <- new_s;
   Array.blit env.v_stack 0 new_v 0 oldsize;

--- a/src/refactorbafparser.mly
+++ b/src/refactorbafparser.mly
@@ -7,7 +7,7 @@ let or_counter = ref 0
 let build_or = ref []
 
 let handle_or is_not s1 s2 =
-  let s,trig_ov = if String.lowercase s1 = "triggeroverride" then begin
+  let s,trig_ov = if String.lowercase_ascii s1 = "triggeroverride" then begin
     let s2 = String.sub s2 1 (String.length s2 - 2) in
     let i = String.index s2 ',' in
     Str.string_after s2 (i + 1),Some (Str.string_before s2 i)

--- a/src/tlk.ml
+++ b/src/tlk.ml
@@ -109,7 +109,7 @@ let null_tlk () : tlk = [| |]
 let load_big_slow_tlk filename = begin
   Stats.time "unmarshal TLK" (fun () -> 
     let fd = Case_ins.unix_openfile filename [Unix.O_RDONLY] 0 in 
-    let buff = String.create 8 in 
+    let buff = Bytes.create 8 in 
     my_read 8 fd buff filename ; 
     if buff <> "TLK V1  " then begin
       failwith "not a valid TLK file (wrong sig)"
@@ -132,7 +132,7 @@ let load_big_slow_tlk filename = begin
 	let text_length = get_int () in 
 	let text = if text_length = 0 then "" else
         begin
-          let string_i_text = String.create text_length in 
+          let string_i_text = Bytes.create text_length in 
           ignore(Unix.lseek fd (offset_strdata + text_offset) Unix.SEEK_SET) ;
           my_read text_length fd string_i_text filename ; 
           string_i_text

--- a/src/toldparser.mly
+++ b/src/toldparser.mly
@@ -368,7 +368,7 @@ optional_evaluate :
 | ALLOW_MISSING upper_string_list tp_flag_list
     { Tp.Allow_Missing($2) :: $3 }
 | SCRIPT_STYLE STRING tp_flag_list
-    { let n = match (String.uppercase $2) with
+    { let n = match (String.uppercase_ascii $2) with
     | "BG"
     | "BG2" -> Load.BG2
     | "BG1" -> BG1
@@ -382,7 +382,7 @@ optional_evaluate :
     ;
 
   upper_string_list :            { [] }
-| STRING upper_string_list  { (String.uppercase $1) :: $2 }
+| STRING upper_string_list  { (String.uppercase_ascii $1) :: $2 }
     ;
 
   tp_lang_list :   { [] }

--- a/src/tpaction.ml
+++ b/src/tpaction.ml
@@ -279,7 +279,7 @@ let rec process_action_real our_lang game this_tp2_filename tp a =
                     let next = Unix.readdir dh in
                     if ((Case_ins.unix_stat (dir ^ "/" ^ next)).Unix.st_kind = Unix.S_REG) &&
                       (Str.string_match reg next 0) then begin
-                        let file = (String.uppercase (dir ^ "/" ^ next)) in
+                        let file = (String.uppercase_ascii (dir ^ "/" ^ next)) in
                         let filespec = Case_ins.filename_basename file in
                         move file (dst ^ "/" ^ filespec)
                       end
@@ -289,7 +289,7 @@ let rec process_action_real our_lang game this_tp2_filename tp a =
 
       | TP_DisableFromKey(file_lst) ->
           let file_lst = List.map Var.get_string (List.map eval_pe_str file_lst) in
-          let file_lst = List.map String.uppercase file_lst in
+          let file_lst = List.map String.uppercase_ascii file_lst in
           let new_key = Key.remove_files game.Load.key file_lst in
           let oc = open_for_writing "CHITIN.KEY" true in
           Key.save_key new_key oc ;
@@ -347,7 +347,7 @@ let rec process_action_real our_lang game this_tp2_filename tp a =
                   if ((Case_ins.unix_stat (directory ^ "/" ^ next)).Unix.st_kind =
                       Unix.S_REG) && (Str.string_match reg next 0) then
                     (if !debug_ocaml then log_and_print "  match!\n";
-                     find_list := (String.uppercase (directory ^ "/" ^ next)) :: !find_list;
+                     find_list := (String.uppercase_ascii (directory ^ "/" ^ next)) :: !find_list;
                      ignore (record_other_file_op ("override/" ^ next))) ;
                 done
               with End_of_file -> ());
@@ -646,7 +646,7 @@ let rec process_action_real our_lang game this_tp2_filename tp a =
                   src
                 else
                   Var.get_string src in
-              if String.uppercase src = "DIALOG.TLK" then
+              if String.uppercase_ascii src = "DIALOG.TLK" then
                 log_and_print_modder "\n\nUse COPY_LARGE rather than COPY on dialog.tlk!\n\n\n" ;
 
               let buff =
@@ -854,7 +854,7 @@ let rec process_action_real our_lang game this_tp2_filename tp a =
                 dest ^ "/" ^ (Case_ins.filename_basename src)
               else
                 dest in
-            (match String.uppercase (snd (split dest)) with
+            (match String.uppercase_ascii (snd (split dest)) with
             | ".IDS" -> Bcs.clear_ids_map game
             | _ -> ()) ;
             ignore (set_copy_vars src dest None) ;
@@ -1122,7 +1122,7 @@ let rec process_action_real our_lang game this_tp2_filename tp a =
             let cells = List.map (Str.split many_whitespace_regexp) lines in
             let headers = List.nth cells 2 in
             let rec get_where lst cnt = match lst with
-            | hd :: tl -> if String.uppercase hd = String.uppercase oldString then cnt else get_where tl (cnt + 1)
+            | hd :: tl -> if String.uppercase_ascii hd = String.uppercase_ascii oldString then cnt else get_where tl (cnt + 1)
             | [] -> failwith (Printf.sprintf "Unknown kit: %s" oldString)
             in
             let column = get_where headers 1 in
@@ -1153,7 +1153,7 @@ let rec process_action_real our_lang game this_tp2_filename tp a =
             "override/" ^ which ^ ".2da"
           in
           let patches = Hashtbl.create 5 in
-          List.iter (fun (a,b) -> Hashtbl.add patches (String.lowercase a) b)
+          List.iter (fun (a,b) -> Hashtbl.add patches (String.lowercase_ascii a) b)
             patches_list;
           let get_clasweap file =
             try get_line file
@@ -1239,7 +1239,7 @@ let rec process_action_real our_lang game this_tp2_filename tp a =
             let a_e1 = TP_Append("ABCLSMOD.2DA",k.abclsmod,[],true,false,0) in
             let a_e2 = TP_Append("DUALCLAS.2DA",k.dualclas,[],true,false,0) in
             let a6 = TP_Append("ALIGNMNT.2DA",k.alignmnt,[],true,false,0) in
-            let abil_file = String.uppercase (Case_ins.filename_basename k.ability_file) in
+            let abil_file = String.uppercase_ascii (Case_ins.filename_basename k.ability_file) in
             if !debug_ocaml then log_and_print "%s\n" abil_file;
             let abil_file_no_ext = Case_ins.filename_chop_extension abil_file in
             let dest_abil_file = "override/" ^ abil_file in
@@ -1562,7 +1562,7 @@ let rec process_action_real our_lang game this_tp2_filename tp a =
           let numd = ref 0 in
           let nums = ref 0 in
           let handle_one_d_file filespec = match split
-              (String.uppercase filespec) with
+              (String.uppercase_ascii filespec) with
           | _,"BAF" -> incr nums
           | _,"D" -> incr numd
           | _,_ -> ()
@@ -1639,7 +1639,7 @@ let rec process_action_real our_lang game this_tp2_filename tp a =
               end;
               (if Modder.enabled "MISSING_EVAL" then
                 check_missing_eval ("COMPILE " ^ d) (load_file newd1);
-               match split (String.uppercase (Case_ins.filename_basename d)) with
+               match split (String.uppercase_ascii (Case_ins.filename_basename d)) with
                | _,"BAF" -> compile_baf_filename game newd1
                | _,"D" -> handle_d_filename newd1
                | _,_ -> ())
@@ -1678,7 +1678,7 @@ let rec process_action_real our_lang game this_tp2_filename tp a =
 
       | TP_Set_Col(file,new_col_list,col_num) ->
           log_and_print_modder "Setting game text column-wise ...\n" ;
-          let eight,three = split (String.uppercase file) in
+          let eight,three = split (String.uppercase_ascii file) in
           let buff,loaded_path = Load.load_resource "SET_COLUMN" game true eight three in
           if buff = "" then
             log_or_print "[%s]: empty or does not exist\n" file
@@ -1739,7 +1739,7 @@ let rec process_action_real our_lang game this_tp2_filename tp a =
             let src_list = prepend count_prepend src_list in
             log_and_print "Appending to files column-wise ...\n" ;
             let buff = if frombif then
-              let eight,three = split (String.uppercase file) in
+              let eight,three = split (String.uppercase_ascii file) in
               let buff,loaded_path =
                 Load.load_resource "APPEND_COLUMN" game true eight three in
               buff
@@ -1832,13 +1832,13 @@ let rec process_action_real our_lang game this_tp2_filename tp a =
       | TP_Append(file,src,con_l,frombif,keep_crlf,do_backup) ->
           let file = Arch.backslash_to_slash file in
           if when_exists file con_l frombif game then begin
-            if Case_ins.filename_check_suffix(String.lowercase file) "ids" then
+            if Case_ins.filename_check_suffix(String.lowercase_ascii file) "ids" then
               Bcs.clear_ids_map game ;
             log_and_print "Appending to files ...\n" ;
             let file = Var.get_string file in
             let src = Var.get_string src in
             let buff = if frombif then begin
-              let eight,three = split (String.uppercase file) in
+              let eight,three = split (String.uppercase_ascii file) in
               let the_buff,loaded_path =
                 Load.load_resource "APPEND" game true eight three in
               the_buff
@@ -1895,7 +1895,7 @@ let rec process_action_real our_lang game this_tp2_filename tp a =
                     if !debug_ocaml then log_and_print "%s\n" buff;
                     if String.length buff < 2 || Str.last_chars buff 2 <> "\r\n" then
                       fn "\r\n";
-                    let src = if String.lowercase dest = "quests.ini" &&
+                    let src = if String.lowercase_ascii dest = "quests.ini" &&
                       Arch.view_command = "start" then
                       (Str.global_replace (Str.regexp "\\([^\r]\\)\n") "\\1\r\n" src)
                     else src in
@@ -2007,7 +2007,7 @@ let rec process_action_real our_lang game this_tp2_filename tp a =
                 raise e
               end) ; in
           List.iter (fun dest ->
-            let base,ext = split (String.uppercase dest) in
+            let base,ext = split (String.uppercase_ascii dest) in
             let dest_script =
               let old_a_m = !Load.allow_missing in
               Load.allow_missing := dest :: old_a_m ;
@@ -2054,7 +2054,7 @@ let rec process_action_real our_lang game this_tp2_filename tp a =
       | TP_At_Exit(str,exact) ->
           begin
             let str = Var.get_string str in
-            let a,b = split (String.uppercase str) in
+            let a,b = split (String.uppercase_ascii str) in
             match b with
             | "TP2" -> (enqueue_tp2_filename) str
             | _ ->
@@ -2071,7 +2071,7 @@ let rec process_action_real our_lang game this_tp2_filename tp a =
             | None -> None
             | Some str -> Some (Var.get_string (eval_pe_str str)) in
             let str = Var.get_string str in
-            let a,b = split (String.uppercase str) in
+            let a,b = split (String.uppercase_ascii str) in
             match b with
             | "TP2" -> (enqueue_tp2_filename) str
             | _ ->
@@ -2106,7 +2106,7 @@ let rec process_action_real our_lang game this_tp2_filename tp a =
             else path ^ "/" in
           let biff_path_list = List.sort_unique compare
               (List.flatten (List.map (fun s ->
-                let s = String.lowercase s in
+                let s = String.lowercase_ascii s in
                 if file_exists s then begin
                   log_and_print "WARNING: giving biffs as %s to \
                     DECOMPRESS_BIFF is deprecated\n" s ;
@@ -2142,7 +2142,7 @@ let rec process_action_real our_lang game this_tp2_filename tp a =
             biff in
           let decompress biff =
             let fd = Case_ins.unix_openfile biff [Unix.O_RDONLY] 0 in
-            let buff = String.create 8 in
+            let buff = Bytes.create 8 in
             ignore (Unix.read fd buff 0 8) ;
             ignore (Unix.close fd) ;
             (match buff with

--- a/src/tppe.ml
+++ b/src/tppe.ml
@@ -32,8 +32,8 @@ let rec eval_pe_str s = match s with
 	| true -> Var.get_string s)
 | PE_GetVar(p) -> (try Var.get_string_exact ("%" ^ eval_pe_str p ^ "%") with _ -> eval_pe_str p)
 | PE_Evaluate(p) -> Var.get_string (eval_pe_str p)
-| PE_Uppercase(s) -> String.uppercase (eval_pe_str s)
-| PE_Lowercase(s) -> String.lowercase (eval_pe_str s)
+| PE_Uppercase(s) -> String.uppercase_ascii (eval_pe_str s)
+| PE_Lowercase(s) -> String.lowercase_ascii (eval_pe_str s)
 | PE_Dollars(s,a,do_eval,do_add) ->
     let a = List.map (fun x -> Var.get_string (eval_pe_str x)) a in
     let s = Var.get_string (eval_pe_str s) in
@@ -214,7 +214,7 @@ let rec eval_pe buff game p =
 	let filename = Var.get_string filename in
 	let reg = Var.get_string reg in
 	let old_allow_missing = !Load.allow_missing in 
-	Load.allow_missing := [String.uppercase filename] ; 
+	Load.allow_missing := [String.uppercase_ascii filename] ; 
 	let answer = 
 	  try
 	    let buf = 
@@ -244,7 +244,7 @@ let rec eval_pe buff game p =
         let digest = Digest.file f in
         let hex = Digest.to_hex digest in
         log_only "File [%s] has MD5 checksum [%s]\n" f hex ;
-        (String.uppercase hex) = (String.uppercase s)
+        (String.uppercase_ascii hex) = (String.uppercase_ascii s)
       end else begin
         false
       end)
@@ -333,8 +333,8 @@ let rec eval_pe buff game p =
       let s1 = Var.get_string s1 in
       let s2 = Var.get_string s2 in 
       let comparison = if ignore_case then 
-        (fun s1 s2 -> String.compare (String.uppercase s1)
-            (String.uppercase s2)) else String.compare
+        (fun s1 s2 -> String.compare (String.uppercase_ascii s1)
+            (String.uppercase_ascii s2)) else String.compare
       in
       let result = Int32.of_int (comparison s1 s2) in
       let bigg_make_bool () =
@@ -436,7 +436,7 @@ let rec eval_pe buff game p =
       let iwdee = f "howparty.2da" in
       let pstee = f "pstchar.2da" in
       let res = List.exists (fun this ->
-        match String.uppercase this with
+        match String.uppercase_ascii this with
         | "BG2"
         | "SOA"        -> bg2 && not tutu && not tob && not ca && not iwdinbg2
         | "TOB"        -> bg2 && not tutu &&     tob && not ca && not iwdinbg2 && not bg2ee
@@ -461,7 +461,7 @@ let rec eval_pe buff game p =
         | "IWDEE"      -> iwdee
         | "PSTEE"      -> pstee
         | "EET"        -> eet
-        | _ -> log_and_print "WARNING: No rule to identify %s\n" (String.uppercase this) ; false
+        | _ -> log_and_print "WARNING: No rule to identify %s\n" (String.uppercase_ascii this) ; false
       ) game_list in
       if res then 1l else 0l;
   end
@@ -477,12 +477,12 @@ let rec eval_pe buff game p =
       let totlm = ["TOTLM"; "IWD_IN_BG2"; "IWDEE"] in
       let iwd2 = ["IWD2"] in
       let ca = ["CA"] in
-      (match String.uppercase game_set with
+      (match String.uppercase_ascii game_set with
       | "SOD" -> eval_pe "" game (PE_FileContainsEvaluated
                                     (PE_LiteralString "CAMPAIGN.2DA",
                                      PE_LiteralString "SOD"))
       | _ -> begin
-          let list = (match String.uppercase game_set with
+          let list = (match String.uppercase_ascii game_set with
           | "BG1" -> bg1
           | "TOTSC" -> totsc
           | "BG2"
@@ -495,7 +495,7 @@ let rec eval_pe buff game p =
           | "TOTLM" -> totlm
           | "IWD2" -> iwd2
           | "CA" -> ca
-          | _ -> log_and_print "WARNING: GAME_INCLUDES has no rule for %s\n" (String.uppercase game_set) ; [(String.uppercase game_set)]) in
+          | _ -> log_and_print "WARNING: GAME_INCLUDES has no rule for %s\n" (String.uppercase_ascii game_set) ; [(String.uppercase_ascii game_set)]) in
           eval_pe buff game (PE_GameIs((String.concat " " list), true))
       end)
   end

--- a/src/tpstate.ml
+++ b/src/tpstate.ml
@@ -156,10 +156,10 @@ let get_component_list tp_file =
  * Evaluate a TP2 Patch Expression
  ************************************************************************)
 let log_match a b =
-  let a = String.uppercase a in
-  let b = String.uppercase b in
-  Str.global_replace (Str.regexp "^SETUP-") "" (Case_ins.filename_basename (String.uppercase a)) =
-  Str.global_replace (Str.regexp "^SETUP-") "" (Case_ins.filename_basename (String.uppercase b))
+  let a = String.uppercase_ascii a in
+  let b = String.uppercase_ascii b in
+  Str.global_replace (Str.regexp "^SETUP-") "" (Case_ins.filename_basename (String.uppercase_ascii a)) =
+  Str.global_replace (Str.regexp "^SETUP-") "" (Case_ins.filename_basename (String.uppercase_ascii b))
 
 let any_installed tp2 =
   let rec is_installed lst = match lst with
@@ -294,11 +294,11 @@ let sprintf_log game handle_tp2_filename handle_tra_filename get_tra_list_filena
         let component_name = Str.global_replace newline_regexp " " component_name in
         let subcomponent_name = Str.global_replace newline_regexp " " subcomponent_name in
         Printf.sprintf "~%s~ #%d #%d // %s%s%s\n"
-          (String.uppercase a) b c subcomponent_name component_name version
+          (String.uppercase_ascii a) b c subcomponent_name component_name version
       end
       else begin
         Printf.sprintf "~%s~ #%d #%d\n"
-          (String.uppercase a) b c
+          (String.uppercase_ascii a) b c
       end
     in
     match d with

--- a/src/tpuninstall.ml
+++ b/src/tpuninstall.ml
@@ -98,7 +98,7 @@ let handle_at_uninstall tp2 m do_uninstall do_interactive_uninstall game =
       | TP_At_Interactive_Uninstall(str,exact) ->
           if do_interactive_uninstall then begin
             let str = Var.get_string str in
-            match (split (String.uppercase str)) with
+            match (split (String.uppercase_ascii str)) with
             | _,"TP2" -> (enqueue_tp2_filename) str
             | _,_ -> let str = if exact then str else Arch.handle_view_command str !skip_at_view in
               ignore(exec_command str exact)
@@ -106,7 +106,7 @@ let handle_at_uninstall tp2 m do_uninstall do_interactive_uninstall game =
       | TP_At_Uninstall(str,exact) ->
           if do_uninstall then begin
             let str = Var.get_string str in
-            match (split (String.uppercase str)) with
+            match (split (String.uppercase_ascii str)) with
             | _,"TP2" -> (enqueue_tp2_filename) str
             | _,_ -> let str = if exact then str else Arch.handle_view_command str !skip_at_view in
               ignore (exec_command str exact)
@@ -114,7 +114,7 @@ let handle_at_uninstall tp2 m do_uninstall do_interactive_uninstall game =
       | TP_At_Interactive_Uninstall_Exit(str,exact) ->
           if do_interactive_uninstall then begin
             let str = Var.get_string str in
-            match (split (String.uppercase str)) with
+            match (split (String.uppercase_ascii str)) with
             | _,"TP2" -> (enqueue_tp2_filename) str
             | _,_ -> let str = if exact then str else Arch.handle_view_command str !skip_at_view in
               if List.mem (Command(str,exact)) !execute_at_exit then
@@ -125,7 +125,7 @@ let handle_at_uninstall tp2 m do_uninstall do_interactive_uninstall game =
       | TP_At_Uninstall_Exit(str,exact) ->
           if do_uninstall then begin
             let str = Var.get_string str in
-            match (split (String.uppercase str)) with
+            match (split (String.uppercase_ascii str)) with
             | _,"TP2" -> (enqueue_tp2_filename) str
             | _,_ -> let str = if exact then str else Arch.handle_view_command str !skip_at_view in
               if List.mem (Command(str,exact)) !execute_at_exit then
@@ -217,9 +217,9 @@ let validate_uninstall_order tp2 =
     match flag with
     | Uninstall_Order str_l ->
         List.iter (fun action ->
-          if not (Hashtbl.mem actions (String.uppercase action)) then
+          if not (Hashtbl.mem actions (String.uppercase_ascii action)) then
             failwith (action ^ " not allowed in UNINSTALL_ORDER");
-          if not (Hashtbl.find actions (String.uppercase action)) then
+          if not (Hashtbl.find actions (String.uppercase_ascii action)) then
             failwith (action ^ " already had an UNINSTALL_ORDER");
           Queue.add action order;
           Hashtbl.add actions action false;
@@ -236,9 +236,9 @@ let validate_uninstall_order tp2 =
   order
 
 let check_pre_hooks game tp2 i interactive override_filename =
-  if (String.uppercase override_filename) = "OVERRIDE/SPELL.IDS" ||
-  (String.uppercase override_filename) = "OVERRIDE\\SPELL.IDS" then begin try
-    let tp2_basename = String.lowercase (Str.global_replace (Str.regexp_case_fold ".*[-/]\\([^-/]*\\)\\.tp2$") "\\1" tp2.tp_filename) in
+  if (String.uppercase_ascii override_filename) = "OVERRIDE/SPELL.IDS" ||
+  (String.uppercase_ascii override_filename) = "OVERRIDE\\SPELL.IDS" then begin try
+    let tp2_basename = String.lowercase_ascii (Str.global_replace (Str.regexp_case_fold ".*[-/]\\([^-/]*\\)\\.tp2$") "\\1" tp2.tp_filename) in
     let marker = Printf.sprintf "override/spell.ids.%s.%d.marker" tp2_basename i in
     let out_chn = Case_ins.perv_open_out_bin marker in
     output_string out_chn "spell.ids edits installed\n";
@@ -249,7 +249,7 @@ let check_pre_hooks game tp2 i interactive override_filename =
   with e -> () end
 
 let check_post_hooks game tp2 i interactive override_filename =
-  if String.uppercase override_filename = "CHITIN.KEY" then begin
+  if String.uppercase_ascii override_filename = "CHITIN.KEY" then begin
     let keyname = Load.find_file_in_path "." "^chitin.key$" in
     let keybuff = load_file keyname in
     game.Load.key <- Key.load_key keyname keybuff ;
@@ -402,7 +402,7 @@ let uninstall_tp2_component game tp2 tp_file i interactive lang_name =
 
 
 let temp_to_perm_uninstalled tp2 i handle_tp2_filename game =
-  let tp2_basename = String.lowercase (Str.global_replace (Str.regexp_case_fold ".*[-/]\\([^-/]*\\)\\.tp2$") "\\1" tp2) in
+  let tp2_basename = String.lowercase_ascii (Str.global_replace (Str.regexp_case_fold ".*[-/]\\([^-/]*\\)\\.tp2$") "\\1" tp2) in
   let marker = Printf.sprintf "override/spell.ids.%s.%d.marker" tp2_basename i in
   my_unlink marker;
   let rec is_installed lst = match lst with
@@ -422,7 +422,7 @@ let temp_to_perm_uninstalled tp2 i handle_tp2_filename game =
           Var.set_int32 "COMPONENT_NUMBER" (Int32.of_int i) ;
           let m = get_nth_module tp2 c true in
           log_only "Running AT_INTERACTIVE_EXITs in ~%s~ %d %d %s\n"
-            (String.uppercase a) b c
+            (String.uppercase_ascii a) b c
             (str_of_str_opt sopt) ;
           handle_at_uninstall tp2 m
             false (* "AT_UNINSTALL" was already done! *)

--- a/src/tpwork.ml
+++ b/src/tpwork.ml
@@ -134,7 +134,7 @@ let do_readme tp this_tp2_filename =
                 if !skip_at_view || not !interactive then answer := "N";
                 while !answer <> "Y" && !answer <> "N" do
                   log_and_print "\n%s\n" (get_trans (-1034));
-                  answer := String.uppercase (read_line())
+                  answer := String.uppercase_ascii (read_line())
                 done;
                 if !answer = "Y" then
                   ignore (Unix.system str);
@@ -395,7 +395,7 @@ let ask_about_quickmenu tp this_tp2_filename using_quickmenu module_defaults
         (Dc.single_string_of_tlk_string_safe (Load.the_game ()) title)
         (if !is_selection then (get_trans (-1027)) else "") ;
       incr cnt) quickmenu ;
-    let ans = String.uppercase (read_line ()) in
+    let ans = String.uppercase_ascii (read_line ()) in
     let set_state inst uninst always_inst always_uninst =
       for i = 0 to last_module_index do
         try
@@ -463,7 +463,7 @@ let ask_about_ungrouped tp this_tp2_filename module_defaults
       finished := true ;
       (* log_and_print "\nWhat should be done with all components that are NOT YET installed?\n[I]nstall them, [S]kip them, [A]sk about each one? " ; *)
       log_and_print "\n%s" ((get_trans (-1002)));
-      match String.uppercase(read_line ()) with
+      match String.uppercase_ascii(read_line ()) with
       | "R"
       | "I" ->
           for i = 0 to last_module_index do
@@ -511,7 +511,7 @@ let ask_about_ungrouped tp this_tp2_filename module_defaults
       finished := true ;
       (* log_and_print "\nWhat should be done with all components that are ALREADY installed?\n[R]e-install them, [U]ninstall them, [S]kip them, [A]sk about each one? " ; *)
       log_and_print "\n%s" ((get_trans (-1003)));
-      match String.uppercase(read_line ()) with
+      match String.uppercase_ascii(read_line ()) with
       | "I"
       | "R" ->
           for i = 0 to last_module_index do
@@ -596,7 +596,7 @@ let ask_about_groups tp groups module_defaults last_module_index using_quickmenu
         log_and_print "\n%s%s%s" (Var.get_string (get_trans (-1028)))
           (Dc.single_string_of_tlk_string_safe
              (Load.the_game ()) this_grp) (get_trans (-1029)) ;
-        match String.uppercase(read_line ()) with
+        match String.uppercase_ascii(read_line ()) with
         | "Y" ->
             for i = 0 to last_module_index do
               try
@@ -837,7 +837,7 @@ let rec handle_tp game this_tp2_filename tp =
               !safe_exit then begin
               let old_log = !the_log in
               the_log := !the_log @
-                [((String.uppercase this_tp2_filename), !our_lang_index, i,
+                [((String.uppercase_ascii this_tp2_filename), !our_lang_index, i,
                   Some(package_name), Installed)];
               let old_tp_quick_log = !Tp.quick_log in
               Tp.quick_log := true;
@@ -919,7 +919,7 @@ let rec handle_tp game this_tp2_filename tp =
           begin
             if List.find_all (fun x -> x = TPM_NotInLog) m.mod_flags = [] then
               the_log := !the_log @
-                [((String.uppercase this_tp2_filename),!our_lang_index,i,Some(package_name),Installed)]
+                [((String.uppercase_ascii this_tp2_filename),!our_lang_index,i,Some(package_name),Installed)]
             else (* log_and_print "NOT adding a WeiDU.log record. You cannot uninstall this.\n" *) ()
           end ;
           finished := true
@@ -1156,7 +1156,7 @@ let rec handle_tp game this_tp2_filename tp =
             done ;
             if !any_unsafe then
               log_and_print "Because of --safe-exit, only [N] and [Q] are acceptable.\n";
-            let answer = String.uppercase (read_line ()) in
+            let answer = String.uppercase_ascii (read_line ()) in
             let answer = if Hashtbl.mem already_ht () then begin
               let (m,i) = Hashtbl.find already_ht () in
               let temp_uninst = temporarily_uninstalled this_tp2_filename i in
@@ -1250,7 +1250,7 @@ let rec handle_tp game this_tp2_filename tp =
       if not (safe_to_handle tp.tp_filename !current) then
         log_and_print "\nBecause of --safe-exit, only [N] and [Q] are acceptable. ";
       begin
-        let answer = String.uppercase(read_line ()) in
+        let answer = String.uppercase_ascii(read_line ()) in
         handle_letter tp answer can_uninstall temp_uninst package_name m
           finished !current ;
         Dc.clear_state () ;

--- a/src/trealparserin.in
+++ b/src/trealparserin.in
@@ -178,7 +178,7 @@ nonterm (Tp.tp_flag) Tp_Flag {
        Tp.Menu_Style "1" ]
   -> ALLOW_MISSING e1:Upper_String_List [ Tp.Allow_Missing e1 ]
   -> SCRIPT_STYLE e1:STRING
-       [ let n = match (String.uppercase e1) with
+       [ let n = match (String.uppercase_ascii e1) with
          | "BG"
          | "BG2" -> Load.BG2
          | "BG1" -> Load.BG1
@@ -191,11 +191,11 @@ nonterm (Tp.tp_flag) Tp_Flag {
          Tp.Script_Style(n) ]
   -> README e1:String_List [ Tp.Readme e1 ]
   -> UNINSTALL_ORDER e1:String_List [
-       List.iter (fun x -> match String.uppercase x with
+       List.iter (fun x -> match String.uppercase_ascii x with
                  | "MOVE" | "COPY" | "STRSET" | "AT" -> ()
                  | _ -> failwith (Printf.sprintf "%s not allowed in UNINSTALL_ORDER" x);
                  ) e1;
-                 Tp.Uninstall_Order (List.map String.uppercase e1) ]
+                 Tp.Uninstall_Order (List.map String.uppercase_ascii e1) ]
   -> QUICK_MENU ALWAYS_ASK e0:String_List END e1:Menu_List END [ Tp.Quick_Menu (e1,List.map int_of_string e0) ]
   -> AUTO_EVAL_STRINGS [ Tp.Auto_Eval_Strings ]
 }
@@ -211,7 +211,7 @@ nonterm((Dlg.tlk_string * int list) list) Menu_List_Rev {
 
 nonterm(string list) Upper_String_List_Rev {
   -> { [] }
-  -> e1:Upper_String_List_Rev e2:STRING [ String.uppercase e2 :: e1 ]
+  -> e1:Upper_String_List_Rev e2:STRING [ String.uppercase_ascii e2 :: e1 ]
 }
 
 nonterm(string list) Upper_String_List {

--- a/src/util.ml
+++ b/src/util.ml
@@ -255,9 +255,9 @@ let str_of_int32 i =
   let a = Int32.to_int (Int32.logand i 255l) in
   let i = Int32.shift_right_logical i 8 in
   let result = String.make 4 (Char.chr a) in
-  result.[0] <- (Char.chr d) ;
-  result.[1] <- (Char.chr c) ;
-  result.[2] <- (Char.chr b) ;
+  Bytes.set result 0 (Char.chr d) ;
+  Bytes.set result 1 (Char.chr c);
+  Bytes.set result 2 (Char.chr b) ;
   result
 
 let str_of_int i =
@@ -269,7 +269,7 @@ let str_of_short i =
   let c = i land 255 in
   let i = i lsr 8 in
   let result = String.make 2 (Char.chr d) in
-  result.[1] <- (Char.chr c) ;
+  Bytes.set result 1 (Char.chr c) ;
   result
 
 let str_of_byte i =
@@ -296,9 +296,9 @@ let write_short buff off value =
   String.blit (str_of_short (value)) 0 buff off 2
 let write_byte buff off value =
   if value < 0 then
-    buff.[off] <- (Char.chr (256+value))
+    Bytes.set buff off (Char.chr (256+value))
   else
-    buff.[off] <- (Char.chr value)
+    Bytes.set buff off (Char.chr value)
 let write_resref buff off str =
   String.blit (str_to_exact_size str 8) 0 buff off 8
 
@@ -397,11 +397,11 @@ let handle_readonly filename =
 
 let rec backup_if_extant filename =
   if Hashtbl.mem backup_ht
-      (String.uppercase (native_separator filename)) then
+      (String.uppercase_ascii (native_separator filename)) then
     ()
   else begin
-    if (String.uppercase filename) = "OVERRIDE/SPELL.IDS" ||
-    (String.uppercase filename) = "OVERRIDE\\SPELL.IDS" then begin
+    if (String.uppercase_ascii filename) = "OVERRIDE/SPELL.IDS" ||
+    (String.uppercase_ascii filename) = "OVERRIDE\\SPELL.IDS" then begin
       if not (file_exists "override/spell.ids.installed") then begin
         backup_if_extant "override/spell.ids.installed" ;
         let out_chn = Case_ins.perv_open_out_bin
@@ -411,7 +411,7 @@ let rec backup_if_extant filename =
       end
     end ;
     Hashtbl.add backup_ht
-      (String.uppercase (native_separator filename)) true ;
+      (String.uppercase_ascii (native_separator filename)) true ;
     (match !backup_list_chn with
     | Some(chn) -> output_string chn (filename ^ "\n") ; flush chn
     | None -> ()) ;
@@ -457,7 +457,7 @@ and copy_large_file name out reason =
         let out_fd = Case_ins.unix_openfile out
             [Unix.O_WRONLY ; Unix.O_CREAT] 511 in
         let chunk_size = 10240 in
-        let chunk = String.create chunk_size in
+        let chunk = Bytes.create chunk_size in
         let sofar = ref 0 in
         while !sofar < size do
           let chunk_size = min (size - !sofar) chunk_size in
@@ -591,7 +591,7 @@ let exec_command cmd exact =
     begin
       (* copy stdout + stderr to logfile *)
       let proc_stdout = Unix.open_process_in (cmd ^ " 2>&1") in
-      let s = String.create 80 in
+      let s = Bytes.create 80 in
       let filter = create_filter () in
       begin
         try
@@ -849,7 +849,7 @@ let attempt_to_load_bgee_lang_dir game_path =
     let regexp = (Str.regexp_case_fold "lang_dir[ \t]+=[ \t]+\\([a-z_]+\\)") in
     (try
       ignore (Str.search_forward regexp buff 0) ;
-      Some (String.lowercase (Str.matched_group 1 buff))
+      Some (String.lowercase_ascii (Str.matched_group 1 buff))
     with Not_found -> None)
   end
   else None
@@ -858,7 +858,7 @@ let write_bgee_lang_dir game_path dir =
   (try
     let conf = Arch.native_separator (game_path ^ "/weidu.conf") in
     let chan = Case_ins.perv_open_out_bin conf in
-    ignore (output_string chan (String.lowercase
+    ignore (output_string chan (String.lowercase_ascii
                                   (Printf.sprintf "lang_dir = %s\n" dir))) ;
     ignore (close_out chan)
   with e ->
@@ -913,7 +913,7 @@ let all_possible_tp2s filename =
 let tp2_name filename =
   let chunk_list = Str.split (Str.regexp "[-]") filename in
   (match chunk_list with
-  | a :: b when (String.uppercase a) = "SETUP" -> (match b with
+  | a :: b when (String.uppercase_ascii a) = "SETUP" -> (match b with
     | c :: [] -> c
     | c -> (String.concat "-" c))
   | a :: b -> (String.concat "-" (a :: b))

--- a/src/var.ml
+++ b/src/var.ml
@@ -289,7 +289,7 @@ let all_the_assoc a =
   set_string "TAB" "\t" ;
 
   List.iter (fun game ->
-    let var = "REGISTRY_" ^ (String.uppercase game) ^ "_PATH" in
+    let var = "REGISTRY_" ^ (String.uppercase_ascii game) ^ "_PATH" in
     try
       let res = Arch.game_path_by_type game in
       set_string var (if res = "." then "" else res)

--- a/src/xor.ml
+++ b/src/xor.ml
@@ -15,8 +15,8 @@ let is_encrypted buff =
   buff.[1] = (Char.chr 255) 
 
 let decrypt buff =
-  let newstr = String.create ((String.length buff) -2) in
+  let newstr = Bytes.create ((String.length buff) -2) in
   for i = 0 to (String.length buff) - 3 do
-    newstr.[i] <- Char.chr ((Char.code buff.[i+2]) lxor key.(i mod 64))
+    Bytes.set newstr i (Char.chr ((Char.code buff.[i+2]) lxor key.(i mod 64)))
   done ;
   newstr


### PR DESCRIPTION
TODO
```
Warning 52: Code should not depend on the actual values of
this constructor's arguments. They are only for information
and may change in future versions. (See manual section 9.5)
```
```
Warning 3: deprecated: Stdlib.String.copy
```