### PR TITLE
fix missing separator and invalid cut option

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ all : weidu
 RELEASE    := 1
 NATIVECAML := 1
 VERSION_MAJOR := $(shell grep 'version =' src/version.ml | cut -d'"' -f2 | cut -c-3)
-VERSION_MINOR := $(shell grep 'version =' src/version.ml | cut -d'"' -f2 | cut -c4-)
+VERSION_MINOR := $(shell grep 'version =' src/version.ml | cut -d'"' -f2 | cut -c5-)
 
 # UNSAFE     := 1
 

--- a/Makefile
+++ b/Makefile
@@ -36,8 +36,8 @@ all : weidu
 
 RELEASE    := 1
 NATIVECAML := 1
-VERSION_MAJOR := $(shell grep 'version =' src/version.ml | cut -d'"' -f2 -z | cut -c-3)
-VERSION_MINOR := $(shell grep 'version =' src/version.ml | cut -d'"' -f2 -z | cut -c4-)
+VERSION_MAJOR := $(shell grep 'version =' src/version.ml | cut -d'"' -f2 | cut -c-3)
+VERSION_MINOR := $(shell grep 'version =' src/version.ml | cut -d'"' -f2 | cut -c4-)
 
 # UNSAFE     := 1
 
@@ -85,7 +85,7 @@ ifeq ($(shell uname -s),Linux)
 endif
 
 ifeq ($(shell uname -s),Darwin)
-@$(NARRATIVE) Linking Darwin executable
+	@$(NARRATIVE) Linking Darwin executable
 	$(CAMLLINK) -o $@ \
                 $(PROJECT_OCAML_LIBS:%=%.$(CMXA)) \
                 $(PROJECT_LIBS:%=-cclib -l%) \


### PR DESCRIPTION
Stuff I had to change on the Makefile to get it to work. The missing indentation was causing an error that stopped the compilation altogether, and cut was complaining about -z being passed to it so I removed that as well (I don't know of any version of the tool that takes -z as an argument, so I simply removed it. Still unsure if that was the right call).