### PR TITLE
load: load both gemrb paths

### DIFF
--- a/src/load.ml
+++ b/src/load.ml
@@ -51,6 +51,7 @@ let add_gemrb_path file =
         if (Util.is_directory path) then begin
           log_only "Adding GemRB data path: [%s]\n" path ;
           add_override_path path
+          add_override_path (path ^ "/../shared/")
         end else
           log_and_print "WARNING: GemRB path is not a directory: [%s]\n" path ;
     | _ -> ())) lines)


### PR DESCRIPTION
fix the remainder of #153

This should do it, but I haven't tested. Conceptually it's fine, but I don't know if you treat paths on windows specially or anything like that (in my experience slashes work there too).