### PR TITLE
Require authorization for mod-supplied external commands

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,6 +1,7 @@
 name: main
 on:
   push:
+  pull_request:
 concurrency:
   group: ${{ github.ref }}-${{ github.workflow }}
   cancel-in-progress: true
@@ -97,6 +98,7 @@ jobs:
           opam switch
           (& opam env) -split '\r?\n' | ForEach-Object { Invoke-Expression $_ }
           make
+          make test-external-command-policy
           make windows_zip
       - name: upload windows artifact
         uses: actions/upload-artifact@v6

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -40,6 +40,7 @@ jobs:
           opam switch
           eval $(opam env)
           make
+          make test-external-command-policy
           make osx_zip
       - uses: actions/upload-artifact@v6
         with:
@@ -69,6 +70,7 @@ jobs:
           opam switch
           eval $(opam env)
           make
+          make test-external-command-policy
           make linux_zip
       - uses: actions/upload-artifact@v6
         with:

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@
 include Configuration
 
 # Just a target to be used by default
-.PHONY: weidu doc all
+.PHONY: weidu doc all test-external-command-policy
 all : weidu
 # "make weinstall" if you want weinstall
 
@@ -69,6 +69,9 @@ PROJECT_RESOURCES = weidu_resources
 
 .PHONY: weidu
 weidu: $(PROJECT_EXECUTABLE)
+
+test-external-command-policy: weidu
+	sh test/external-command-policy/run_tests.sh $(PROJECT_EXECUTABLE)
 
 $(PROJECT_EXECUTABLE) : $(PROJECT_MODULES:%=$(OBJDIR)/%.$(CMO)) \
                         $(PROJECT_CMODULES:%=$(OBJDIR)/%.$(OBJEXT))

--- a/README-WeiDU-Changes.txt
+++ b/README-WeiDU-Changes.txt
@@ -1,4 +1,8 @@
 Version 251:
+  * Mod-supplied external commands require explicit authorization.
+    Interactive runs ask before execution, while non-interactive runs
+    deny by default. Add --ask-external-commands,
+    --allow-external-commands, and --deny-external-commands.
   * CREATE called within CREATE works as expected.
   * CREATE sets SOURCE_* and DEST_* variables.
   * Auto-update does not fail if the filename of the newest WeiDU

--- a/README-WeiDU-Changes.txt
+++ b/README-WeiDU-Changes.txt
@@ -3,6 +3,12 @@ Version 251:
     Interactive runs ask before execution, while non-interactive runs
     deny by default. Add --ask-external-commands,
     --allow-external-commands, and --deny-external-commands.
+    Prompts identify the requesting TP2, component, and action and use
+    a fresh confirmation token. Interactive allow-all decisions apply
+    only to that TP2 component; the command-line allow policy remains
+    invocation-wide. A denial cannot be caught by ACTION_TRY or
+    overridden by --continue, and uninstall restoration still runs
+    before a denied hook is reported as an error.
   * CREATE called within CREATE works as expected.
   * CREATE sets SOURCE_* and DEST_* variables.
   * Auto-update does not fail if the filename of the newest WeiDU

--- a/doc/base.tex
+++ b/doc/base.tex
@@ -983,7 +983,8 @@ when processing \ttref{D} and \ttref{BAF} files. \\
 \tt{FILE.}\ttref{TP2} & Read {\tt FILE} and ask the user whether to install,
 reinstall or uninstall its \ttref{TP2} \ttref{Component}s. \\
 \DEFINE{--yes} & Answer all \ttref{TP2} questions with 'Yes' and do not
-prompt for a key to be pressed at the end of \ttref{TP2} processing. \\
+prompt for a key to be pressed at the end of \ttref{TP2} processing.
+This does not authorize external operating-system commands. \\
 \DEFINE{--uninstall}  	& Answer all \ttref{TP2} questions with 'Uninstall'
 and do not prompt for a key to be pressed at the end of \ttref{TP2}
 processing. \\
@@ -1010,6 +1011,16 @@ selection X. Can be combined with --force-install and friends, but
 only if the latter components are defined in ALWAYS_ASK.  \\
 \DEFINE{--skip-at-view} & AT_* ~VIEW this~ actions (and the extra chromosome versions like
 ~NOTEPAD this~) aren't processed, while still processing batch files and similia. \\
+\DEFINE{--ask-external-commands} & Ask before each external command unless
+the requesting \ttref{TP2} and component were approved at an earlier prompt.
+Running a command requires the fresh confirmation token displayed by the
+prompt. This is the default when standard input and output are terminals. \\
+\DEFINE{--allow-external-commands} & Allow all mod-supplied external
+commands for this WeiDU invocation without prompting. Authorized commands
+retain the user's operating-system permissions; use this only with trusted
+mods. \\
+\DEFINE{--deny-external-commands} & Deny all mod-supplied external commands.
+This is the default when standard input or output is not a terminal. \\
 \DEFINE{--safe-exit} & Save WeiDU.log every time a component installation is begun.
 This makes it impossible to uninstall components (don't ask), but allows the user to kill
 the weidu process (E.G. closing the DOS console via the X button) without leaving the game in an
@@ -1023,7 +1034,8 @@ present for all \ttref{TP2} components. \\
 only asking about components number X Y..., skipping the others
 (cumulative) \\
 \DEFINE{--continue}     & Continue \ttref{TP2} processing despite
-\ttref{TP2 Action} errors. \\
+\ttref{TP2 Action} errors. External-command authorization denials are
+security decisions and are never continued. \\
 \DEFINE{--args} \t{X}       & X will be stored in the tp2 variable \verb+%argv[n]%+, where
 n is 0 for the first argument, 1 for the second, etc.
 
@@ -2859,7 +2871,8 @@ global option to your \ttref{TP2} file. \\
        before installing any component. If more than one file name is provided,
        they are checked for existence in the order they're provided, and the first available
        one will be opened. If you wish to open multiple readme files, use multiple \t{README}
-       statements.
+       statements. Launching the system viewer is an external command and
+       requires authorization under the selected external-command policy.
   \\
   or & \DEFSYN{UNINSTALL_ORDER} String \Slist &
 		\emph{Do not use this without a real reason.}
@@ -2876,7 +2889,9 @@ global option to your \ttref{TP2} file. \\
 		If this is specified, then ALL operations must be specified
 		(if any isn't, a warning is printed). Please note that this means that
 		your mod might start printing warnings three years down the line if
-		a new uninstall action is coded.
+		a new uninstall action is coded. If processing an AT hook raises an
+		error or the hook is denied, WeiDU still attempts COPY, MOVE and
+		STRSET restoration before reporting the uninstall failure.
   \\
   or & \DEFINE{MODDER} String \Slist &
        Enable additional debug info. By default, these messages are verbose but do
@@ -3158,8 +3173,11 @@ MOVE ~sourceDirectory~ ~destinationDirectory~
 MOVE (~sourceDirectory~ ~^[A-M].*\.itm$~) ~destinationDirectory
 \end{verbatim}
 
-       Safety notes: when uninstalling, MOVE is restored first,
-       then all generic actions are restored, then \t{AT_*!UNINSTALL} is handled.
+       Safety notes: with the default \ttref{UNINSTALL_ORDER}, MOVE is restored
+       first, then all generic actions are restored, then
+       \t{AT_*!UNINSTALL} is handled. Regardless of a custom order, an AT
+       processing error or denial does not prevent the remaining restoration
+       categories from being attempted.
        As such, do your \ttref{AT_NOW}, then do your \ttref{COPY}, then do your \t{MOVE}s
        (exception: if you \t{MOVE} for biffing purposes, it is safe to call
        \ttref{MAKE_BIFF} after \t{MOVE}. \emph{Do not use the --make-biff command-line argument}).
@@ -3403,7 +3421,9 @@ P Q R 3
     \Oe \t{BEGIN} \ttref{TP2 Action} \Slist \t{END} \Oe \Ob \t{ANY}
     condition-\ttref{value} \t{BEGIN} \ttref{TP2 Action} \Slist \t{END}
     \Oe ... \t{DEFAULT} \ttref{TP2 Action} \Slist \t{END} &
-    If evaluating the action list results in an error, the error is matched, as per \ttref{ACTION_MATCH}.
+    If evaluating the action list results in an error, the error is matched,
+    as per \ttref{ACTION_MATCH}. External-command authorization denials are
+    not matchable errors and are re-raised immediately.
 
     \textbf{N.B.} \t{TRY} is generally \emph{not safe} to use because
     many errors are intended to be fatal and if the mod installation
@@ -3446,14 +3466,24 @@ P Q R 3
     file and run it from here.
     \end{itemize}
     External operating-system commands require explicit authorization.
-    With an interactive terminal, WeiDU displays the exact command and asks
-    whether to run it once, allow all external commands for the current WeiDU
-    run, or deny it. Without an interactive terminal, commands are denied by
-    default. The command-line options \t{--ask-external-commands},
-    \t{--allow-external-commands}, and \t{--deny-external-commands} select the
-    policy explicitly. \t{--yes} does not authorize external commands.
-    Denying a command aborts and rolls back the component rather than
-    continuing after an expected side effect did not occur.
+    With an interactive terminal, WeiDU displays the escaped requesting
+    \ttref{TP2} filename, component number, action type and exact command.
+    To distinguish the real prompt from mod output, running or approving a
+    command requires the fresh confirmation token shown in that prompt.
+    \t{Y token} runs the command once, while \t{A token} approves external
+    commands only for the same \ttref{TP2} filename and component. Without an
+    interactive terminal, commands are denied by default. The command-line
+    options \t{--ask-external-commands}, \t{--allow-external-commands}, and
+    \t{--deny-external-commands} select the policy explicitly; only
+    \t{--allow-external-commands} grants invocation-wide approval.
+    \t{--yes} does not authorize external commands.
+
+    Denial is a fatal security decision for the current component:
+    \ttref{ACTION_TRY}, uninstall \ttref{ACTION_IF}, and \t{--continue}
+    cannot consume it. During uninstall, WeiDU attempts COPY, MOVE and STRSET
+    restoration even if an AT hook is denied, updates \t{WeiDU.log} to match
+    completed restoration, and reports the uninstall as failed rather than
+    printing a success message.
 
     External commands run with the user's operating-system permissions and
     are not restricted to the game directory. Only use

--- a/doc/base.tex
+++ b/doc/base.tex
@@ -3445,6 +3445,21 @@ P Q R 3
     WeiDU doesn't handle, like extracting WAVs from an MP3, make a batch
     file and run it from here.
     \end{itemize}
+    External operating-system commands require explicit authorization.
+    With an interactive terminal, WeiDU displays the exact command and asks
+    whether to run it once, allow all external commands for the current WeiDU
+    run, or deny it. Without an interactive terminal, commands are denied by
+    default. The command-line options \t{--ask-external-commands},
+    \t{--allow-external-commands}, and \t{--deny-external-commands} select the
+    policy explicitly. \t{--yes} does not authorize external commands.
+    Denying a command aborts and rolls back the component rather than
+    continuing after an expected side effect did not occur.
+
+    External commands run with the user's operating-system permissions and
+    are not restricted to the game directory. Only use
+    \t{--allow-external-commands} with mods that you trust. This authorization
+    boundary is not an operating-system sandbox and does not restrict
+    WeiDU's built-in file operations.
     Slashes and backslashes will be converted appropriately for the
     underlying operating system. If \t{EXACT} is specified, \verb+/+
     and \verb+\+ will instead be preserved as they are. \t{EXACT}

--- a/src/main.ml
+++ b/src/main.ml
@@ -1536,10 +1536,10 @@ let main () =
     "--skip-at-view", Myarg.Set Tp.skip_at_view, "\tkills AT_* ~VIEW this~";
     "--ask-external-commands", Myarg.Unit (fun () ->
       set_external_command_policy External_command_ask),
-      "\task before running each mod-supplied external command";
+      "\task before mod-supplied external commands (prompt approval is TP2/component-scoped)";
     "--allow-external-commands", Myarg.Unit (fun () ->
       set_external_command_policy External_command_allow),
-      "\tallow mod-supplied external commands without prompting (unsafe)";
+      "\tallow mod-supplied external commands for this invocation without prompting (unsafe)";
     "--deny-external-commands", Myarg.Unit (fun () ->
       set_external_command_policy External_command_deny),
       "\tdeny all mod-supplied external commands";
@@ -2142,7 +2142,11 @@ let main () =
 
 (try
   Stats.time "stuff not covered elsewhere" main ();
-with e ->
+with
+| External_command_denied _ as e ->
+  exit_status := StatusInstallFailure ;
+  log_and_print "\nFATAL ERROR: %s\n" (printexc_to_string e)
+| e ->
   log_and_print "\nFATAL ERROR: %s\n" (printexc_to_string e) ) ;
 
 (match !Util.log_channel with
@@ -2151,7 +2155,13 @@ with e ->
 
 List.iter (fun c -> match c with
 | Command command ->
-    log_or_print "Executing: [%s]\n" command.command ;
+    let request = command.request in
+    log_or_print
+      "Executing external command for %S component %s (%s): [%s]\n"
+      request.external_command_tp2
+      (external_command_component_name request)
+      (external_command_action_name request.external_command_action)
+      command.command ;
     ignore (execute_authorized_external_command command)
 | Fn f ->
     Lazy.force f)

--- a/src/main.ml
+++ b/src/main.ml
@@ -1238,9 +1238,9 @@ let do_script process_script pause_at_end game =
           Tpwork.handle_tp game tp_file result
             ) (List.rev !toproc);
         List.iter (fun c -> match c with
-        | Command (s,e) ->
-            log_or_print "Executing: [%s]\n" s ;
-            ignore (exec_command s e)
+        | Command command ->
+            log_or_print "Executing: [%s]\n" command.command ;
+            ignore (execute_authorized_external_command command)
         | Fn f ->
             Lazy.force f
               )
@@ -1534,6 +1534,15 @@ let main () =
     "--quick-menu", Myarg.Int (fun d -> Tp.chosen_quick_menu := Some d), "\tX installs the quick menu selection X";
     "--process-script", Myarg.String (fun s -> process_script := s; Tp.skip_at_view := true; Tp.quick_log := true; test_output_tlk_p := true), "\tX process installation script X";
     "--skip-at-view", Myarg.Set Tp.skip_at_view, "\tkills AT_* ~VIEW this~";
+    "--ask-external-commands", Myarg.Unit (fun () ->
+      set_external_command_policy External_command_ask),
+      "\task before running each mod-supplied external command";
+    "--allow-external-commands", Myarg.Unit (fun () ->
+      set_external_command_policy External_command_allow),
+      "\tallow mod-supplied external commands without prompting (unsafe)";
+    "--deny-external-commands", Myarg.Unit (fun () ->
+      set_external_command_policy External_command_deny),
+      "\tdeny all mod-supplied external commands";
     "--quick-log", Myarg.Set Tp.quick_log, "\tDoesn't print the name of components in WeiDU.log (much faster)";
     "--safe-exit", Myarg.Set Tpstate.safe_exit, "\tPrints WeiDU.log after starting the installation of every component";
     "--version", Myarg.Set exit_now, "\tprint version number and exit";
@@ -2141,9 +2150,9 @@ with e ->
 | None -> () ) ;
 
 List.iter (fun c -> match c with
-| Command (s,e) ->
-    log_or_print "Executing: [%s]\n" s ;
-    ignore (exec_command s e)
+| Command command ->
+    log_or_print "Executing: [%s]\n" command.command ;
+    ignore (execute_authorized_external_command command)
 | Fn f ->
     Lazy.force f)
     !execute_at_exit ;

--- a/src/tpaction.ml
+++ b/src/tpaction.ml
@@ -2138,10 +2138,7 @@ let rec process_action_real our_lang game this_tp2_filename tp a =
             | "TP2" -> (enqueue_tp2_filename) str
             | _ ->
                 let str = if exact then str else Arch.handle_view_command str !skip_at_view in
-                if List.mem (Command (str,exact)) !execute_at_exit then
-                  ()
-                else
-                  execute_at_exit := (Command (str,exact)) :: !execute_at_exit
+                enqueue_external_command str exact
           end
 
       | TP_At_Now(retvar,str,exact) ->

--- a/src/tpaction.ml
+++ b/src/tpaction.ml
@@ -17,7 +17,8 @@ open Tpuninstall
 (*************************************************************************
  * process_action
  *************************************************************************)
-let rec process_action_real our_lang game this_tp2_filename tp a =
+let rec process_action_real
+    our_lang game this_tp2_filename component tp a =
 
   let get_next_col_number file =
     let (a,b) = split_resref file in
@@ -174,11 +175,54 @@ let rec process_action_real our_lang game this_tp2_filename tp a =
               caller filename v ; true
           end) true con_l in
 
-  let process_action = (process_action_real our_lang game this_tp2_filename) in
+  let process_action =
+    process_action_real our_lang game this_tp2_filename component in
   let process_patch2 = process_patch2_real process_action tp our_lang in
 
   let run_patch x = ignore (process_patch2 "" game "" x) in
   let pl_of_al x = [TP_PatchInnerAction x] in
+
+  let external_command_request action = {
+      external_command_tp2 = this_tp2_filename ;
+      external_command_component = Some component ;
+      external_command_action = action ;
+    } in
+
+  let process_external_at_exit action str exact =
+    let str = Var.get_string str in
+    let _, extension = split_resref (String.uppercase str) in
+    match extension with
+    | "TP2" -> enqueue_tp2_filename str
+    | _ ->
+        let str =
+          if exact then str
+          else Arch.handle_view_command str !skip_at_view in
+        enqueue_external_command
+          (external_command_request action) str exact
+  in
+
+  let process_external_at_now action retvar str exact =
+    let retvar = match retvar with
+    | None -> None
+    | Some str -> Some (Var.get_string (eval_pe_str str)) in
+    let str = Var.get_string str in
+    let _, extension = split_resref (String.uppercase str) in
+    match extension with
+    | "TP2" -> enqueue_tp2_filename str
+    | _ ->
+        let str =
+          if exact then str
+          else Arch.handle_view_command str !skip_at_view in
+        let request = external_command_request action in
+        match retvar with
+        | None -> ignore (exec_command request str exact)
+        | Some var ->
+            let retval = match exec_command request str exact with
+            | Unix.WEXITED i
+            | Unix.WSIGNALED i
+            | Unix.WSTOPPED i -> i in
+            Var.set_int var retval
+  in
 
   let str = action_to_str a in
   Stats.time str (fun () ->
@@ -600,7 +644,7 @@ let rec process_action_real our_lang game this_tp2_filename tp a =
       | TP_ClearCodes ->
           log_and_print "Clearing the macros.\n" ;
           clear_codes () ;
-          process_action_real our_lang game this_tp2_filename tp
+          process_action_real our_lang game this_tp2_filename component tp
             (TP_Include Tph.builtin_definitions);
 
       | TP_ClearInlined ->
@@ -612,7 +656,9 @@ let rec process_action_real our_lang game this_tp2_filename tp a =
           Bcs.clear_ids_map game ;
 
       | TP_ClearEverything ->
-          List.iter (process_action_real our_lang game this_tp2_filename tp)
+          List.iter
+            (process_action_real
+               our_lang game this_tp2_filename component tp)
             [ TP_ClearArrays; TP_ClearMemory; TP_ClearInlined;
               TP_ClearCodes; TP_Clear_Ids_Map ]
 
@@ -2126,41 +2172,18 @@ let rec process_action_real our_lang game this_tp2_filename tp a =
       end
 
       | TP_At_Interactive_Exit(str,exact) ->
-          if !interactive then process_action tp (TP_At_Exit(str,exact))
+          if !interactive then
+            process_external_at_exit External_at_interactive_exit str exact
       | TP_At_Interactive_Now(retvar,str,exact) ->
-          if !interactive then process_action tp (TP_At_Now(retvar,str,exact))
+          if !interactive then
+            process_external_at_now
+              External_at_interactive_now retvar str exact
 
       | TP_At_Exit(str,exact) ->
-          begin
-            let str = Var.get_string str in
-            let a,b = split_resref (String.uppercase str) in
-            match b with
-            | "TP2" -> (enqueue_tp2_filename) str
-            | _ ->
-                let str = if exact then str else Arch.handle_view_command str !skip_at_view in
-                enqueue_external_command str exact
-          end
+          process_external_at_exit External_at_exit str exact
 
       | TP_At_Now(retvar,str,exact) ->
-          begin
-            let retvar = match retvar with
-            | None -> None
-            | Some str -> Some (Var.get_string (eval_pe_str str)) in
-            let str = Var.get_string str in
-            let a,b = split_resref (String.uppercase str) in
-            match b with
-            | "TP2" -> (enqueue_tp2_filename) str
-            | _ ->
-                let str = if exact then str else Arch.handle_view_command str !skip_at_view in
-                (match retvar with
-                | None -> ignore (exec_command str exact)
-                | Some var ->
-                    let retval = match exec_command str exact with
-                    | Unix.WEXITED i
-                    | Unix.WSIGNALED i
-                    | Unix.WSTOPPED i -> i in
-                    Var.set_int var retval)
-          end
+          process_external_at_now External_at_now retvar str exact
 
       | TP_At_Interactive_Uninstall(_)
       | TP_At_Uninstall(_)
@@ -2487,6 +2510,9 @@ let rec process_action_real our_lang game this_tp2_filename tp a =
         clear_memory := true;
       end;
       with
+     | External_command_denied _ as e ->
+        exit_status := StatusInstallFailure ;
+        raise e
      | Abort msg -> raise (Abort msg)
      | e -> (* from: let rec process_action = try *)
       (if !continue_on_error then begin

--- a/src/tppatch.ml
+++ b/src/tppatch.ml
@@ -479,7 +479,9 @@ let rec process_patch2_real process_action tp our_lang patch_filename game buff 
         try
           List.fold_left (fun acc elt ->
             process_patch2 patch_filename game acc elt) buff pl
-        with e ->
+        with
+        | External_command_denied _ as e -> raise e
+        | e ->
           current_exception := e;
           let e = printexc_to_string e in
           Var.set_string "ERROR_MESSAGE" e;

--- a/src/tpuninstall.ml
+++ b/src/tpuninstall.ml
@@ -92,54 +92,66 @@ let record_tlk_path_info game filename =
 (************************************************************************
  * Uninstall a TP2 component
  ************************************************************************)
-let handle_at_uninstall tp2 m do_uninstall do_interactive_uninstall game =
+let handle_at_uninstall tp2 m component
+    do_uninstall do_interactive_uninstall game =
+  let external_command_request action = {
+      external_command_tp2 = tp2.tp_filename ;
+      external_command_component = Some component ;
+      external_command_action = action ;
+    } in
+  let execute_external_command action str exact =
+    let str = Var.get_string str in
+    match split (String.uppercase str) with
+    | _, "TP2" -> enqueue_tp2_filename str
+    | _, _ ->
+        let str =
+          if exact then str
+          else Arch.handle_view_command str !skip_at_view in
+        ignore
+          (exec_command (external_command_request action) str exact)
+  in
+  let enqueue_external_command_for action str exact =
+    let str = Var.get_string str in
+    match split (String.uppercase str) with
+    | _, "TP2" -> enqueue_tp2_filename str
+    | _, _ ->
+        let str =
+          if exact then str
+          else Arch.handle_view_command str !skip_at_view in
+        enqueue_external_command
+          (external_command_request action) str exact
+  in
   let rec handle_al al =
     List.iter (fun a ->
       match a with
       | TP_At_Interactive_Uninstall(str,exact) ->
-          if do_interactive_uninstall then begin
-            let str = Var.get_string str in
-            match (split (String.uppercase str)) with
-            | _,"TP2" -> (enqueue_tp2_filename) str
-            | _,_ -> let str = if exact then str else Arch.handle_view_command str !skip_at_view in
-              ignore(exec_command str exact)
-          end
+          if do_interactive_uninstall then
+            execute_external_command
+              External_at_interactive_uninstall str exact
       | TP_At_Uninstall(str,exact) ->
-          if do_uninstall then begin
-            let str = Var.get_string str in
-            match (split (String.uppercase str)) with
-            | _,"TP2" -> (enqueue_tp2_filename) str
-            | _,_ -> let str = if exact then str else Arch.handle_view_command str !skip_at_view in
-              ignore (exec_command str exact)
-          end
+          if do_uninstall then
+            execute_external_command External_at_uninstall str exact
       | TP_At_Interactive_Uninstall_Exit(str,exact) ->
-          if do_interactive_uninstall then begin
-            let str = Var.get_string str in
-            match (split (String.uppercase str)) with
-            | _,"TP2" -> (enqueue_tp2_filename) str
-            | _,_ -> let str = if exact then str else Arch.handle_view_command str !skip_at_view in
-              enqueue_external_command str exact
-          end
+          if do_interactive_uninstall then
+            enqueue_external_command_for
+              External_at_interactive_uninstall_exit str exact
       | TP_At_Uninstall_Exit(str,exact) ->
-          if do_uninstall then begin
-            let str = Var.get_string str in
-            match (split (String.uppercase str)) with
-            | _,"TP2" -> (enqueue_tp2_filename) str
-            | _,_ -> let str = if exact then str else Arch.handle_view_command str !skip_at_view in
-              enqueue_external_command str exact
-          end
+          if do_uninstall then
+            enqueue_external_command_for
+              External_at_uninstall_exit str exact
       | TP_If(p,al1,al2) ->
-          begin try
+          begin
             eval_pe_warn := false ;
-            let res = is_true (eval_pe "" game p) in
-            (* log_or_print "IF evaluates to %b\n" res ; *)
-            if res then begin
-              handle_al al1
-            end else begin
-              handle_al al2
-            end
-          with _ -> () ;
-            eval_pe_warn := true ;
+            (try
+              let res = is_true (eval_pe "" game p) in
+              (* log_or_print "IF evaluates to %b\n" res ; *)
+              if res then handle_al al1 else handle_al al2
+            with
+            | External_command_denied _ as e ->
+                eval_pe_warn := true ;
+                raise e
+            | _ -> ()) ;
+            eval_pe_warn := true
           end
       | TP_Biff _ ->
           (* re-load the chitin *)
@@ -261,6 +273,8 @@ let check_post_hooks game tp2 i interactive override_filename =
     game.Load.loaded_biffs <- Hashtbl.create 5 ;
   end
 
+exception Uninstall_completed_with_error of exn
+
 let uninstall_tp2_component game tp2 tp_file i interactive lang_name =
   let order = validate_uninstall_order tp2 in
   Stats.time "tp2 uninstall" (fun () ->
@@ -372,17 +386,37 @@ let uninstall_tp2_component game tp2 tp_file i interactive lang_name =
         Var.set_string "LANGUAGE" lang_name ;
         ignore (set_tp2_vars tp2) ;
         Var.set_int32 "COMPONENT_NUMBER" (Int32.of_int i) ;
-        handle_at_uninstall tp2 m true interactive game ;
+        handle_at_uninstall tp2 m i true interactive game ;
+      in
+      let first_error = ref None in
+      let security_denial = ref None in
+      let restoration_failed = ref false in
+      let run_uninstall_action action f =
+        try f ()
+        with e ->
+          (match !first_error with
+          | None -> first_error := Some e
+          | Some _ -> ()) ;
+          (match e, !security_denial with
+          | (External_command_denied _ as denial), None ->
+              security_denial := Some denial
+          | _ -> ()) ;
+          if action <> "AT" then restoration_failed := true ;
+          log_and_print
+            "Error during %s uninstallation for [%s] component %d:\n%s\n"
+            action tp_file i (printexc_to_string e)
       in
       Queue.iter (fun action ->
         match action with
-        | "COPY" -> uninstall_copy();
-        | "MOVE" -> uninstall_move();
-        | "AT"   -> uninstall_at();
-        | "STRSET" -> uninstall_strset();
-        | _ -> failwith ("Unknown action during uninstall: " ^ action);
+        | "COPY" -> run_uninstall_action action uninstall_copy
+        | "MOVE" -> run_uninstall_action action uninstall_move
+        | "AT" -> run_uninstall_action action uninstall_at
+        | "STRSET" -> run_uninstall_action action uninstall_strset
+        | _ ->
+            run_uninstall_action action (fun () ->
+              failwith ("Unknown action during uninstall: " ^ action))
                  ) order;
-      if (interactive) then begin
+      if not !restoration_failed && interactive then begin
         my_unlink (Printf.sprintf "%s/READLN.%d" d i);
         my_unlink (Printf.sprintf "%s/READLN.%d.TEXT" d i);
         my_unlink (Printf.sprintf "%s/ARGS.%d" d i);
@@ -392,16 +426,34 @@ let uninstall_tp2_component game tp2 tp_file i interactive lang_name =
         if (Array.length (Case_ins.sys_readdir tp2.backup) = 0) then
           my_rmdir tp2.backup
       end;
-    with e ->
-      log_and_print "Error Uninstalling [%s] component %d:\n%s\n"
-        tp_file i (printexc_to_string e);
-      (try assert false with Assert_failure(file,line,col) -> set_errors file line)
+      match !first_error with
+      | None -> ()
+      | Some e when not !restoration_failed ->
+          raise (Uninstall_completed_with_error e)
+      | Some e ->
+          (match !security_denial with
+          | None -> raise e
+          | Some denial -> raise denial)
+    with
+    | Uninstall_completed_with_error e as outcome ->
+        log_and_print "Error Uninstalling [%s] component %d:\n%s\n"
+          tp_file i (printexc_to_string e);
+        (try assert false with
+          Assert_failure(file,line,col) -> set_errors file line);
+        raise outcome
+    | e ->
+        log_and_print "Error Uninstalling [%s] component %d:\n%s\n"
+          tp_file i (printexc_to_string e);
+        (try assert false with
+          Assert_failure(file,line,col) -> set_errors file line);
+        raise e
                              ) ()
 
 
 let temp_to_perm_uninstalled tp2 i handle_tp2_filename game =
   let marker = spell_ids_marker tp2 i in
   my_unlink marker;
+  let hook_error = ref None in
   let rec is_installed lst = match lst with
   | [] -> []
   | (a,b,c,sopt,d) :: tl when log_match a tp2
@@ -421,9 +473,11 @@ let temp_to_perm_uninstalled tp2 i handle_tp2_filename game =
           log_only "Running AT_INTERACTIVE_EXITs in ~%s~ %d %d %s\n"
             (String.uppercase a) b c
             (str_of_str_opt sopt) ;
-          handle_at_uninstall tp2 m
-            false (* "AT_UNINSTALL" was already done! *)
-            true (* but the user just asked for this to be explicit *) game ;
+          (try
+            handle_at_uninstall tp2 m i
+              false (* "AT_UNINSTALL" was already done! *)
+              true (* but the user just asked for this to be explicit *) game
+          with e -> hook_error := Some e) ;
           begin
             let d = tp2.backup ^ "/" ^ (string_of_int i) in
             my_unlink (Printf.sprintf "%s/READLN.%d" d i);
@@ -437,7 +491,11 @@ let temp_to_perm_uninstalled tp2 i handle_tp2_filename game =
           end;
           (a,b,c,sopt,Permanently_Uninstalled) :: tl
   | hd :: tl -> hd :: (is_installed tl)
-  in the_log := is_installed !the_log
+  in
+  the_log := is_installed !the_log ;
+  match !hook_error with
+  | None -> ()
+  | Some e -> raise e
 
 (************************************************************************
  * Do everything necessary to uninstall the given tp2 component. This
@@ -456,6 +514,14 @@ let uninstall game handle_tp2_filename tp2 i interactive =
   log_or_print "uninstall: %s %d\n" tp2 i ;
   Var.set_int32 "COMPONENT_NUMBER" (Int32.of_int i);
   let worked = ref true in
+  let security_denial = ref None in
+  let remember_security_denial = function
+  | External_command_denied _ as e ->
+      (match !security_denial with
+      | None -> security_denial := Some e
+      | Some _ -> ())
+  | _ -> ()
+  in
   if not (already_installed tp2 i) then begin
     log_and_print "Internal Error: trying to uninstall non-installed mod component [%s] %d\n" tp2 i ;(try assert false with Assert_failure(file,line,col) -> set_errors file line);
     false
@@ -483,7 +549,16 @@ let uninstall game handle_tp2_filename tp2 i interactive =
                   with _ -> "" ) in
                 uninstall_tp2_component game (handle_tp2_filename best) a c interactive lang_name;
                 (a,b,c,sopt,Permanently_Uninstalled) :: tl
-              with _ ->
+              with
+              | Uninstall_completed_with_error e ->
+                remember_security_denial e ;
+                worked := false ;
+                (a,b,c,sopt,Permanently_Uninstalled) :: tl
+              | External_command_denied _ as e ->
+                remember_security_denial e ;
+                worked := false ;
+                lst
+              | _ ->
                 log_and_print "ERROR: This Mod is too old (or too new) to uninstall that component for you.\nUpgrade to the newest versions of this mod and that one and try again.\n" ;(try assert false with Assert_failure(file,line,col) -> set_errors file line);
                 worked := false ;
                 lst
@@ -510,7 +585,16 @@ let uninstall game handle_tp2_filename tp2 i interactive =
                   with _ -> "" ) in
                 uninstall_tp2_component game (handle_tp2_filename best) a c false  lang_name;
                 (a,b,c,sopt,Temporarily_Uninstalled) :: (prepare tl)
-              with e ->
+              with
+              | Uninstall_completed_with_error e ->
+                remember_security_denial e ;
+                worked := false ;
+                (a,b,c,sopt,Temporarily_Uninstalled) :: (prepare tl)
+              | External_command_denied _ as e ->
+                remember_security_denial e ;
+                worked := false ;
+                lst
+              | e ->
                 log_and_print "ERROR: This Mod is too old (or too new) to uninstall that component for you.\nUpgrade to the newest versions of this mod and that one and try again.\n[%s]\n"
                   (printexc_to_string e);(try assert false with Assert_failure(file,line,col) -> set_errors file line);
                 worked := false ;
@@ -520,5 +604,7 @@ let uninstall game handle_tp2_filename tp2 i interactive =
     in
     let new_log = List.rev (prepare (List.rev !the_log)) in
     the_log := new_log ;
-    !worked
+    match !security_denial with
+    | None -> !worked
+    | Some e -> raise e
   end

--- a/src/tpuninstall.ml
+++ b/src/tpuninstall.ml
@@ -118,10 +118,7 @@ let handle_at_uninstall tp2 m do_uninstall do_interactive_uninstall game =
             match (split (String.uppercase str)) with
             | _,"TP2" -> (enqueue_tp2_filename) str
             | _,_ -> let str = if exact then str else Arch.handle_view_command str !skip_at_view in
-              if List.mem (Command(str,exact)) !execute_at_exit then
-                ()
-              else
-                execute_at_exit := (Command(str,exact)) :: !execute_at_exit
+              enqueue_external_command str exact
           end
       | TP_At_Uninstall_Exit(str,exact) ->
           if do_uninstall then begin
@@ -129,10 +126,7 @@ let handle_at_uninstall tp2 m do_uninstall do_interactive_uninstall game =
             match (split (String.uppercase str)) with
             | _,"TP2" -> (enqueue_tp2_filename) str
             | _,_ -> let str = if exact then str else Arch.handle_view_command str !skip_at_view in
-              if List.mem (Command(str,exact)) !execute_at_exit then
-                ()
-              else
-                execute_at_exit := (Command(str,exact)) :: !execute_at_exit
+              enqueue_external_command str exact
           end
       | TP_If(p,al1,al2) ->
           begin try

--- a/src/tpwork.ml
+++ b/src/tpwork.ml
@@ -138,7 +138,7 @@ let do_readme tp this_tp2_filename =
                   answer := String.uppercase (read_line())
                 done;
                 if !answer = "Y" then
-                  ignore (Unix.system str);
+                  ignore (exec_command str false);
               end
               else walk tail
           | [] -> log_and_print

--- a/src/tpwork.ml
+++ b/src/tpwork.ml
@@ -137,8 +137,14 @@ let do_readme tp this_tp2_filename =
                   log_and_print "\n%s\n" (get_trans (-1034));
                   answer := String.uppercase (read_line())
                 done;
-                if !answer = "Y" then
-                  ignore (exec_command str false);
+                if !answer = "Y" then begin
+                  let request = {
+                      external_command_tp2 = this_tp2_filename ;
+                      external_command_component = None ;
+                      external_command_action = External_readme ;
+                    } in
+                  ignore (exec_command request str false)
+                end;
               end
               else walk tail
           | [] -> log_and_print
@@ -637,7 +643,15 @@ let rollback_component game tp this_tp2_filename strset_backup_filename
       let l = List.nth tp.languages !our_lang_index in
       l.lang_dir_name ;
     with _ -> "" ) in
-  uninstall_tp2_component game tp this_tp2_filename i !interactive lang_name;
+  (try
+    uninstall_tp2_component
+      game tp this_tp2_filename i !interactive lang_name
+  with
+  | Uninstall_completed_with_error e ->
+      log_and_print
+        "Rollback restored WeiDU-managed state, but an uninstall hook \
+         failed:\n%s\n"
+        (printexc_to_string e));
   print_log () ;
   if List.find_all (fun x -> x = TPM_NotInLog) m.mod_flags = [] && !safe_exit then begin
     let old_tp_quick_log = !Tp.quick_log in
@@ -834,7 +848,7 @@ let rec handle_tp game this_tp2_filename tp =
               (Int32.of_int (if !interactive then 1 else 0)) ;
             let old_silent = !be_silent in
             be_silent := true;
-            process_action_real our_lang game this_tp2_filename tp
+            process_action_real our_lang game this_tp2_filename i tp
               (TP_Include Tph.builtin_definitions);
             be_silent := old_silent;
 
@@ -852,7 +866,11 @@ let rec handle_tp game this_tp2_filename tp =
             end ;
 
             List.iter (fun flag -> match flag with
-            | Always(al) -> List.iter (process_action_real our_lang game this_tp2_filename tp) al
+            | Always(al) ->
+                List.iter
+                  (process_action_real
+                     our_lang game this_tp2_filename i tp)
+                  al
             | TP_No_If_Eval () -> has_if_eval_bug := false ;
             | Define_Action_Macro(str,decl,al) ->
                 Hashtbl.replace macros (str,false) (decl, [TP_PatchInnerAction al])
@@ -869,7 +887,10 @@ let rec handle_tp game this_tp2_filename tp =
                 log_and_print "WARNING: Unable to read readln references from [%s]: %s\n"
                   args_backup_filename (printexc_to_string e)
             end ;
-            List.iter (process_action_real our_lang game this_tp2_filename tp) m.mod_parts ;
+            List.iter
+              (process_action_real
+                 our_lang game this_tp2_filename i tp)
+              m.mod_parts ;
             if !interactive then begin
               Mymarshal.write_readln readln_backup_filename (List.rev !readln_strings);
             end ;

--- a/src/util.ml
+++ b/src/util.ml
@@ -616,8 +616,91 @@ let create_filter = function () ->
     res
   in f
 
-let exec_command cmd exact =
-  let cmd = if exact then cmd else Arch.slash_to_backslash cmd in
+type external_command_policy =
+| External_command_ask
+| External_command_allow
+| External_command_deny
+
+let external_command_policy =
+  ref
+    (try
+      if Unix.isatty Unix.stdin && Unix.isatty Unix.stdout then
+        External_command_ask
+      else
+        External_command_deny
+    with _ -> External_command_deny)
+
+let set_external_command_policy policy =
+  external_command_policy := policy
+
+let security_log_and_print fmt =
+  let k result = begin
+    output_string stdout result ;
+    flush stdout ;
+    (match !log_channel with
+    | None -> ()
+    | Some(o) -> output_string o result ; flush o)
+  end in
+  Printf.kprintf k fmt
+
+let rec prompt_for_external_command cmd =
+  security_log_and_print
+    "\nSECURITY: A mod requests permission to run an external command.\n\
+     Command: %S\n\
+     The command runs with your account's permissions and is not restricted \
+     to the game directory.\n\
+     Run it [Y]es once, allow [A]ll external commands for this WeiDU run, \
+     or [N]o? "
+    cmd ;
+  let answer =
+    try String.uppercase_ascii (String.trim (read_line ()))
+    with _ -> "N" in
+  match answer with
+  | "Y"
+  | "YES" -> true
+  | "A"
+  | "ALL" ->
+      external_command_policy := External_command_allow ;
+      true
+  | "N"
+  | "NO"
+  | "" -> false
+  | _ ->
+      security_log_and_print
+        "Please answer Y (once), A (all for this run), or N (deny).\n" ;
+      prompt_for_external_command cmd
+
+let prepare_external_command cmd exact =
+  if exact then cmd else Arch.slash_to_backslash cmd
+
+type authorized_external_command = {
+    command : string ;
+  }
+
+let authorize_prepared_external_command cmd =
+  if cmd = "" then
+    ()
+  else
+    let authorized =
+      match !external_command_policy with
+      | External_command_allow -> true
+      | External_command_deny -> false
+      | External_command_ask -> prompt_for_external_command cmd in
+    if authorized then
+      log_only "External command authorized: %S\n" cmd
+    else begin
+      security_log_and_print
+        "\nExternal command denied by security policy: %S\n" cmd ;
+      failwith "External command denied by security policy"
+    end
+
+let authorize_external_command command exact =
+  let command = prepare_external_command command exact in
+  authorize_prepared_external_command command ;
+  { command }
+
+let execute_authorized_external_command authorized =
+  let cmd = authorized.command in
   let ret = if !log_extern then
     begin
       (* copy stdout + stderr to logfile *)
@@ -642,11 +725,24 @@ let exec_command cmd exact =
     end else Unix.system cmd
   in ret
 
+let exec_command command exact =
+  execute_authorized_external_command
+    (authorize_external_command command exact)
+
 type execute_at_exit_type =
-| Command of string * bool
+| Command of authorized_external_command
 | Fn of (unit) Lazy.t
 
 let execute_at_exit = ref ([] : (execute_at_exit_type) list)
+
+let enqueue_external_command command exact =
+  let candidate = { command = prepare_external_command command exact } in
+  if List.mem (Command candidate) !execute_at_exit then
+    ()
+  else begin
+    authorize_prepared_external_command candidate.command ;
+    execute_at_exit := (Command candidate) :: !execute_at_exit
+  end
 
 (* for some stupid reason these cannot be in the parser or the lexer *)
 

--- a/src/util.ml
+++ b/src/util.ml
@@ -621,6 +621,25 @@ type external_command_policy =
 | External_command_allow
 | External_command_deny
 
+type external_command_action =
+| External_at_now
+| External_at_interactive_now
+| External_at_exit
+| External_at_interactive_exit
+| External_at_uninstall
+| External_at_interactive_uninstall
+| External_at_uninstall_exit
+| External_at_interactive_uninstall_exit
+| External_readme
+
+type external_command_request = {
+    external_command_tp2 : string ;
+    external_command_component : int option ;
+    external_command_action : external_command_action ;
+  }
+
+exception External_command_denied of external_command_request
+
 let external_command_policy =
   ref
     (try
@@ -630,8 +649,12 @@ let external_command_policy =
         External_command_deny
     with _ -> External_command_deny)
 
+let approved_external_command_scopes =
+  ref ([] : (string * int option) list)
+
 let set_external_command_policy policy =
-  external_command_policy := policy
+  external_command_policy := policy ;
+  approved_external_command_scopes := []
 
 let security_log_and_print fmt =
   let k result = begin
@@ -643,61 +666,165 @@ let security_log_and_print fmt =
   end in
   Printf.kprintf k fmt
 
-let rec prompt_for_external_command cmd =
-  security_log_and_print
-    "\nSECURITY: A mod requests permission to run an external command.\n\
-     Command: %S\n\
-     The command runs with your account's permissions and is not restricted \
-     to the game directory.\n\
-     Run it [Y]es once, allow [A]ll external commands for this WeiDU run, \
-     or [N]o? "
-    cmd ;
-  let answer =
-    try String.uppercase_ascii (String.trim (read_line ()))
-    with _ -> "N" in
-  match answer with
-  | "Y"
-  | "YES" -> true
-  | "A"
-  | "ALL" ->
-      external_command_policy := External_command_allow ;
-      true
-  | "N"
-  | "NO"
-  | "" -> false
-  | _ ->
+let external_command_action_name = function
+| External_at_now -> "AT_NOW"
+| External_at_interactive_now -> "AT_INTERACTIVE_NOW"
+| External_at_exit -> "AT_EXIT"
+| External_at_interactive_exit -> "AT_INTERACTIVE_EXIT"
+| External_at_uninstall -> "AT_UNINSTALL"
+| External_at_interactive_uninstall -> "AT_INTERACTIVE_UNINSTALL"
+| External_at_uninstall_exit -> "AT_UNINSTALL_EXIT"
+| External_at_interactive_uninstall_exit ->
+    "AT_INTERACTIVE_UNINSTALL_EXIT"
+| External_readme -> "README"
+
+let external_command_component_name request =
+  match request.external_command_component with
+  | Some component -> string_of_int component
+  | None -> "not applicable"
+
+let external_command_scope request =
+  (request.external_command_tp2, request.external_command_component)
+
+let external_command_scope_is_approved request =
+  List.mem
+    (external_command_scope request)
+    !approved_external_command_scopes
+
+let approve_external_command_scope request =
+  let scope = external_command_scope request in
+  if not (List.mem scope !approved_external_command_scopes) then
+    approved_external_command_scopes :=
+      scope :: !approved_external_command_scopes
+
+let external_command_confirmation_state =
+  lazy (Random.State.make_self_init ())
+
+let external_command_confirmation_alphabet =
+  "ABCDEFGHJKLMNPQRSTUVWXYZ23456789"
+
+let external_command_confirmation_length = 8
+
+let make_external_command_confirmation_token () =
+  let state = Lazy.force external_command_confirmation_state in
+  let alphabet_length =
+    String.length external_command_confirmation_alphabet in
+  let token = Bytes.create external_command_confirmation_length in
+  for i = 0 to external_command_confirmation_length - 1 do
+    Bytes.set token i
+      (String.get external_command_confirmation_alphabet
+         (Random.State.int state alphabet_length))
+  done ;
+  Bytes.to_string token
+
+type external_command_prompt_decision =
+| External_command_allow_once
+| External_command_allow_scope
+| External_command_reject
+
+let prompt_for_external_command request cmd =
+  let token =
+    try Some (make_external_command_confirmation_token ())
+    with _ -> None in
+  match token with
+  | None ->
       security_log_and_print
-        "Please answer Y (once), A (all for this run), or N (deny).\n" ;
-      prompt_for_external_command cmd
+        "\nSECURITY: WeiDU could not create a fresh confirmation token; \
+         the external command will be denied.\n" ;
+      External_command_reject
+  | Some token ->
+      security_log_and_print
+        "\n=== WEIDU EXTERNAL COMMAND AUTHORIZATION ===\n\
+         Requesting TP2: %S\n\
+         Component: %s\n\
+         Action: %s\n\
+         Command: %S\n\
+         The command runs with your account's permissions and is not restricted \
+         to the game directory.\n\
+         Confirmation token: %s\n\
+         Type \"Y %s\" to run it once, \"A %s\" to allow external commands \
+         from this TP2 component, or \"N\" to deny: "
+        request.external_command_tp2
+        (external_command_component_name request)
+        (external_command_action_name request.external_command_action)
+        cmd token token token ;
+      let rec read_decision () =
+        let answer =
+          try String.uppercase_ascii (String.trim (read_line ()))
+          with _ -> "N" in
+        let words =
+          if answer = "" then []
+          else Str.split (Str.regexp "[ \t]+") answer in
+        match words with
+        | ["Y"; supplied]
+        | ["YES"; supplied] when supplied = token ->
+            External_command_allow_once
+        | ["A"; supplied]
+        | ["ALL"; supplied] when supplied = token ->
+            External_command_allow_scope
+        | []
+        | ["N"]
+        | ["NO"] ->
+            External_command_reject
+        | _ ->
+            security_log_and_print
+              "The confirmation did not match. Type \"Y %s\", \"A %s\", or \
+               \"N\": "
+              token token ;
+            read_decision ()
+      in
+      read_decision ()
 
 let prepare_external_command cmd exact =
   if exact then cmd else Arch.slash_to_backslash cmd
 
 type authorized_external_command = {
     command : string ;
+    request : external_command_request ;
   }
 
-let authorize_prepared_external_command cmd =
+let authorize_prepared_external_command request cmd =
   if cmd = "" then
     ()
   else
-    let authorized =
+    let decision =
       match !external_command_policy with
-      | External_command_allow -> true
-      | External_command_deny -> false
-      | External_command_ask -> prompt_for_external_command cmd in
-    if authorized then
-      log_only "External command authorized: %S\n" cmd
-    else begin
-      security_log_and_print
-        "\nExternal command denied by security policy: %S\n" cmd ;
-      failwith "External command denied by security policy"
-    end
+      | External_command_allow -> External_command_allow_once
+      | External_command_deny -> External_command_reject
+      | External_command_ask
+          when external_command_scope_is_approved request ->
+          External_command_allow_once
+      | External_command_ask ->
+          prompt_for_external_command request cmd in
+    match decision with
+    | External_command_allow_once ->
+        log_only
+          "External command authorized for %S component %s (%s): %S\n"
+          request.external_command_tp2
+          (external_command_component_name request)
+          (external_command_action_name request.external_command_action)
+          cmd
+    | External_command_allow_scope ->
+        approve_external_command_scope request ;
+        log_only
+          "External command scope authorized for %S component %s: %S\n"
+          request.external_command_tp2
+          (external_command_component_name request)
+          cmd
+    | External_command_reject ->
+        security_log_and_print
+          "\nExternal command denied by security policy for %S component %s \
+           (%s): %S\n"
+          request.external_command_tp2
+          (external_command_component_name request)
+          (external_command_action_name request.external_command_action)
+          cmd ;
+        raise (External_command_denied request)
 
-let authorize_external_command command exact =
+let authorize_external_command request command exact =
   let command = prepare_external_command command exact in
-  authorize_prepared_external_command command ;
-  { command }
+  authorize_prepared_external_command request command ;
+  { command ; request }
 
 let execute_authorized_external_command authorized =
   let cmd = authorized.command in
@@ -725,9 +852,9 @@ let execute_authorized_external_command authorized =
     end else Unix.system cmd
   in ret
 
-let exec_command command exact =
+let exec_command request command exact =
   execute_authorized_external_command
-    (authorize_external_command command exact)
+    (authorize_external_command request command exact)
 
 type execute_at_exit_type =
 | Command of authorized_external_command
@@ -735,12 +862,17 @@ type execute_at_exit_type =
 
 let execute_at_exit = ref ([] : (execute_at_exit_type) list)
 
-let enqueue_external_command command exact =
-  let candidate = { command = prepare_external_command command exact } in
-  if List.mem (Command candidate) !execute_at_exit then
+let enqueue_external_command request command exact =
+  let candidate = {
+      command = prepare_external_command command exact ;
+      request ;
+    } in
+  if List.exists (function
+    | Command queued -> queued.command = candidate.command
+    | Fn _ -> false) !execute_at_exit then
     ()
   else begin
-    authorize_prepared_external_command candidate.command ;
+    authorize_prepared_external_command request candidate.command ;
     execute_at_exit := (Command candidate) :: !execute_at_exit
   end
 

--- a/test/external-command-policy/action-try.tp2
+++ b/test/external-command-policy/action-try.tp2
@@ -1,0 +1,13 @@
+BACKUP ~backup~
+AUTHOR ~WeiDU regression tests~
+
+BEGIN ~External command policy: ACTION_TRY~
+
+ACTION_TRY
+  AT_NOW ~echo ran > denied-command-ran~ EXACT
+WITH
+  DEFAULT
+    COPY ~source.txt~ ~action-try-caught~
+END
+
+COPY ~source.txt~ ~continued-after-action-try~

--- a/test/external-command-policy/at-exit.tp2
+++ b/test/external-command-policy/at-exit.tp2
@@ -3,4 +3,4 @@ AUTHOR ~WeiDU regression tests~
 
 BEGIN ~External command policy: AT_EXIT~
 
-AT_EXIT ~: > command-ran~ EXACT
+AT_EXIT ~echo ran > command-ran~ EXACT

--- a/test/external-command-policy/at-exit.tp2
+++ b/test/external-command-policy/at-exit.tp2
@@ -1,0 +1,6 @@
+BACKUP ~backup~
+AUTHOR ~WeiDU regression tests~
+
+BEGIN ~External command policy: AT_EXIT~
+
+AT_EXIT ~: > command-ran~ EXACT

--- a/test/external-command-policy/at-now-twice.tp2
+++ b/test/external-command-policy/at-now-twice.tp2
@@ -1,0 +1,7 @@
+BACKUP ~backup~
+AUTHOR ~WeiDU regression tests~
+
+BEGIN ~External command policy: allow for run~
+
+AT_NOW ~: > first-command-ran~ EXACT
+AT_NOW ~: > second-command-ran~ EXACT

--- a/test/external-command-policy/at-now-twice.tp2
+++ b/test/external-command-policy/at-now-twice.tp2
@@ -3,5 +3,5 @@ AUTHOR ~WeiDU regression tests~
 
 BEGIN ~External command policy: allow for run~
 
-AT_NOW ~: > first-command-ran~ EXACT
-AT_NOW ~: > second-command-ran~ EXACT
+AT_NOW ~echo ran > first-command-ran~ EXACT
+AT_NOW ~echo ran > second-command-ran~ EXACT

--- a/test/external-command-policy/at-now.tp2
+++ b/test/external-command-policy/at-now.tp2
@@ -3,4 +3,4 @@ AUTHOR ~WeiDU regression tests~
 
 BEGIN ~External command policy: AT_NOW~
 
-AT_NOW ~: > command-ran~ EXACT
+AT_NOW ~echo ran > command-ran~ EXACT

--- a/test/external-command-policy/at-now.tp2
+++ b/test/external-command-policy/at-now.tp2
@@ -1,0 +1,6 @@
+BACKUP ~backup~
+AUTHOR ~WeiDU regression tests~
+
+BEGIN ~External command policy: AT_NOW~
+
+AT_NOW ~: > command-ran~ EXACT

--- a/test/external-command-policy/continue.tp2
+++ b/test/external-command-policy/continue.tp2
@@ -1,0 +1,7 @@
+BACKUP ~backup~
+AUTHOR ~WeiDU regression tests~
+
+BEGIN ~External command policy: --continue~
+
+AT_NOW ~echo ran > denied-command-ran~ EXACT
+COPY ~source.txt~ ~continued-after-denial~

--- a/test/external-command-policy/non-exact.tp2
+++ b/test/external-command-policy/non-exact.tp2
@@ -1,0 +1,6 @@
+BACKUP ~backup~
+AUTHOR ~WeiDU regression tests~
+
+BEGIN ~External command policy: non-EXACT~
+
+AT_NOW ~echo path/segment > command-ran~

--- a/test/external-command-policy/readme.tp2
+++ b/test/external-command-policy/readme.tp2
@@ -1,0 +1,6 @@
+BACKUP ~backup~
+AUTHOR ~WeiDU regression tests~
+
+README ~readme.txt~
+
+BEGIN ~External command policy: README~

--- a/test/external-command-policy/run_tests.sh
+++ b/test/external-command-policy/run_tests.sh
@@ -1,0 +1,137 @@
+#!/bin/sh
+
+set -eu
+
+weidu_bin=${1:-./weidu}
+case "$weidu_bin" in
+  /*) ;;
+  *) weidu_bin="$(pwd)/$weidu_bin" ;;
+esac
+
+script_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+test_root=$(mktemp -d "${TMPDIR:-/tmp}/weidu-command-policy.XXXXXX")
+
+cleanup()
+{
+  if [ -n "${test_root:-}" ] && [ -d "$test_root" ]; then
+    rm -rf -- "$test_root"
+  fi
+}
+trap cleanup EXIT HUP INT TERM
+
+fail()
+{
+  echo "external-command-policy test failed: $*" >&2
+  exit 1
+}
+
+fail_case()
+{
+  failed_case_dir=$1
+  shift
+  if [ -f "$failed_case_dir/output.log" ]; then
+    echo "----- captured WeiDU output -----" >&2
+    sed 's/^/| /' "$failed_case_dir/output.log" >&2
+    echo "----- end captured output -----" >&2
+  fi
+  fail "$@"
+}
+
+prepare_case()
+{
+  case_name=$1
+  fixture=$2
+  case_dir="$test_root/$case_name"
+  mkdir "$case_dir"
+  cp "$script_dir/$fixture" "$case_dir/test.tp2"
+}
+
+assert_denied()
+{
+  case_name=$1
+  shift
+  case_dir="$test_root/$case_name"
+  if (
+    cd "$case_dir"
+    "$weidu_bin" --nogame --no-exit-pause --force-install 0 "$@" \
+      test.tp2 </dev/null >output.log 2>&1
+  ); then
+    fail_case "$case_dir" "$case_name unexpectedly succeeded"
+  fi
+  [ ! -e "$case_dir/command-ran" ] ||
+    fail_case "$case_dir" "$case_name executed the denied command"
+  grep -F "External command denied by security policy" \
+    "$case_dir/output.log" >/dev/null ||
+    fail_case "$case_dir" "$case_name did not report the denial"
+}
+
+prepare_case default-deny at-now.tp2
+assert_denied default-deny
+
+prepare_case explicit-deny at-now.tp2
+assert_denied explicit-deny --deny-external-commands
+
+prepare_case yes-does-not-authorize at-now.tp2
+assert_denied yes-does-not-authorize --yes
+
+prepare_case prompt-deny at-now.tp2
+case_dir="$test_root/prompt-deny"
+if (
+  cd "$case_dir"
+  printf 'N\n' |
+    "$weidu_bin" --nogame --no-exit-pause --force-install 0 \
+      --ask-external-commands test.tp2 >output.log 2>&1
+); then
+  fail_case "$case_dir" "prompt-deny unexpectedly succeeded"
+fi
+[ ! -e "$case_dir/command-ran" ] ||
+  fail_case "$case_dir" "prompt-deny executed the denied command"
+
+prepare_case prompt-allow-once at-now.tp2
+case_dir="$test_root/prompt-allow-once"
+(
+  cd "$case_dir"
+  printf 'Y\n' |
+    "$weidu_bin" --nogame --no-exit-pause --force-install 0 \
+      --ask-external-commands test.tp2 >output.log 2>&1
+)
+[ -e "$case_dir/command-ran" ] ||
+  fail_case "$case_dir" "prompt-allow-once did not execute the authorized command"
+
+prepare_case explicit-allow at-now.tp2
+case_dir="$test_root/explicit-allow"
+(
+  cd "$case_dir"
+  "$weidu_bin" --nogame --no-exit-pause --force-install 0 \
+    --allow-external-commands test.tp2 </dev/null >output.log 2>&1
+)
+[ -e "$case_dir/command-ran" ] ||
+  fail_case "$case_dir" "explicit-allow did not execute the authorized command"
+
+prepare_case prompt-allow-all at-now-twice.tp2
+case_dir="$test_root/prompt-allow-all"
+(
+  cd "$case_dir"
+  printf 'A\n' |
+    "$weidu_bin" --nogame --no-exit-pause --force-install 0 \
+      --ask-external-commands test.tp2 >output.log 2>&1
+)
+[ -e "$case_dir/first-command-ran" ] ||
+  fail_case "$case_dir" "prompt-allow-all did not execute the first command"
+[ -e "$case_dir/second-command-ran" ] ||
+  fail_case "$case_dir" "prompt-allow-all did not authorize the rest of the run"
+
+prepare_case deferred-deny at-exit.tp2
+assert_denied deferred-deny
+
+prepare_case deferred-allow at-exit.tp2
+case_dir="$test_root/deferred-allow"
+(
+  cd "$case_dir"
+  "$weidu_bin" --nogame --no-exit-pause --force-install 0 \
+    --allow-external-commands test.tp2 </dev/null >output.log 2>&1
+)
+[ -e "$case_dir/command-ran" ] ||
+  fail_case "$case_dir" "deferred-allow did not execute the authorized command"
+
+echo "external-command-policy tests passed"

--- a/test/external-command-policy/run_tests.sh
+++ b/test/external-command-policy/run_tests.sh
@@ -10,9 +10,14 @@ esac
 
 script_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
 test_root=$(mktemp -d "${TMPDIR:-/tmp}/weidu-command-policy.XXXXXX")
+prompt_pid=
 
 cleanup()
 {
+  if [ -n "${prompt_pid:-}" ]; then
+    kill "$prompt_pid" 2>/dev/null || true
+    wait "$prompt_pid" 2>/dev/null || true
+  fi
   if [ -n "${test_root:-}" ] && [ -d "$test_root" ]; then
     rm -rf -- "$test_root"
   fi
@@ -29,11 +34,13 @@ fail_case()
 {
   failed_case_dir=$1
   shift
-  if [ -f "$failed_case_dir/output.log" ]; then
-    echo "----- captured WeiDU output -----" >&2
-    sed 's/^/| /' "$failed_case_dir/output.log" >&2
-    echo "----- end captured output -----" >&2
-  fi
+  for failed_log in output.log install.log; do
+    if [ -f "$failed_case_dir/$failed_log" ]; then
+      echo "----- captured $failed_log -----" >&2
+      sed 's/^/| /' "$failed_case_dir/$failed_log" >&2
+      echo "----- end captured $failed_log -----" >&2
+    fi
+  done
   fail "$@"
 }
 
@@ -46,10 +53,38 @@ prepare_case()
   cp "$script_dir/$fixture" "$case_dir/test.tp2"
 }
 
+assert_absent()
+{
+  assertion_case_dir=$1
+  assertion_path=$2
+  assertion_message=$3
+  [ ! -e "$assertion_case_dir/$assertion_path" ] ||
+    fail_case "$assertion_case_dir" "$assertion_message"
+}
+
+assert_present()
+{
+  assertion_case_dir=$1
+  assertion_path=$2
+  assertion_message=$3
+  [ -e "$assertion_case_dir/$assertion_path" ] ||
+    fail_case "$assertion_case_dir" "$assertion_message"
+}
+
+assert_output()
+{
+  assertion_case_dir=$1
+  assertion_text=$2
+  assertion_message=$3
+  grep -F "$assertion_text" "$assertion_case_dir/output.log" >/dev/null ||
+    fail_case "$assertion_case_dir" "$assertion_message"
+}
+
 assert_denied()
 {
   case_name=$1
-  shift
+  marker=$2
+  shift 2
   case_dir="$test_root/$case_name"
   if (
     cd "$case_dir"
@@ -58,21 +93,82 @@ assert_denied()
   ); then
     fail_case "$case_dir" "$case_name unexpectedly succeeded"
   fi
-  [ ! -e "$case_dir/command-ran" ] ||
-    fail_case "$case_dir" "$case_name executed the denied command"
-  grep -F "External command denied by security policy" \
-    "$case_dir/output.log" >/dev/null ||
-    fail_case "$case_dir" "$case_name did not report the denial"
+  assert_absent "$case_dir" "$marker" \
+    "$case_name executed the denied command"
+  assert_output "$case_dir" "External command denied by security policy" \
+    "$case_name did not report the denial"
+}
+
+start_prompt_case()
+{
+  prompt_case_name=$1
+  shift
+  case_dir="$test_root/$prompt_case_name"
+  input_fifo="$case_dir/input.fifo"
+  mkfifo "$input_fifo"
+  (
+    cd "$case_dir"
+    "$weidu_bin" --nogame --no-exit-pause "$@" \
+      test.tp2 <input.fifo >output.log 2>&1
+  ) &
+  prompt_pid=$!
+  exec 3>"$input_fifo"
+}
+
+wait_for_confirmation_token()
+{
+  token_index=$1
+  token_tries=0
+  while [ "$token_tries" -lt 30 ]; do
+    confirmation_token=$(
+      sed -n 's/^Confirmation token: \([A-Z2-9][A-Z2-9]*\)$/\1/p' \
+        "$case_dir/output.log" | sed -n "${token_index}p"
+    )
+    if [ -n "$confirmation_token" ]; then
+      printf '%s\n' "$confirmation_token"
+      return
+    fi
+    if ! kill -0 "$prompt_pid" 2>/dev/null; then
+      fail_case "$case_dir" \
+        "prompt process exited before confirmation token $token_index"
+    fi
+    token_tries=$((token_tries + 1))
+    sleep 1
+  done
+  fail_case "$case_dir" \
+    "timed out waiting for confirmation token $token_index"
+}
+
+send_prompt_answer()
+{
+  prompt_choice=$1
+  prompt_token=${2:-}
+  if [ -n "$prompt_token" ]; then
+    printf '%s %s\n' "$prompt_choice" "$prompt_token" >&3
+  else
+    printf '%s\n' "$prompt_choice" >&3
+  fi
+}
+
+finish_prompt_case()
+{
+  exec 3>&-
+  if wait "$prompt_pid"; then
+    prompt_status=0
+  else
+    prompt_status=$?
+  fi
+  prompt_pid=
 }
 
 prepare_case default-deny at-now.tp2
-assert_denied default-deny
+assert_denied default-deny command-ran
 
 prepare_case explicit-deny at-now.tp2
-assert_denied explicit-deny --deny-external-commands
+assert_denied explicit-deny command-ran --deny-external-commands
 
 prepare_case yes-does-not-authorize at-now.tp2
-assert_denied yes-does-not-authorize --yes
+assert_denied yes-does-not-authorize command-ran --yes
 
 prepare_case prompt-deny at-now.tp2
 case_dir="$test_root/prompt-deny"
@@ -84,19 +180,16 @@ if (
 ); then
   fail_case "$case_dir" "prompt-deny unexpectedly succeeded"
 fi
-[ ! -e "$case_dir/command-ran" ] ||
-  fail_case "$case_dir" "prompt-deny executed the denied command"
-
-prepare_case prompt-allow-once at-now.tp2
-case_dir="$test_root/prompt-allow-once"
-(
-  cd "$case_dir"
-  printf 'Y\n' |
-    "$weidu_bin" --nogame --no-exit-pause --force-install 0 \
-      --ask-external-commands test.tp2 >output.log 2>&1
-)
-[ -e "$case_dir/command-ran" ] ||
-  fail_case "$case_dir" "prompt-allow-once did not execute the authorized command"
+assert_absent "$case_dir" command-ran \
+  "prompt-deny executed the denied command"
+assert_output "$case_dir" 'Requesting TP2: "test.tp2"' \
+  "prompt-deny omitted the requesting TP2"
+assert_output "$case_dir" "Component: 0" \
+  "prompt-deny omitted the component number"
+assert_output "$case_dir" "Action: AT_NOW" \
+  "prompt-deny omitted the action type"
+assert_output "$case_dir" "Confirmation token:" \
+  "prompt-deny omitted the fresh confirmation token"
 
 prepare_case explicit-allow at-now.tp2
 case_dir="$test_root/explicit-allow"
@@ -105,24 +198,35 @@ case_dir="$test_root/explicit-allow"
   "$weidu_bin" --nogame --no-exit-pause --force-install 0 \
     --allow-external-commands test.tp2 </dev/null >output.log 2>&1
 )
-[ -e "$case_dir/command-ran" ] ||
-  fail_case "$case_dir" "explicit-allow did not execute the authorized command"
+assert_present "$case_dir" command-ran \
+  "explicit-allow did not execute the authorized command"
 
-prepare_case prompt-allow-all at-now-twice.tp2
-case_dir="$test_root/prompt-allow-all"
+prepare_case non-exact non-exact.tp2
+case_dir="$test_root/non-exact"
 (
   cd "$case_dir"
-  printf 'A\n' |
-    "$weidu_bin" --nogame --no-exit-pause --force-install 0 \
-      --ask-external-commands test.tp2 >output.log 2>&1
+  "$weidu_bin" --nogame --no-exit-pause --force-install 0 \
+    --allow-external-commands test.tp2 </dev/null >output.log 2>&1
 )
-[ -e "$case_dir/first-command-ran" ] ||
-  fail_case "$case_dir" "prompt-allow-all did not execute the first command"
-[ -e "$case_dir/second-command-ran" ] ||
-  fail_case "$case_dir" "prompt-allow-all did not authorize the rest of the run"
+assert_present "$case_dir" command-ran \
+  "non-EXACT command did not execute after authorization"
+
+prepare_case action-try action-try.tp2
+printf 'source\n' >"$test_root/action-try/source.txt"
+assert_denied action-try denied-command-ran
+assert_absent "$test_root/action-try" action-try-caught \
+  "ACTION_TRY caught and downgraded command denial"
+assert_absent "$test_root/action-try" continued-after-action-try \
+  "processing continued after ACTION_TRY command denial"
+
+prepare_case continue continue.tp2
+printf 'source\n' >"$test_root/continue/source.txt"
+assert_denied continue denied-command-ran --continue
+assert_absent "$test_root/continue" continued-after-denial \
+  "--continue downgraded command denial"
 
 prepare_case deferred-deny at-exit.tp2
-assert_denied deferred-deny
+assert_denied deferred-deny command-ran
 
 prepare_case deferred-allow at-exit.tp2
 case_dir="$test_root/deferred-allow"
@@ -131,7 +235,160 @@ case_dir="$test_root/deferred-allow"
   "$weidu_bin" --nogame --no-exit-pause --force-install 0 \
     --allow-external-commands test.tp2 </dev/null >output.log 2>&1
 )
-[ -e "$case_dir/command-ran" ] ||
-  fail_case "$case_dir" "deferred-allow did not execute the authorized command"
+assert_present "$case_dir" command-ran \
+  "deferred-allow did not execute the authorized command"
+
+prepare_case readme-deny readme.tp2
+printf 'readme\n' >"$test_root/readme-deny/readme.txt"
+case_dir="$test_root/readme-deny"
+if (
+  cd "$case_dir"
+  printf 'Y\nN\n' |
+    "$weidu_bin" --nogame --no-exit-pause --ask-external-commands \
+      test.tp2 >output.log 2>&1
+); then
+  fail_case "$case_dir" "readme-deny unexpectedly succeeded"
+fi
+assert_output "$case_dir" "Action: README" \
+  "README authorization omitted the action type"
+assert_output "$case_dir" "Component: not applicable" \
+  "README authorization reported a stale component"
+
+prepare_case uninstall-restoration uninstall-state.tp2
+case_dir="$test_root/uninstall-restoration"
+printf 'original\n' >"$case_dir/target.txt"
+printf 'replacement\n' >"$case_dir/replacement.txt"
+printf 'moved\n' >"$case_dir/move-source.txt"
+(
+  cd "$case_dir"
+  "$weidu_bin" --nogame --no-exit-pause --force-install 0 \
+    test.tp2 </dev/null >install.log 2>&1
+)
+grep -Fx "replacement" "$case_dir/target.txt" >/dev/null ||
+  fail_case "$case_dir" "uninstall fixture did not install replacement content"
+assert_absent "$case_dir" move-source.txt \
+  "uninstall fixture did not install its MOVE action"
+assert_present "$case_dir" move-destination.txt \
+  "uninstall fixture did not create the MOVE destination"
+: >"$case_dir/backup/0/UNSETSTR.0"
+if (
+  cd "$case_dir"
+  "$weidu_bin" --nogame --no-exit-pause --force-uninstall 0 \
+    --deny-external-commands --continue \
+    test.tp2 </dev/null >output.log 2>&1
+); then
+  fail_case "$case_dir" "denied uninstall unexpectedly succeeded"
+fi
+assert_absent "$case_dir" uninstall-command-ran \
+  "denied uninstall hook executed"
+grep -Fx "original" "$case_dir/target.txt" >/dev/null ||
+  fail_case "$case_dir" "COPY restoration did not run after hook denial"
+grep -Fx "moved" "$case_dir/move-source.txt" >/dev/null ||
+  fail_case "$case_dir" "MOVE restoration did not run after hook denial"
+assert_absent "$case_dir" move-destination.txt \
+  "MOVE destination remained after hook denial"
+assert_absent "$case_dir" backup/0/UNSETSTR.0 \
+  "STRSET restoration did not run after hook denial"
+if grep -E '^~TEST\.TP2~[[:space:]]+#0[[:space:]]+#0' \
+    "$case_dir/WeiDU.log" >/dev/null; then
+  fail_case "$case_dir" "WeiDU.log still records restored files as installed"
+fi
+grep -F "// Recently Uninstalled: ~TEST.TP2~ #0 #0" \
+  "$case_dir/WeiDU.log" >/dev/null ||
+  fail_case "$case_dir" "WeiDU.log did not record the restored component state"
+if grep -F "SUCCESSFULLY REMOVED" "$case_dir/output.log" >/dev/null; then
+  fail_case "$case_dir" "denied uninstall reported false success"
+fi
+
+case_dir="$test_root/uninstall-action-try"
+mkdir -p "$case_dir"
+cp "$script_dir/uninstall-action-if.tp2" "$case_dir/victim.tp2"
+cp "$script_dir/uninstall-action-try.tp2" "$case_dir/test.tp2"
+printf 'source\n' >"$case_dir/source.txt"
+printf 'original\n' >"$case_dir/target.txt"
+printf 'replacement\n' >"$case_dir/replacement.txt"
+printf 'moved\n' >"$case_dir/move-source.txt"
+(
+  cd "$case_dir"
+  "$weidu_bin" --nogame --no-exit-pause --force-install 0 \
+    victim.tp2 </dev/null >install.log 2>&1
+)
+if (
+  cd "$case_dir"
+  "$weidu_bin" --nogame --no-exit-pause --force-install 0 \
+    --deny-external-commands --continue \
+    test.tp2 </dev/null >output.log 2>&1
+); then
+  fail_case "$case_dir" \
+    "ACTION_TRY around a denied uninstall unexpectedly succeeded"
+fi
+assert_absent "$case_dir" uninstall-action-try-caught \
+  "ACTION_TRY caught and downgraded an uninstall-hook denial"
+assert_absent "$case_dir" continued-after-uninstall-denial \
+  "--continue downgraded an uninstall-hook denial"
+grep -Fx "original" "$case_dir/target.txt" >/dev/null ||
+  fail_case "$case_dir" \
+    "nested UNINSTALL did not restore files after hook denial"
+if grep -E '^~VICTIM\.TP2~[[:space:]]+#0[[:space:]]+#0' \
+    "$case_dir/WeiDU.log" >/dev/null; then
+  fail_case "$case_dir" \
+    "nested UNINSTALL left the restored victim marked as installed"
+fi
+
+if [ "${WEIDU_OS:-}" != "win32" ]; then
+  prepare_case prompt-allow-once at-now.tp2
+  start_prompt_case prompt-allow-once --force-install 0 \
+    --ask-external-commands
+  first_token=$(wait_for_confirmation_token 1)
+  send_prompt_answer Y "$first_token"
+  finish_prompt_case
+  [ "$prompt_status" -eq 0 ] ||
+    fail_case "$case_dir" "prompt-allow-once failed"
+  assert_present "$case_dir" command-ran \
+    "prompt-allow-once did not execute the authorized command"
+
+  prepare_case prompt-allow-once-then-deny at-now-twice.tp2
+  start_prompt_case prompt-allow-once-then-deny --force-install 0 \
+    --ask-external-commands
+  first_token=$(wait_for_confirmation_token 1)
+  send_prompt_answer Y "$first_token"
+  second_token=$(wait_for_confirmation_token 2)
+  send_prompt_answer N
+  finish_prompt_case
+  [ "$prompt_status" -ne 0 ] ||
+    fail_case "$case_dir" "Y-once followed by N unexpectedly succeeded"
+  assert_present "$case_dir" first-command-ran \
+    "Y-once did not execute the first command"
+  assert_absent "$case_dir" second-command-ran \
+    "Y-once authorized the second command"
+
+  prepare_case prompt-component-scope scope.tp2
+  start_prompt_case prompt-component-scope --force-install 0 \
+    --force-install 1 --ask-external-commands
+  first_token=$(wait_for_confirmation_token 1)
+  send_prompt_answer A SPOOFED
+  send_prompt_answer A "$first_token"
+  second_token=$(wait_for_confirmation_token 2)
+  send_prompt_answer N
+  finish_prompt_case
+  [ "$prompt_status" -ne 0 ] ||
+    fail_case "$case_dir" "component-scope denial unexpectedly succeeded"
+  assert_present "$case_dir" first-command-ran \
+    "component approval did not execute the first command"
+  assert_present "$case_dir" second-command-ran \
+    "component approval did not cover the same component"
+  assert_absent "$case_dir" third-command-ran \
+    "component approval leaked into another component"
+  token_count=$(grep -c '^Confirmation token:' "$case_dir/output.log")
+  [ "$token_count" -eq 2 ] ||
+    fail_case "$case_dir" \
+      "component-scoped approval produced $token_count prompts instead of 2"
+  assert_output "$case_dir" "The confirmation did not match." \
+    "a mod-supplied fake token was accepted"
+  assert_output "$case_dir" "Component: 0" \
+    "mod code changed the security prompt's component provenance"
+  assert_output "$case_dir" "Component: 1" \
+    "second component prompt omitted its provenance"
+fi
 
 echo "external-command-policy tests passed"

--- a/test/external-command-policy/scope.tp2
+++ b/test/external-command-policy/scope.tp2
@@ -1,0 +1,13 @@
+BACKUP ~backup~
+AUTHOR ~WeiDU regression tests~
+
+BEGIN ~External command policy: component-scoped approval~
+
+PRINT ~A mod can print a fake token such as SPOOFED, but not the fresh token below.~
+OUTER_SET COMPONENT_NUMBER = 1
+AT_NOW ~echo ran > first-command-ran~ EXACT
+AT_NOW ~echo ran > second-command-ran~ EXACT
+
+BEGIN ~External command policy: next component~
+
+AT_NOW ~echo ran > third-command-ran~ EXACT

--- a/test/external-command-policy/uninstall-action-if.tp2
+++ b/test/external-command-policy/uninstall-action-if.tp2
@@ -1,0 +1,13 @@
+BACKUP ~backup~
+AUTHOR ~WeiDU regression tests~
+
+UNINSTALL_ORDER ~AT~ ~COPY~ ~MOVE~ ~STRSET~
+
+BEGIN ~External command policy: uninstall ACTION_IF~
+
+COPY ~replacement.txt~ ~target.txt~
+MOVE ~move-source.txt~ ~move-destination.txt~
+
+ACTION_IF 1 THEN BEGIN
+  AT_UNINSTALL ~echo ran > uninstall-command-ran~ EXACT
+END

--- a/test/external-command-policy/uninstall-action-try.tp2
+++ b/test/external-command-policy/uninstall-action-try.tp2
@@ -1,0 +1,13 @@
+BACKUP ~controller-backup~
+AUTHOR ~WeiDU regression tests~
+
+BEGIN ~External command policy: UNINSTALL inside ACTION_TRY~
+
+ACTION_TRY
+  UNINSTALL ~victim.tp2~ 0
+WITH
+  DEFAULT
+    COPY ~source.txt~ ~uninstall-action-try-caught~
+END
+
+COPY ~source.txt~ ~continued-after-uninstall-denial~

--- a/test/external-command-policy/uninstall-state.tp2
+++ b/test/external-command-policy/uninstall-state.tp2
@@ -1,0 +1,11 @@
+BACKUP ~backup~
+AUTHOR ~WeiDU regression tests~
+
+UNINSTALL_ORDER ~AT~ ~COPY~ ~MOVE~ ~STRSET~
+
+BEGIN ~External command policy: uninstall restoration~
+
+COPY ~replacement.txt~ ~target.txt~
+MOVE ~move-source.txt~ ~move-destination.txt~
+
+AT_UNINSTALL ~echo ran > uninstall-command-ran~ EXACT


### PR DESCRIPTION
## Summary

- Adds a native, fail-closed authorization boundary for mod-supplied operating-system commands.
- Requires explicit authorization before immediate, deferred, interactive, uninstall, or README-view commands can reach the host shell.
- Preserves existing command handling, including `EXACT` and non-`EXACT` behavior.
- Adds regression coverage and CI integration for Linux, macOS, and Windows.
- Requires no Docker, Podman, Python, `strace`, command allowlist, or additional sandbox utility.

This partially addresses the external-command execution concerns discussed in #313 without imposing a single game-directory boundary or introducing additional runtime dependencies.

## Authorization behavior

- Interactive runs ask before executing external commands.
- Each prompt displays:
  - The escaped requesting TP2 filename
  - WeiDU’s immutable component number, when applicable
  - The action type
  - The exact prepared command
  - A fresh confirmation token
- `Y <token>` authorizes one command.
- `A <token>` authorizes commands only for the same TP2 and component.
- Non-interactive runs deny external commands by default.
- The policy can be selected explicitly with:
  - `--ask-external-commands`
  - `--allow-external-commands`
  - `--deny-external-commands`
- Only `--allow-external-commands` grants invocation-wide authorization.
- `--yes` does not authorize external commands.
- Deferred commands are authorized before being queued, and the already-authorized command is retained for later execution.

## Denial and uninstall safety

External-command denial is represented as a dedicated fatal security decision. It cannot be caught or downgraded by:

- `ACTION_TRY`
- Uninstall `ACTION_IF`
- `--continue`

During uninstall, an error or denial in an `AT` hook does not prevent WeiDU from attempting the remaining `COPY`, `MOVE`, and `STRSET` restoration categories.

After restoration:

- `WeiDU.log` reflects the restored component state.
- The denied or failed hook is still propagated as an uninstall failure.
- WeiDU does not print a false successful-removal message.

## Security scope

This is an authorization boundary, not an operating-system sandbox.

Authorized commands retain the user’s operating-system permissions and are not restricted to the game directory. WeiDU’s built-in file operations and other authority surfaces remain outside this PR’s scope.

Accordingly, this PR partially addresses #313 and is not intended to close the entire issue.

## Validation

Local verification against the current head (`db45223`) includes:

- Clean-checkout native OCaml build and link
- Complete external-command policy integration suite
- Windows-compatible non-FIFO test subset
- Regression coverage for:
  - Default non-interactive denial
  - Explicit ask, allow, and deny policies
  - `--yes` isolation
  - One-command authorization followed by denial
  - TP2/component-scoped authorization
  - Immutable component provenance
  - Invalid and mod-supplied confirmation tokens
  - `ACTION_TRY`
  - `--continue`
  - Uninstall `ACTION_IF`
  - Nested uninstall through `ACTION_TRY`
  - `COPY`, `MOVE`, and `STRSET` restoration
  - `WeiDU.log` state after denied uninstall hooks
  - Immediate and deferred commands
  - README viewer commands
  - Non-`EXACT` commands
- Reproduction of the pre-fix uninstall false-success defect against the earlier PR head (`a88b69b`)
- OCaml parser checks for every modified module
- POSIX shell syntax validation
- `git diff --check`

The policy suite is wired into the repository’s Linux, macOS, and Windows jobs, and the main workflow now runs for pull requests. The current GitHub-hosted runs require upstream-maintainer approval before their jobs can execute.