### PR TITLE
Fail on incorrect ALTER_TRANS EPILOG directive

### DIFF
--- a/src/dc.ml
+++ b/src/dc.ml
@@ -883,9 +883,9 @@ let rec process_action game a = match a with
           let get_next s =
             let parts = Str.split (Str.regexp " ") s in
             match parts with
-            | [a;b;c] -> Dlg.Symbolic(String.uppercase b,c,false)
-            | [a;b] -> Dlg.Symbolic(String.uppercase n,b,false)
-            | [a] -> Dlg.Exit
+            | [a;b;c] when a = "EXTERN" -> Dlg.Symbolic(String.uppercase b,c,false)
+            | [a;b] when a = "GOTO" || a = "+" -> Dlg.Symbolic(String.uppercase n,b,false)
+            | [a] when a = "EXIT" -> Dlg.Exit
             | _ -> failwith "unknown transition in ALTER_STRING"
           in
           let intos = match into with


### PR DESCRIPTION
While `.d` parser does complain about incorrect keywords, it only warns, not fails. Meaning that `.d` compiler ends up accepting constructions like `~XXX 1~` because it does not check anything beyond number of tokens.

I suppose a better solution would be fixing parser to fail, but I am a bit lost on what it is trying to do.
Anyway, this change can serve as an illustration of the bug, at least.