### PR TITLE
feat(bell): Add terminal bell for *_READLN statements

### DIFF
--- a/src/tppatch.ml
+++ b/src/tppatch.ml
@@ -2397,7 +2397,7 @@ let rec process_patch2_real process_action tp our_lang patch_filename game buff 
 
     | TP_PatchReadLN(x) ->
         if !interactive then begin
-          let y = read_line ()in
+          let y = read_line_with_bell ()in
           log_only "User answer: \"%s\"\n" y;
           Var.set_string (eval_pe_str x) y;
           readln_strings:= y :: !readln_strings;

--- a/src/util.ml
+++ b/src/util.ml
@@ -78,6 +78,11 @@ let log_only_modder fmt =
     | Some(o) -> output_string o result ; flush o) in
   Printf.kprintf k fmt
 
+let read_line_with_bell () =
+  print_string "\007";
+  flush stdout;
+  read_line ()
+
 let log_and_print fmt =
   let k result = begin
     if not !be_silent then (output_string stdout result ; flush stdout ) ;


### PR DESCRIPTION
@FredrikLindgren, this adds a terminal bell when weidu asks for input (shout out to @podcherklife). Its going to be super useful for my mod_installer. It allows us to detect without fail when weidu asks for input.

If you feel this needs to be disabled we can add a flag for it. Let me know what you think.