### PR TITLE
Optimize array index tracking and RET_ARRAY performance

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@
 include Configuration
 
 # Just a target to be used by default
-.PHONY: weidu doc all
+.PHONY: weidu doc all test-array-assignment benchmark-array-assignment
 all : weidu
 # "make weinstall" if you want weinstall
 
@@ -69,6 +69,12 @@ PROJECT_RESOURCES = weidu_resources
 
 .PHONY: weidu
 weidu: $(PROJECT_EXECUTABLE)
+
+test-array-assignment: weidu
+	sh test/array-assignment/run_tests.sh $(PROJECT_EXECUTABLE)
+
+benchmark-array-assignment: weidu
+	sh test/array-assignment/run_benchmark.sh $(PROJECT_EXECUTABLE)
 
 $(PROJECT_EXECUTABLE) : $(PROJECT_MODULES:%=$(OBJDIR)/%.$(CMO)) \
                         $(PROJECT_CMODULES:%=$(OBJDIR)/%.$(OBJEXT))

--- a/README-WeiDU-Changes.txt
+++ b/README-WeiDU-Changes.txt
@@ -1,4 +1,6 @@
 Version 251:
+  * Improve the performance of array assignment and RET_ARRAY by
+    avoiding linear index scans and repeated array-name bindings.
   * CREATE called within CREATE works as expected.
   * CREATE sets SOURCE_* and DEST_* variables.
   * Auto-update does not fail if the filename of the newest WeiDU

--- a/src/tppatch.ml
+++ b/src/tppatch.ml
@@ -540,9 +540,9 @@ let rec process_patch2_real process_action tp our_lang patch_filename game buff 
             let final_ret_arrays = Hashtbl.create 5 in
             List.iter (fun s ->
               let s = Var.get_string (eval_pe_str s) in
-              if (Hashtbl.mem !Var.arrays s) then
+              if Var.local_array_mem s then
                 Hashtbl.add final_ret_arrays s
-                  (Some (Hashtbl.find !Var.arrays s))
+                  (Some (Var.find_local_array s))
               else
                 (* to differentiate uninitialised arrays from unknown ones *)
                 Hashtbl.add final_ret_arrays s None) f_retas ;
@@ -553,7 +553,8 @@ let rec process_patch2_real process_action tp our_lang patch_filename game buff 
                 Some vars ->
                   let vars = List.map (fun var ->
                     let var = List.map get_pe_string var in
-                    PE_Dollars(name,var,false,false)) vars in
+                    PE_Dollars(name,var,false,false))
+                    (Var.array_indices vars) in
                   List.append acc vars
               | None -> acc)) final_ret_arrays f_rets in
             List.iter (fun a ->
@@ -571,17 +572,17 @@ let rec process_patch2_real process_action tp our_lang patch_filename game buff 
               with Not_found ->
                 failwith (Printf.sprintf "Unknown return array: %s" is)) in
               ignore (match v with
-                Some a -> Hashtbl.add !Var.arrays want a
+                Some a -> Var.set_local_array want a
               | None -> ())) retas ;
             let rets = List.fold_left (fun acc (want,was) ->
               let was = Var.get_string (eval_pe_str was) in
               let want = Var.get_string (eval_pe_str want) in
-              if (Hashtbl.mem !Var.arrays want) then
+              if Var.local_array_mem want then
                 let vars = List.map (fun var ->
                   let var = List.map get_pe_string var in
                   let wasvar = PE_Dollars(PE_LiteralString was,var,false,false) in
                   let wantvar = PE_Dollars(PE_LiteralString want,var,false,false) in
-                  (wantvar,wasvar)) (Hashtbl.find !Var.arrays want) in
+                  (wantvar,wasvar)) (Var.find_local_array_indices want) in
                 List.append acc (List.filter (fun (_,wasvar) ->
                   (* if function array is empty *)
                   Hashtbl.mem final_returns (eval_pe_str wasvar)) vars)
@@ -690,13 +691,7 @@ let rec process_patch2_real process_action tp our_lang patch_filename game buff 
         let arr = eval_pe_str arr in
         let _,global = (try Var.array_lookup arr
         with Not_found -> [],false) in
-        if global then
-          while Hashtbl.mem !Var.global_arrays arr do
-            Hashtbl.remove !Var.global_arrays arr
-          done else
-          while Hashtbl.mem !Var.arrays arr do
-            Hashtbl.remove !Var.arrays arr
-          done ;
+        Var.clear_array global arr ;
         buff
 
     | TP_PatchDefineArray(arr,vals) ->
@@ -745,11 +740,7 @@ let rec process_patch2_real process_action tp our_lang patch_filename game buff 
         let sorted_indices = List.map (fun (_,var) ->
           var) sorted in
         if List.length sorted_indices > 0 then begin
-          if global then
-            ignore (Hashtbl.add !Var.global_arrays array
-                      (List.rev sorted_indices))
-          else
-            ignore (Hashtbl.add !Var.arrays array (List.rev sorted_indices))
+          Var.set_array_indices global array (List.rev sorted_indices)
         end ;
         buff
 
@@ -2478,8 +2469,7 @@ let rec process_patch2_real process_action tp our_lang patch_filename game buff 
             offset count index length;
         let arrS = eval_pe_str arr in
         process_action tp (TP_ActionClearArray arr);
-        if not (Hashtbl.mem !Var.arrays arrS) then
-          Hashtbl.add !Var.arrays arrS [];
+        Var.ensure_local_array arrS;
         for i = index to index + count - 1 do
           Var.set_string
             (eval_pe_str

--- a/src/tppe.ml
+++ b/src/tppe.ml
@@ -53,9 +53,7 @@ with _ -> eval_pe_str p)
           Var.get_string_exact ("%" ^ result ^ "%")
         with _ -> result) else result
     in
-    if do_add then (
-      let old = try Hashtbl.find !Var.arrays s with Not_found -> [] in
-      if not (List.mem a old) then Hashtbl.add !Var.arrays s (a :: old)) ;
+    if do_add then Var.add_array_index s a ;
     result
 
 let eval_pe_tlk_str game s = match s with
@@ -150,9 +148,7 @@ let rec eval_pe buff game p =
           let name = Var.get_string (eval_pe_str name) in
           let body = List.map (fun key -> Var.get_string
               (eval_pe_str key)) keys in
-          let bodies,_ =
-            (try Var.array_lookup name with Not_found -> [],false) in
-          if body <> [] && List.mem body bodies &&
+          if body <> [] && Var.array_index_mem name body &&
             (eval_pe buff game (PE_VariableIsSet (ac_to_pe_string a))) = 1l
           then 1l else 0l)
 

--- a/src/var.ml
+++ b/src/var.ml
@@ -23,11 +23,31 @@ type variable_value =
   | Int32 of Int32.t
   | String of string
 
+module ArrayIndexSet = Set.Make(struct
+  type t = string list
+  let compare = compare
+end)
+
+type array_value = {
+  indices : string list list;
+  index_set : ArrayIndexSet.t;
+}
+
+let array_value_of_indices indices = {
+  indices;
+  index_set = List.fold_left
+    (fun set index -> ArrayIndexSet.add index set)
+    ArrayIndexSet.empty indices;
+}
+
+let empty_array_value = array_value_of_indices []
+
 let variables = ref(Hashtbl.create 255)
 let global_scope = ref (Hashtbl.create 255)
 
-let arrays : (string, string list list) Hashtbl.t ref = ref(Hashtbl.create 255)
-let global_arrays = ref(Hashtbl.create 255)
+let arrays : (string, array_value) Hashtbl.t ref = ref(Hashtbl.create 255)
+let global_arrays : (string, array_value) Hashtbl.t ref =
+  ref(Hashtbl.create 255)
 
 let variables_stack = ref []
 let arrays_stack = ref []
@@ -73,10 +93,62 @@ let global_pop_arrays () =
 let array_lookup var =
   (try
     let a = Hashtbl.find !arrays var in
-    (a,false)
+    (a.indices,false)
   with Not_found ->
     let a = Hashtbl.find !global_arrays var in
-    (a,true))
+    (a.indices,true))
+
+let local_array_mem var =
+  Hashtbl.mem !arrays var
+
+let find_local_array var =
+  Hashtbl.find !arrays var
+
+let find_local_array_indices var =
+  (find_local_array var).indices
+
+let array_indices value =
+  value.indices
+
+let set_local_array var value =
+  Hashtbl.replace !arrays var value
+
+let set_array_indices global var indices =
+  let table = if global then !global_arrays else !arrays in
+  Hashtbl.replace table var (array_value_of_indices indices)
+
+let ensure_local_array var =
+  if not (local_array_mem var) then
+    set_local_array var empty_array_value
+
+let remove_all_array_bindings table var =
+  while Hashtbl.mem table var do
+    Hashtbl.remove table var
+  done
+
+let clear_array global var =
+  let table = if global then !global_arrays else !arrays in
+  remove_all_array_bindings table var
+
+let add_array_index var index =
+  let value =
+    try find_local_array var
+    with Not_found -> empty_array_value
+  in
+  if not (ArrayIndexSet.mem index value.index_set) then
+    set_local_array var {
+      indices = index :: value.indices;
+      index_set = ArrayIndexSet.add index value.index_set;
+    }
+
+let array_index_mem var index =
+  let value =
+    try Hashtbl.find !arrays var
+    with Not_found ->
+      try Hashtbl.find !global_arrays var
+      with Not_found -> empty_array_value
+  in
+  ArrayIndexSet.mem index value.index_set
 
 let var_wrap name =
   "%" ^ name ^ "%"
@@ -213,8 +285,6 @@ let clear_var () =
   Hashtbl.clear !variables
 
 let clear_arr () =
-  let arr_spec = Hashtbl.copy !arrays in
-  Hashtbl.iter (fun a b -> Hashtbl.remove !arrays a) arr_spec ;
   Hashtbl.clear !arrays
 
 let assoc name value =

--- a/test/array-assignment/benchmark.tp2
+++ b/test/array-assignment/benchmark.tp2
@@ -1,0 +1,75 @@
+BACKUP ~backup~
+AUTHOR ~WeiDU benchmark~
+
+BEGIN ~Array assignment benchmark~
+
+DEFINE_ACTION_FUNCTION scalar_returns
+  RET number text
+BEGIN
+  OUTER_SET number = 1
+  OUTER_SPRINT text ~X~
+END
+
+DEFINE_ACTION_FUNCTION parameterized_returns
+  INT_VAR x = 0 y = 0 z = 0
+  STR_VAR a = ~~ b = ~~ c = ~~
+  RET number text
+BEGIN
+  OUTER_SET number = x + y + z
+  OUTER_SPRINT text ~%a%-%b%-%c%~
+END
+
+DEFINE_ACTION_FUNCTION array_returns
+  INT_VAR x = 0 y = 0 z = 0
+  STR_VAR a = ~~ b = ~~ c = ~~
+  RET number text
+  RET_ARRAY items
+BEGIN
+  OUTER_SET number = x + y + z
+  OUTER_SPRINT text ~%a%-%b%-%c%~
+  OUTER_SPRINT $items(~%x%~) ~%a%~
+  OUTER_SPRINT $items(~%y%~) ~%b%~
+  OUTER_SPRINT $items(~%z%~) ~%c%~
+END
+
+OUTER_SET return_count = 100000
+OUTER_FOR (i = 0; i < return_count; ++i) BEGIN
+  ACTION_TIME ~parameterless-function-calls~ BEGIN
+    LAF scalar_returns RET number text END
+  END
+END
+
+OUTER_FOR (i = 0; i < return_count; ++i) BEGIN
+  ACTION_TIME ~parameterized-function-calls~ BEGIN
+    LAF parameterized_returns
+      INT_VAR x = 1 y = 2 z = 3
+      STR_VAR a = ~A~ b = ~B~ c = ~C~
+      RET number text
+    END
+  END
+END
+
+OUTER_FOR (i = 0; i < return_count; ++i) BEGIN
+  ACTION_TIME ~repeated-ret-array~ BEGIN
+    LAF array_returns
+      INT_VAR x = 1 y = 2 z = 3
+      STR_VAR a = ~A~ b = ~B~ c = ~C~
+      RET number text
+      RET_ARRAY items
+    END
+  END
+END
+
+OUTER_SET assignment_count = 10000
+ACTION_TIME ~unique-array-assignments~ BEGIN
+  OUTER_FOR (i = 0; i < assignment_count; ++i) BEGIN
+    OUTER_SET $array1(~first~ ~second~ ~third~ ~fourth~ ~fifth~ ~%i%~) = i
+  END
+END
+
+ACTION_TIME ~equivalent-variable-assignments~ BEGIN
+  OUTER_SPRINT array_var ~array2_first_second_third_fourth_fifth~
+  OUTER_FOR (i = 0; i < assignment_count; ++i) BEGIN
+    OUTER_SET $~%array_var%~(~%i%~) = i
+  END
+END

--- a/test/array-assignment/correctness.tp2
+++ b/test/array-assignment/correctness.tp2
@@ -1,0 +1,134 @@
+BACKUP ~backup~
+AUTHOR ~WeiDU regression tests~
+
+BEGIN ~Array assignment correctness~
+
+OUTER_SET entry_count = 2000
+OUTER_FOR (i = 0; i < entry_count; ++i) BEGIN
+  OUTER_SET $entries(~first~ ~second~ ~third~ ~fourth~ ~fifth~ ~%i%~) = i
+END
+
+OUTER_SET $entries(~first~ ~second~ ~third~ ~fourth~ ~fifth~ ~42~) = 99
+OUTER_SET $entries(~first~ ~second~ ~third~ ~fourth~ ~fifth~ ~42~) += 1
+
+ACTION_IF
+  $entries(~first~ ~second~ ~third~ ~fourth~ ~fifth~ ~0~) != 0 OR
+  $entries(~first~ ~second~ ~third~ ~fourth~ ~fifth~ ~42~) != 100 OR
+  $entries(~first~ ~second~ ~third~ ~fourth~ ~fifth~ ~1999~) != 1999
+BEGIN
+  FAIL ~array values changed while their indices were registered~
+END
+
+ACTION_IF NOT VARIABLE_IS_IN_ARRAY
+  $entries(~first~ ~second~ ~third~ ~fourth~ ~fifth~ ~42~)
+BEGIN
+  FAIL ~VARIABLE_IS_IN_ARRAY did not find an assigned index~
+END
+
+OUTER_SET iterated_entries = 0
+ACTION_PHP_EACH entries AS key => value BEGIN
+  OUTER_SET ++iterated_entries
+END
+ACTION_IF iterated_entries != entry_count BEGIN
+  FAIL ~reassigning an index registered a duplicate array entry~
+END
+
+OUTER_SET $underscored_name(~under_scored~ ~tail~) = 1
+OUTER_SET $underscored(~name_under~ ~scored_tail~) = 2
+ACTION_IF
+  NOT VARIABLE_IS_IN_ARRAY $underscored_name(~under_scored~ ~tail~) OR
+  NOT VARIABLE_IS_IN_ARRAY $underscored(~name_under~ ~scored_tail~)
+BEGIN
+  FAIL ~structurally distinct underscored indices were conflated~
+END
+
+OUTER_SET GLOBAL $global_entries(~alpha~) = 1
+OUTER_SET GLOBAL $global_entries(~beta~) = 2
+OUTER_SET GLOBAL $global_entries(~alpha~) = 3
+ACTION_IF
+  NOT VARIABLE_IS_IN_ARRAY $global_entries(~alpha~) OR
+  NOT VARIABLE_IS_IN_ARRAY $global_entries(~beta~) OR
+  $global_entries(~alpha~) != 3
+BEGIN
+  FAIL ~global array membership or values changed~
+END
+OUTER_SET global_entries_seen = 0
+ACTION_PHP_EACH global_entries AS key => value BEGIN
+  OUTER_SET ++global_entries_seen
+END
+ACTION_IF global_entries_seen != 2 BEGIN
+  FAIL ~reassigning a global index registered a duplicate array entry~
+END
+
+OUTER_SET $ordered(~10~) = 10
+OUTER_SET $ordered(~2~) = 2
+OUTER_SET $ordered(~1~) = 1
+ACTION_SORT_ARRAY_INDICES ordered NUMERICALLY
+OUTER_SPRINT order ~~
+ACTION_PHP_EACH ordered AS key => value BEGIN
+  OUTER_SPRINT order ~%order%,%key%~
+END
+ACTION_IF ~%order%~ STR_CMP ~,1,2,10~ BEGIN
+  FAIL ~sorting no longer controls array iteration order~
+END
+
+OUTER_SET $scoped(~outer~) = 1
+WITH_SCOPE BEGIN
+  OUTER_SET $scoped(~inner~) = 2
+  ACTION_IF NOT VARIABLE_IS_IN_ARRAY $scoped(~inner~) BEGIN
+    FAIL ~an index assigned inside a scope was not registered~
+  END
+END
+ACTION_IF VARIABLE_IS_IN_ARRAY $scoped(~inner~) BEGIN
+  FAIL ~an index assigned inside a scope leaked into its parent scope~
+END
+ACTION_IF NOT VARIABLE_IS_IN_ARRAY $scoped(~outer~) BEGIN
+  FAIL ~an outer-scope array index was lost after leaving a scope~
+END
+
+DEFINE_ACTION_FUNCTION return_items
+  INT_VAR seed = 0
+  RET_ARRAY items
+BEGIN
+  OUTER_SET $items(~alpha~) = seed
+  OUTER_SET $items(~beta~) = seed + 1
+  OUTER_SET $items(~gamma~) = seed + 2
+  OUTER_SET $items(~beta~) = seed + 3
+END
+
+OUTER_SET return_count = 5000
+OUTER_FOR (i = 0; i < return_count; ++i) BEGIN
+  LAF return_items
+    INT_VAR seed = i
+    RET_ARRAY items
+  END
+END
+
+OUTER_SET returned_entries = 0
+ACTION_PHP_EACH items AS key => value BEGIN
+  OUTER_SET ++returned_entries
+END
+ACTION_IF returned_entries != 3 BEGIN
+  FAIL ~repeated RET_ARRAY calls changed the returned array's index set~
+END
+ACTION_IF
+  $items(~alpha~) != return_count - 1 OR
+  $items(~beta~) != return_count + 2 OR
+  $items(~gamma~) != return_count + 1
+BEGIN
+  FAIL ~repeated RET_ARRAY calls returned incorrect values~
+END
+
+ACTION_CLEAR_ARRAY entries
+ACTION_IF VARIABLE_IS_IN_ARRAY
+  $entries(~first~ ~second~ ~third~ ~fourth~ ~fifth~ ~42~)
+BEGIN
+  FAIL ~clearing an array retained its index membership~
+END
+
+ACTION_CLEAR_ARRAY global_entries
+ACTION_IF VARIABLE_IS_IN_ARRAY $global_entries(~alpha~) BEGIN
+  FAIL ~clearing a global array retained its index membership~
+END
+
+PRINT ~array-assignment tests passed~

--- a/test/array-assignment/run_benchmark.sh
+++ b/test/array-assignment/run_benchmark.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+
+set -eu
+
+weidu_bin=${1:-./weidu}
+case "$weidu_bin" in
+  /*) ;;
+  *) weidu_bin="$(pwd)/$weidu_bin" ;;
+esac
+
+script_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+benchmark_root=$(mktemp -d "${TMPDIR:-/tmp}/weidu-array-benchmark.XXXXXX")
+
+cleanup()
+{
+  if [ -n "${benchmark_root:-}" ] && [ -d "$benchmark_root" ]; then
+    rm -rf -- "$benchmark_root"
+  fi
+}
+trap cleanup EXIT HUP INT TERM
+
+cp "$script_dir/benchmark.tp2" "$benchmark_root/test.tp2"
+(
+  cd "$benchmark_root"
+  "$weidu_bin" --nogame --no-exit-pause --force-install 0 \
+    --log benchmark.log test.tp2 </dev/null
+)
+cat "$benchmark_root/benchmark.log"

--- a/test/array-assignment/run_tests.sh
+++ b/test/array-assignment/run_tests.sh
@@ -1,0 +1,39 @@
+#!/bin/sh
+
+set -eu
+
+weidu_bin=${1:-./weidu}
+case "$weidu_bin" in
+  /*) ;;
+  *) weidu_bin="$(pwd)/$weidu_bin" ;;
+esac
+
+script_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+test_root=$(mktemp -d "${TMPDIR:-/tmp}/weidu-array-assignment.XXXXXX")
+
+cleanup()
+{
+  if [ -n "${test_root:-}" ] && [ -d "$test_root" ]; then
+    rm -rf -- "$test_root"
+  fi
+}
+trap cleanup EXIT HUP INT TERM
+
+cp "$script_dir/correctness.tp2" "$test_root/test.tp2"
+if ! (
+  cd "$test_root"
+  "$weidu_bin" --nogame --no-exit-pause --force-install 0 \
+    test.tp2 </dev/null >output.log 2>&1
+); then
+  sed 's/^/| /' "$test_root/output.log" >&2
+  exit 1
+fi
+
+if ! grep -F "array-assignment tests passed" \
+  "$test_root/output.log" >/dev/null; then
+  sed 's/^/| /' "$test_root/output.log" >&2
+  echo "array-assignment test completion marker was not printed" >&2
+  exit 1
+fi
+
+echo "array-assignment tests passed"


### PR DESCRIPTION
## Summary

- Replace linear array-index membership scans with a persistent set while retaining the ordered index list used for iteration.
- Replace existing array-name bindings instead of stacking shadowed bindings, preventing repeated `RET_ARRAY` calls from growing array metadata.
- Add reusable correctness and issue-scale benchmark targets.
- Document the performance improvement in the changelog.

## Root cause

Array metadata stored indices only as a list. Registering each new index called `List.mem`, so constructing an array with unique indices became quadratic as the array grew.

Updated arrays were also recorded with `Hashtbl.add`. That retained prior bindings for the same array name. In particular, every `RET_ARRAY` call added another hidden destination binding, and subsequent function scopes copied those accumulated bindings.

## Implementation

Array metadata now contains:

- the existing index list, preserving observable iteration and sorting order;
- an immutable set of structured `string list` indices for logarithmic membership checks.

Because the set and record are immutable, array values remain safe to share across the shallow hash-table copies used for variable scopes. Mutations create a new value and replace the table entry.

Local/global lookup, replacement, clearing, sorting, membership checks, and returned-array handling now use centralized helpers rather than manipulating the array tables directly.

## Validation

A disposable branch-only workflow compiled and ran the regression suite on:

- Ubuntu 22.04
- Windows Server 2022
- macOS Intel
- macOS ARM

The workflow was removed before the final commit. Validation run:

https://github.com/4Luke4/weidu/actions/runs/30564887379

The regression fixture covers:

- 2,000 unique multidimensional indices;
- repeated assignments without duplicate iteration entries;
- structurally distinct indices containing underscores;
- local and global array membership, replacement, iteration, and clearing;
- sorted iteration order;
- variable-scope isolation;
- 5,000 repeated `RET_ARRAY` calls with value and index-set verification.

Three paired issue-scale benchmark runs produced the following median CPU timings:

| Workload | `devel` median | This branch median | Speedup |
| --- | ---: | ---: | ---: |
| 100,000 parameterless function calls | 0.497 s | 0.485 s | 1.02× |
| 100,000 parameterized function calls | 0.705 s | 0.701 s | 1.01× |
| 100,000 calls returning an array | 10.969 s | 1.541 s | 7.12× |
| 10,000 unique array assignments | 3.756 s | 0.089 s | 42.20× |
| 10,000 equivalent variable assignments | 0.835 s | 0.052 s | 16.06× |

The scalar-function controls remain effectively unchanged, isolating the improvement to array handling.

Fixes #316