### PR TITLE
Fixed aggregation for dActionWhen conditions

### DIFF
--- a/src/dc.ml
+++ b/src/dc.ml
@@ -614,7 +614,7 @@ let append_state n state =
   dlg.Dlg.state <- Array.append dlg.Dlg.state [| state |]
 
 let passes d_when str =
-  List.fold_left (fun acc elt -> match elt with
+  List.fold_left (fun acc elt -> acc && match elt with
   | W_If s -> begin
       let my_regexp = Str.regexp_case_fold (Var.get_string s) in
       try let _ = Str.search_forward my_regexp str 0 in


### PR DESCRIPTION
So grammar allows specifying a list of conditions for some d actions, but as of now values are not properly folded, the last condition always wins.

This is obviously an oversight, but this fix is kind of questionable. Like, should should conditions be combined with `||` or with `&&`?  `&&` seems more intuitive, but `||` seems more useful. Does it even make sense at all, why would anybody want to have two separate conditions instead of combining them into a single regex? I've searched through a quite extensive(but not exhaustive) list of .d files and none was using more than 1 condition.
Questions, questions...

Nevertheless, something should be dome about this, even if just adding a warning about dead conditions.