### PR TITLE
Remove EXPERIMENTAL from --list-components-json

### DIFF
--- a/src/main.ml
+++ b/src/main.ml
@@ -1551,7 +1551,7 @@ let main () =
     "--list-components-json", Myarg.Tuple [
     Myarg.String (fun s -> list_comp_json := Some s) ;
     Myarg.Int (fun i -> list_comp_lang := i) ;
-  ], "\tX Y lists all components in X using language Y with JSON output EXPERIMENTAL!" ;
+  ], "\tX Y lists all components in X using language Y with JSON output" ;
     "--save-components-name", Myarg.Set save_comp_name, "\trewrites WeiDU.log, printing every component name";
     "--change-log",Myarg.String (fun s -> change_log := s :: !change_log), "\tgenerates a changelog for the given resource (cumulative)";
     "--change-log-list",Myarg.List (Myarg.String (fun s -> change_log := s :: !change_log)), "\tgenerates a changelog for the given resource (cumulative)";


### PR DESCRIPTION
Given it's been used for 5+ years and there was only a single bugfix, it's hardly considered experimental.

Context: People are scared of using `--list-components-json` (and thus LABELS since it's the only way to get them) because of the 'experimental' flag.