### PR TITLE
Set ADD_ITEM_EQEFFECT defaults to target 1 and timing 2

### DIFF
--- a/README-WeiDU-Changes.txt
+++ b/README-WeiDU-Changes.txt
@@ -1,4 +1,5 @@
 Version 251:
+  * ADD_ITEM_EQEFFECT defaults target to 1 and timing to 2.
   * CREATE called within CREATE works as expected.
   * CREATE sets SOURCE_* and DEST_* variables.
   * Auto-update does not fail if the filename of the newest WeiDU

--- a/doc/base.tex
+++ b/doc/base.tex
@@ -8953,9 +8953,11 @@ This is an ACTION macro.
 
 \\
 
-Note that, differently from the standalone versions, for these macros you \emph{need}
-to set all the needed values - they aren't initialized automatically. This is untrue functions
-(they are initialized to either 0 or the empty string, except for \verb+probability1+ which is initialized to 100).
+Unlike the standalone functions, these macros require all needed values to be set
+explicitly; macro parameters are not initialized automatically. Functions initialize
+their parameters, generally to 0 or the empty string, except for
+\verb+probability1+, which is initialized to 100. Additional exceptions are
+documented with the corresponding function.
 
 \verb+DELETE_SPELL_EFFECT+: deletes all extended effects with specified opcode from a spell.
 This is a PATCH macro and function.
@@ -9037,12 +9039,12 @@ This is a PATCH macro and function.
 \item SET \verb+insert_point+ to the position of the effect. If this variable is 0 the effect will be inserted as the first effect of the extended header. If this variable is negative or greater than the number of effects, the effect will be inserted as the last effect. The effect is added as the last effect by default.
 \end{itemize}
 
-\verb+ADD_ITEM_EQEFFECT+: adds an equipping effect to an item. All variables except \verb+probability1+ are 0 by default.
+\verb+ADD_ITEM_EQEFFECT+: adds an equipping effect to an item. The \verb+target+ variable defaults to 1, \verb+timing+ defaults to 2, and \verb+probability1+ defaults to 100; all other variables default to 0.
 This is a PATCH macro and function.
 \begin{itemize}
 \item SET \verb+opcode+ to opcode
-\item SET \verb+target+ to target type
-\item SET \verb+timing+ to timing type
+\item SET \verb+target+ to target type (default 1)
+\item SET \verb+timing+ to timing type (default 2)
 \item SET \verb+parameter1+ to first parameter
 \item SET \verb+parameter2+ to second parameter
 \item SET \verb+power+ to power

--- a/src/tph/include/g_functions.tpa
+++ b/src/tph/include/g_functions.tpa
@@ -83,8 +83,8 @@ END
 DEFINE_PATCH_FUNCTION ~ADD_ITEM_EQEFFECT~
   INT_VAR
     opcode = 0
-    target = 0
-    timing = 0
+    target = 1
+    timing = 2
     parameter1 = 0
     parameter2 = 0
     power = 0


### PR DESCRIPTION
## Summary

- change the built-in `ADD_ITEM_EQEFFECT` function defaults from `target = 0` and `timing = 0` to `target = 1` and `timing = 2`
- document the function-specific defaults in `doc/base.tex`
- clarify the general macro/function defaults documentation so that function-specific exceptions are documented with the corresponding function
- add a release-note entry for version 251

## Rationale

`ADD_ITEM_EQEFFECT` adds an equipping effect to an item. When callers omit the `target` and `timing` parameters, the built-in patch-function wrapper should supply the appropriate equipping-effect defaults:

- `target = 1` (Self)
- `timing = 2` (Instant/While equipped)

The change is intentionally limited to `DEFINE_PATCH_FUNCTION ~ADD_ITEM_EQEFFECT~`.

The shared `ADD_ITEM_EQEFFECT` macro remains unchanged because it is also used by `ADD_SPELL_CFEFFECT`. Consequently, `ADD_SPELL_CFEFFECT` retains its existing `target = 0` and `timing = 0` defaults, and the shared macro's field-writing and cleanup behavior is unaffected.

## Validation

- verified that `ADD_ITEM_EQEFFECT` defaults to `target = 1` and `timing = 2`
- verified that `ADD_SPELL_CFEFFECT` remains at `target = 0` and `timing = 0`
- verified that the shared `ADD_ITEM_EQEFFECT` macro's field writes and cleanup values remain unchanged
- verified all corresponding documentation references
- verified the version 251 release-note entry
- ran `git diff --check`
- successfully built WeiDU on Ubuntu 22.04 with OCaml 4.14.2, `ocaml-option-default-unsafe-string`, and Elkhound 1.0.3