### PR TITLE
Update parameters of function fj_are_structure

### DIFF
--- a/doc/base.tex
+++ b/doc/base.tex
@@ -10017,6 +10017,9 @@ Spawn structure variables:
 \item INT_VAR \verb+fj_schedule+ to the hourly appearance schedule (bits 0-23, default -1 or always);
 \item INT_VAR \verb+fj_day_prob+ to the spawn point daytime probability (default 100);
 \item INT_VAR \verb+fj_night_prob+ to the spawn point nighttime probability (default 100);
+\item INT_VAR \verb+fj_spawn_freq+ to the spawn frequency in seconds (Enhanced Editions only);
+\item INT_VAR \verb+fj_countdown+ to the spawn countdown (Enhanced Editions only);
+\item INT_VAR \verb+fj_weight0...fj_weight9+ to the weight of the spawn creatures (Enhanced Editions only);
 \end{itemize}
 Entrance structure variables:
 \begin{itemize}
@@ -10135,6 +10138,8 @@ Animation structure variables:
 \item INT_VAR \verb+fj_loop_chance+ to the chance of looping;
 \item INT_VAR \verb+fj_skip_cycles+ to start delay in frames;
 \item STR_VAR \verb+fj_bmp_resref+ to the palette bitmap;
+\item INT_VAR \verb+fj_width+ to the animation width (only required for WBM and PVRZ resources, Enhanced Editions only);
+\item INT_VAR \verb+fj_height+ to the animation height (only required for WBM and PVRZ resources, Enhanced Editions only);
 \end{itemize}
 Bitmask structure variables:
 \begin{itemize}
@@ -10147,6 +10152,11 @@ Songlist structure variables:
 \item INT_VAR \verb+fj_song_victory+ to the victory SONGLIST.2DA entry;
 \item INT_VAR \verb+fj_song_battle+ to the battle SONGLIST.2DA entry;
 \item INT_VAR \verb+fj_song_defeat+ to the defeat SONGLIST.2DA entry;
+\item INT_VAR \verb+fj_song_day_alt+ to the alternative day SONGLIST.2DA entry (default -1, Enhanced Editions only);
+\item INT_VAR \verb+fj_song_night_alt+ to the alternative night SONGLIST.2DA entry (default -1, Enhanced Editions only);
+\item INT_VAR \verb+fj_song_victory_alt+ to the alternative victory SONGLIST.2DA entry (default -1, Enhanced Editions only);
+\item INT_VAR \verb+fj_song_battle_alt+ to the alternative battle SONGLIST.2DA entry (default -1, Enhanced Editions only);
+\item INT_VAR \verb+fj_song_defeat_alt+ to the alternative defeat SONGLIST.2DA entry (default -1, Enhanced Editions only);
 \item STR_VAR \verb+fj_song_day0+ to the day song WAV resref;
 \item STR_VAR \verb+fj_song_day1+ to the night song WAV resref;
 \item INT_VAR \verb+fj_song_day_vol+ to the day songs volume (default 100);
@@ -10190,7 +10200,8 @@ Projectile trap structure variables (not available on PST):
 \item INT_VAR \verb+fj_loc_x+ to the X coordinate*;
 \item INT_VAR \verb+fj_loc_y+ to the Y coordinate*;
 \item INT_VAR \verb+fj_loc_z+ to the height;
-\item INT_VAR \verb+fj_target+ to the target ID;
+\item INT_VAR \verb+fj_target+ to the ea.ids value of the target;
+\item INT_VAR \verb+fj_creator+ to the index of the party member who created this projectile (0-5);
 \item STR_VAR \verb+fj_embedded_eff0+ to ~path/to/v2.eff~ or eff resref containing to projectile's effects*;
 \end{itemize}
 A few examples best illustrate the use of this function.

--- a/src/tph/include/fj_are_struct.tpa
+++ b/src/tph/include/fj_are_struct.tpa
@@ -77,6 +77,18 @@ DEFINE_PATCH_FUNCTION fj_are_structure
   fj_enable            = 1
   fj_day_prob          = 100
   fj_night_prob        = 100
+  fj_spawn_freq        = 0
+  fj_countdown         = 0
+  fj_weight0           = 0
+  fj_weight1           = 0
+  fj_weight2           = 0
+  fj_weight3           = 0
+  fj_weight4           = 0
+  fj_weight5           = 0
+  fj_weight6           = 0
+  fj_weight7           = 0
+  fj_weight8           = 0
+  fj_weight9           = 0
 
   // containers
   fj_lock_diff         = 100
@@ -129,6 +141,8 @@ DEFINE_PATCH_FUNCTION fj_are_structure
   fj_init_frame        = 0
   fj_loop_chance       = 0
   fj_skip_cycles       = 0
+  fj_width             = 0
+  fj_height            = 0
 
   // songs
   fj_song_day          = 0
@@ -136,6 +150,11 @@ DEFINE_PATCH_FUNCTION fj_are_structure
   fj_song_victory      = 0
   fj_song_battle       = 0
   fj_song_defeat       = 0
+  fj_song_day_alt      = ` 0
+  fj_song_night_alt    = ` 0
+  fj_song_victory_alt  = ` 0
+  fj_song_battle_alt   = ` 0
+  fj_song_defeat_alt   = ` 0
   fj_song_day_vol      = 100
   fj_song_night_vol    = 100
   fj_song_reverb       = 0
@@ -167,6 +186,7 @@ DEFINE_PATCH_FUNCTION fj_are_structure
   fj_missile_num       = ` 0
   fj_frequency         = 0
   fj_target            = 0
+  fj_creator           = 0
 
   STR_VAR
 
@@ -666,6 +686,18 @@ PHP_EACH struct AS key => value BEGIN
       WRITE_LONG   fj_return_offset + 0x88 fj_schedule
       WRITE_SHORT  fj_return_offset + 0x8c fj_day_prob
       WRITE_SHORT  fj_return_offset + 0x8e fj_night_prob
+      WRITE_LONG   fj_return_offset + 0x90 fj_spawn_freq
+      WRITE_LONG   fj_return_offset + 0x94 fj_countdown
+      WRITE_BYTE   fj_return_offset + 0x98 fj_weight0
+      WRITE_BYTE   fj_return_offset + 0x99 fj_weight1
+      WRITE_BYTE   fj_return_offset + 0x9a fj_weight2
+      WRITE_BYTE   fj_return_offset + 0x9b fj_weight3
+      WRITE_BYTE   fj_return_offset + 0x9c fj_weight4
+      WRITE_BYTE   fj_return_offset + 0x9d fj_weight5
+      WRITE_BYTE   fj_return_offset + 0x9e fj_weight6
+      WRITE_BYTE   fj_return_offset + 0x9f fj_weight7
+      WRITE_BYTE   fj_return_offset + 0xa0 fj_weight8
+      WRITE_BYTE   fj_return_offset + 0xa1 fj_weight9
     END ELSE
 
     // entrance
@@ -799,6 +831,8 @@ PHP_EACH struct AS key => value BEGIN
       WRITE_BYTE   fj_return_offset + 0x3e fj_loop_chance
       WRITE_BYTE   fj_return_offset + 0x3f fj_skip_cycles
       WRITE_ASCIIE fj_return_offset + 0x40 ~%fj_bmp_resref%~ #8
+      WRITE_SHORT  fj_return_offset + 0x48 fj_width
+      WRITE_SHORT  fj_return_offset + 0x4a fj_height
     END ELSE
 
     // bitmask
@@ -820,11 +854,11 @@ PHP_EACH struct AS key => value BEGIN
       WRITE_LONG   fj_return_offset + 0x08 fj_song_victory
       WRITE_LONG   fj_return_offset + 0x0c fj_song_battle
       WRITE_LONG   fj_return_offset + 0x10 fj_song_defeat
-      WRITE_LONG   fj_return_offset + 0x14 0xffffffff
-      WRITE_LONG   fj_return_offset + 0x18 0xffffffff
-      WRITE_LONG   fj_return_offset + 0x1c 0xffffffff
-      WRITE_LONG   fj_return_offset + 0x20 0xffffffff
-      WRITE_LONG   fj_return_offset + 0x24 0xffffffff
+      WRITE_LONG   fj_return_offset + 0x14 fj_song_day_alt
+      WRITE_LONG   fj_return_offset + 0x18 fj_song_night_alt
+      WRITE_LONG   fj_return_offset + 0x1c fj_song_victory_alt
+      WRITE_LONG   fj_return_offset + 0x20 fj_song_battle_alt
+      WRITE_LONG   fj_return_offset + 0x24 fj_song_defeat_alt
       WRITE_ASCIIE fj_return_offset + 0x28 ~%fj_song_day0%~ #8
       WRITE_ASCIIE fj_return_offset + 0x30 ~%fj_song_day1%~ #8
       WRITE_LONG   fj_return_offset + 0x38 fj_song_day_vol
@@ -901,7 +935,8 @@ PHP_EACH struct AS key => value BEGIN
       WRITE_SHORT  fj_return_offset + 0x14 fj_loc_x
       WRITE_SHORT  fj_return_offset + 0x16 fj_loc_y
       WRITE_SHORT  fj_return_offset + 0x18 fj_loc_z
-      WRITE_SHORT  fj_return_offset + 0x1a fj_target
+      WRITE_BYTE   fj_return_offset + 0x1a fj_target
+      WRITE_BYTE   fj_return_offset + 0x1b fj_creator
     END
 
   END


### PR DESCRIPTION
Added/updated EE-specific fields for fj_are_structure types `spawn`, `animation`, `songs` and `projectile`.

**Note:**
Parameter `fj_target` (short) of `projectile` type may not be fully backwards compatible because it has been split into `fj_target` (byte) for the intended EA target and the trap creator `fj_creator` (byte). However, it isn't widely known that the creator field exists and should default to 0 in existing mods (if there are any).