### PR TITLE
Stop UPX-packing Windows release executables

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -87,11 +87,12 @@ jobs:
         uses: ocaml/setup-ocaml@v3.5.1
         with:
           ocaml-compiler: ocaml-variants.4.14.2+options,ocaml-option-default-unsafe-string
-      - name: Set-up Zip and Upx
-        run: choco install upx zip
+      - name: Set-up Zip
+        run: choco install zip
       - name: build weidu
         run: |
-          mv elkhound.exe D:/a/weidu/weidu/_opam/bin/elkhound.exe
+          $opamBin = opam var bin
+          Move-Item elkhound.exe (Join-Path $opamBin 'elkhound.exe')
           opam switch
           (& opam env) -split '\r?\n' | ForEach-Object { Invoke-Expression $_ }
           make

--- a/Makefile
+++ b/Makefile
@@ -178,11 +178,8 @@ windows_zip : weidu weinstall tolower
 	mv -f wein*.exe WeiDU-Windows/weinstall.exe || true
 	mv -f tolo*.exe WeiDU-Windows/tolower.exe || true
 	strip WeiDU-Windows/weidu.exe || true
-	upx --best WeiDU-Windows/weidu.exe || echo "No EXE Compression"
 	strip WeiDU-Windows/weinstall.exe || true
-	upx --best WeiDU-Windows/weinstall.exe || echo "No EXE Compression"
 	strip WeiDU-Windows/tolower.exe || true
-	upx --best WeiDU-Windows/tolower.exe || echo "No EXE Compression"
 	cp README* WeiDU-Windows
 	rm WeiDU-Windows/README.md
 	cp COPYING WeiDU-Windows

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ first-hand experience.
 - A Cygwin-based *nix tool chain, particularly `binutils` and `make`
   from the `Devel` group. Perl is also required but is typically
   installed by default. Optionally also `git` (Devel), `openssh`
-  (Net), `zip` (Archive) and `upx` (Utils).
+  (Net) and `zip` (Archive).
 
 - Cygwin-hosted MinGW-GCC, called `mingw-gcc-core`, or some such.
 


### PR DESCRIPTION
## Summary

- Stop applying UPX compression to executables in Windows release archives.
- Continue stripping the Windows executables before packaging.
- Remove UPX from the Windows GitHub Actions dependencies.
- Resolve the Elkhound installation destination through `opam var bin` instead of a repository-specific absolute path.
- Update the Windows build prerequisites accordingly.
- Leave Linux and macOS packaging unchanged.

## Problem

Issue #373 reports that Microsoft Defender detects:

```text
Trojan:Win32/Suschil!rfn
```

in `WeiDU-Windows-251.zip` and in some subsequent nightly Windows archives.

The Windows distribution target currently performs two separate forms of compression:

1. UPX packs each individual PE executable.
2. ZIP compresses the complete distribution directory.

Executable packing changes the PE representation and can trigger heuristic antivirus detections. ZIP already provides distribution compression, so applying an executable packer first is unnecessary and makes the Windows artifacts more susceptible to signature- and heuristic-based false positives.

This change removes the generic trigger rather than adding a Defender-specific exception, detection-name allow-list, hardcoded file hash, or end-user workaround.

## Controlled reproduction

A disposable GitHub Actions workflow tested the exact release assets referenced in issue #373:

- `v251.00/WeiDU-Windows-251.zip`
- `v252.01-nightly-686875d/WeiDU-Windows-25201.zip`

For each release, the workflow:

1. downloaded the published Windows ZIP without rebuilding or modifying it;
2. verified that all three executables were valid UPX-packed payloads;
3. copied the extracted distribution;
4. losslessly decompressed only the three executables with `upx -d`;
5. recreated the archive using the same Info-ZIP command used by the production target:

   ```sh
   zip -9r <archive> WeiDU-Windows
   ```

6. updated Microsoft Defender security intelligence;
7. verified that Defender was enabled and running in `Normal` mode;
8. scanned the original and unpacked/repacked archives with remediation disabled.

This isolates executable packing as the material variable while preserving the published files and the production ZIP implementation.

## Validation results

Microsoft Defender environment:

| Property | Value |
| --- | --- |
| Running mode | `Normal` |
| Antivirus service | Enabled |
| Antivirus | Enabled |
| Platform version | `4.18.26060.3008` |
| Security intelligence version | `1.455.378.0` |
| Security intelligence timestamp | `2026-07-27T11:07:40Z` |

Production-equivalent Info-ZIP comparison:

| Fixture | Defender result | Exit code |
| --- | ---: | ---: |
| Original `WeiDU-Windows-251.zip` | 1 threat | 2 |
| v251 executables UPX-decompressed and repacked with `zip -9r` | 0 threats | 0 |
| Original clean nightly ZIP | 0 threats | 0 |
| Clean nightly executables UPX-decompressed and repacked with `zip -9r` | 0 threats | 0 |

The original v251 archive reproduced the issue exactly:

```text
Threat : Trojan:Win32/Suschil!rfn
Resources : 1 total
```

The corresponding archive containing the same distribution after UPX decompression was clean.

The referenced nightly remained clean in both packed and unpacked forms, confirming that the heuristic is sensitive to the particular packed binary/archive representation rather than being emitted for every WeiDU or UPX build.

A broader comparison also scanned the original and unpacked forms both as ZIP archives and as extracted directories. Every unpacked fixture was clean.

Validation runs:

- [Production-equivalent Info-ZIP validation](https://github.com/4Luke4/weidu/actions/runs/30287205182)
- [Packed-versus-unpacked archive and directory validation](https://github.com/4Luke4/weidu/actions/runs/30286451784)

The disposable workflows and generated reports were removed from the production branch after the evidence was collected.

## Implementation

### `Makefile`

The `windows_zip` target still:

- builds the three Windows programs;
- moves them into `WeiDU-Windows`;
- strips the executables;
- copies the documentation, examples, and license;
- creates the distribution ZIP with maximum ZIP compression.

It no longer invokes `upx --best` on:

- `weidu.exe`;
- `weinstall.exe`;
- `tolower.exe`.

The Linux and macOS distribution targets retain their existing UPX behavior.

### `.github/workflows/main.yaml`

The Windows job now installs ZIP without installing UPX:

```yaml
- name: Set-up Zip
  run: choco install zip
```

The Elkhound destination is also obtained from the active opam switch:

```powershell
$opamBin = opam var bin
Move-Item elkhound.exe (Join-Path $opamBin 'elkhound.exe')
```

This avoids depending on a hardcoded GitHub Actions checkout path.

### `README.md`

The Windows requirements no longer list UPX, since Windows distribution packaging no longer uses it.

## Scope

This change does not:

- modify WeiDU runtime or interpreter behavior;
- modify any OCaml or C source;
- add an end-user dependency;
- weaken or bypass antivirus scanning;
- introduce signature-specific exceptions;
- change Linux or macOS packaging.

Already-published archives are not modified retroactively. New Windows nightlies and releases built after this change will contain stripped but non-UPX-packed executables.

Fixes #373 