### PR TITLE
Fixed EXTEND_(TOP|BOTTOM) .d actions maximum pos

### DIFF
--- a/src/dc.ml
+++ b/src/dc.ml
@@ -729,11 +729,11 @@ let rec process_action game a = match a with
         let place =
           if place < 0 then
             failwith "EXTEND_TOP #position must be non-negative"
-          else if place >= tlen then begin
+          else if place > tlen then begin
             log_or_print
               "WARNING: EXTEND_TOP #position %d out of range 0-%d\n"
               place tlen ;
-            tlen - 1
+            tlen
           end else place
         in
         (* insert these transitions just after already-extans transition
@@ -769,11 +769,11 @@ let rec process_action game a = match a with
         let place =
           if place < 0 then
             failwith "EXTEND_BOTTOM #position must be non-negative"
-          else if place >= tlen then begin
+          else if place > tlen then begin
             log_or_print
               "WARNING: EXTEND_BOTTOM #position %d out of range 0-%d\n"
               place tlen ;
-            tlen - 1
+            tlen
           end else place
         in
         let place = tlen - place in


### PR DESCRIPTION
There is a sort of off by 1 error in EXTEND_TOP and EXTEND_BOTTOM `.d` actions.
Current implementation allows inserting transitions only at indexes in range `[0, len(arr) - 1]` whereas `len(arr)` should actually also be a valid insertion position.
Think of how `[X]` has two insertion positions: one at 0, prodicing `[_, X]` and one at 1, producing `[X, _]` 