### PR TITLE
Fix REFACTOR_TRIGGER negation and OR ordering

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@
 include Configuration
 
 # Just a target to be used by default
-.PHONY: weidu doc all
+.PHONY: weidu doc all test-refactor-trigger
 all : weidu
 # "make weinstall" if you want weinstall
 
@@ -69,6 +69,9 @@ PROJECT_RESOURCES = weidu_resources
 
 .PHONY: weidu
 weidu: $(PROJECT_EXECUTABLE)
+
+test-refactor-trigger: weidu
+	sh test/refactor-trigger/run_tests.sh $(PROJECT_EXECUTABLE)
 
 $(PROJECT_EXECUTABLE) : $(PROJECT_MODULES:%=$(OBJDIR)/%.$(CMO)) \
                         $(PROJECT_CMODULES:%=$(OBJDIR)/%.$(OBJEXT))

--- a/README-WeiDU-Changes.txt
+++ b/README-WeiDU-Changes.txt
@@ -1,4 +1,8 @@
 Version 251:
+  * REFACTOR_TRIGGER retains a single negation when substituting a
+    negated trigger with a negated trigger.
+  * REFACTOR_TRIGGER preserves trigger order when substituting inside
+    OR() blocks.
   * CREATE called within CREATE works as expected.
   * CREATE sets SOURCE_* and DEST_* variables.
   * Auto-update does not fail if the filename of the newest WeiDU

--- a/src/refactorbaf.ml
+++ b/src/refactorbaf.ml
@@ -7,13 +7,10 @@ type trigger =
   | Trigger of string * string option
   | NotTrigger of string * string option
 
-let do_refactor : (Str.regexp * string * bool) option ref = ref None
+let do_refactor : (Str.regexp * string) option ref = ref None
 
 let parse_triggers : (string -> trigger list) ref = ref (fun s ->
   failwith "parse_triggers not loaded")
-
-let spacer = "tb#refactor_baf_must_certainly_not_match_against_me"
-let spacer_r = Str.regexp spacer
 
 let refactor_ht = Hashtbl.create 5
 
@@ -28,17 +25,7 @@ let set_refactor x = do_refactor := match x with
       | false, true  -> Str.regexp_string_case_fold a
       | false, false -> Str.regexp_case_fold a
       in
-      let parts = Str.split many_whitespace_or_nl_regexp b in
-      let any = ref false in
-      let parts = List.map (fun s ->
-        let is_neg = s.[0] = '!' in
-        let s = if is_neg then Str.string_after s 1 else s in
-        if Str.string_match a_reg s 0 && Str.matched_string s = s then begin
-          (* Variable any is technically redundant now; but ... *)
-          any := true ;
-          (if is_neg then "!" else "") ^ spacer ^ s
-        end else (if is_neg then "!" else "") ^ s) parts in
-      let ans = Some(a_reg, String.concat " " parts, !any) in
+      let ans = Some(a_reg, b) in
       Hashtbl.add refactor_ht (a,b, case_sens, exact_m) ans ;
       ans
     end
@@ -58,30 +45,6 @@ let rec print_t t =
 and print_tl tl =
   List.fold_left (fun acc elt -> acc^ " " ^ print_t elt) "" tl
 
-let rec find pre tl =
-  List.exists (fun t -> match t with
-  | Trigger (s,_)
-  | NotTrigger (s,_) -> Str.string_match pre s 0 && Str.matched_string s = s
-  | Or tl -> find pre tl) tl
-
-let fix_trigger acc tl =
-  List.iter (fun t -> acc := t :: !acc) (List.rev tl)
-
-let rec invert and_acc or_acc t = match t with
-| Trigger (s,a) -> or_acc := NotTrigger (s,a) :: !or_acc
-| NotTrigger (s,a) -> or_acc := Trigger (s,a) :: !or_acc
-| Or tl' -> List.iter (invert or_acc and_acc) (List.rev tl')
-
-let rec fix_nottrigger acc tl =
-  let or_acc = ref [] in
-  let and_acc = ref [] in
-  List.iter (invert and_acc or_acc) tl ;
-  if List.length !and_acc = 0 then
-    acc := Or(!or_acc) :: !acc
-  else
-    List.iter (fun t ->
-      acc := Or(t :: !or_acc) :: !acc) !and_acc
-
 let rec enforce_actor tl a =
   List.map (fun t ->
     match t with
@@ -94,65 +57,70 @@ let rec enforce_actor tl a =
         failwith msg) tl
 
 let sub pre post s a =
-  let tl = !parse_triggers (Str.global_replace pre (spacer ^ post) s) in
+  let tl = !parse_triggers (Str.global_replace pre post s) in
   match a with
   | None -> tl
-  | Some x -> enforce_actor tl a
+  | Some _ -> enforce_actor tl a
 
-let fix_or_internal pre post acc tl =
-  let old_tl = ref [] in
-  let new_tl = ref [] in
-  let found = ref false in
-  List.iter (fun t -> match t with
-  | Or _ -> failwith "Nested OR()"
-  | Trigger (s,a) -> if not !found && find pre [t] then begin
-      found := true ;
-      new_tl := List.append (sub pre post s a) !new_tl
-  end
-  else old_tl := t :: !old_tl
-  | NotTrigger (s,a) -> if not !found && find pre [t] then begin
-      found := true ;
-      List.iter (invert new_tl old_tl) (sub pre post s a)
-  end
-  else old_tl := t :: !old_tl) tl ;
-  let flatten_or tl =
-    let a = ref [] in
-    List.iter (fun t -> match t with
-    | Or tl' -> List.iter (fun t -> a := t :: !a) tl'
-    | _ -> a := t :: !a) tl ;
-    Or !a
-  in
-  if !new_tl = [] then acc := flatten_or !old_tl :: !acc
-  else begin
-    List.iter (fun t ->
-      acc := flatten_or (t :: !old_tl) :: !acc) !new_tl
-  end
+(* A trigger list is a conjunction of clauses. A plain trigger is a
+   one-element clause and [Or] contains the alternatives in a larger clause. *)
+let clause_of_trigger = function
+| Or tl -> tl
+| t -> [t]
 
+let trigger_of_clause = function
+| [t] -> t
+| tl -> Or tl
 
-let rec subst pre post acc tl =
-  List.iter (fun t -> if find pre [t] then match t with
-  | Trigger (s,a) -> fix_trigger acc (sub pre post s a)
-  | NotTrigger (s,a) -> fix_nottrigger acc (sub pre post s a)
-  | Or tl -> fix_or pre post acc tl
-  else acc := t :: !acc) tl ;
+let cnf_of_triggers tl = List.map clause_of_trigger tl
 
-and fix_or pre post acc tl =
-  let acc' = ref [] in
-  fix_or_internal pre post acc' tl ;
-  if find pre !acc' then begin
-    subst pre post acc !acc' ;
-  end else acc := !acc' @ !acc
+let matches pre s =
+  Str.string_match pre s 0 && Str.matched_string s = s
 
-let rec remove_spacer tl = List.map (fun t -> match t with
-| Trigger (s,a) -> Trigger (Str.global_replace spacer_r "" s,a)
-| NotTrigger (s,a) -> NotTrigger (Str.global_replace spacer_r "" s,a)
-| Or tl' -> Or (remove_spacer tl')) tl
+(* Applying the matched source's negation to an already-negated replacement
+   keeps one negation rather than turning [!A] into [A]. *)
+let ensure_negated = function
+| Trigger (s,a)
+| NotTrigger (s,a) -> NotTrigger (s,a)
+| Or _ -> failwith "Nested OR()"
+
+(* Negate a replacement in CNF. Each source clause contributes one choice to
+   every resulting clause; this is the distributive product required by De
+   Morgan's laws. The choices and the generated clauses retain source order. *)
+let negate_cnf cnf =
+  List.fold_left (fun clauses source_clause ->
+    List.concat (List.map (fun clause ->
+      List.map (fun t -> clause @ [ensure_negated t]) source_clause
+    ) clauses)
+  ) [[]] cnf
+
+(* Disjoin two CNF expressions. False is represented by one empty clause and
+   true by an empty clause list, which also makes empty replacements behave
+   consistently during distribution. *)
+let or_cnf left right =
+  if left = [] || right = [] then []
+  else
+    List.concat (List.map (fun left_clause ->
+      List.map (fun right_clause -> left_clause @ right_clause) right
+    ) left)
+
+let substitute_atom pre post = function
+| Trigger (s,a) as t ->
+    if matches pre s then cnf_of_triggers (sub pre post s a) else [[t]]
+| NotTrigger (s,a) as t ->
+    if matches pre s then
+      negate_cnf (cnf_of_triggers (sub pre post s a))
+    else [[t]]
+| Or _ -> failwith "Nested OR()"
+
+let substitute_trigger pre post t =
+  let clause = clause_of_trigger t in
+  let cnf = List.fold_left (fun acc atom ->
+    or_cnf acc (substitute_atom pre post atom)
+  ) [[]] clause in
+  List.map trigger_of_clause cnf
 
 let refactor tl = match !do_refactor with
 | None -> tl
-| Some(pre, post, any) -> begin
-    let acc = ref [] in
-    let tl = subst pre post acc (List.rev tl) in
-    (* Used to check any instead of always being true *)
-    if true then remove_spacer !acc else !acc
-end
+| Some(pre, post) ->
+    List.concat (List.map (substitute_trigger pre post) tl)

--- a/test/refactor-trigger/expected/issue-95-different.baf
+++ b/test/refactor-trigger/expected/issue-95-different.baf
@@ -1,0 +1,6 @@
+IF
+  !See(Player2)
+THEN
+  RESPONSE #100
+    NoAction()
+END

--- a/test/refactor-trigger/expected/issue-95-positive.baf
+++ b/test/refactor-trigger/expected/issue-95-positive.baf
@@ -1,0 +1,6 @@
+IF
+  !See(Player2)
+THEN
+  RESPONSE #100
+    NoAction()
+END

--- a/test/refactor-trigger/expected/issue-95-same.baf
+++ b/test/refactor-trigger/expected/issue-95-same.baf
@@ -1,0 +1,6 @@
+IF
+  !See(Player1)
+THEN
+  RESPONSE #100
+    NoAction()
+END

--- a/test/refactor-trigger/expected/issue-96-backreference.baf
+++ b/test/refactor-trigger/expected/issue-96-backreference.baf
@@ -1,0 +1,11 @@
+IF
+  See(Player1)
+  OR(3)
+    RandomNum(10,1)
+    RandomNum(10,2)
+    RandomNum(10,3)
+  See(Player2)
+THEN
+  RESPONSE #100
+    NoAction()
+END

--- a/test/refactor-trigger/expected/issue-96-conjunction.baf
+++ b/test/refactor-trigger/expected/issue-96-conjunction.baf
@@ -1,0 +1,15 @@
+IF
+  See(Player1)
+  OR(3)
+    RandomNum(10,1)
+    RandomNum(10,2)
+    RandomNum(10,3)
+  OR(3)
+    RandomNum(10,1)
+    RandomNum(10,9)
+    RandomNum(10,3)
+  See(Player2)
+THEN
+  RESPONSE #100
+    NoAction()
+END

--- a/test/refactor-trigger/expected/issue-96-negated-conjunction.baf
+++ b/test/refactor-trigger/expected/issue-96-negated-conjunction.baf
@@ -1,0 +1,12 @@
+IF
+  See(Player1)
+  OR(4)
+    RandomNum(10,1)
+    !RandomNum(10,8)
+    !RandomNum(10,9)
+    RandomNum(10,3)
+  See(Player2)
+THEN
+  RESPONSE #100
+    NoAction()
+END

--- a/test/refactor-trigger/expected/issue-96-negated-explicit.baf
+++ b/test/refactor-trigger/expected/issue-96-negated-explicit.baf
@@ -1,0 +1,11 @@
+IF
+  See(Player1)
+  OR(3)
+    RandomNum(10,1)
+    !RandomNum(10,9)
+    RandomNum(10,3)
+  See(Player2)
+THEN
+  RESPONSE #100
+    NoAction()
+END

--- a/test/refactor-trigger/expected/issue-96-negated-or.baf
+++ b/test/refactor-trigger/expected/issue-96-negated-or.baf
@@ -1,0 +1,15 @@
+IF
+  See(Player1)
+  OR(3)
+    RandomNum(10,1)
+    !RandomNum(10,8)
+    RandomNum(10,3)
+  OR(3)
+    RandomNum(10,1)
+    !RandomNum(10,9)
+    RandomNum(10,3)
+  See(Player2)
+THEN
+  RESPONSE #100
+    NoAction()
+END

--- a/test/refactor-trigger/expected/issue-96-negated-simple.baf
+++ b/test/refactor-trigger/expected/issue-96-negated-simple.baf
@@ -1,0 +1,11 @@
+IF
+  See(Player1)
+  OR(3)
+    RandomNum(10,1)
+    !RandomNum(10,9)
+    RandomNum(10,3)
+  See(Player2)
+THEN
+  RESPONSE #100
+    NoAction()
+END

--- a/test/refactor-trigger/expected/issue-96-or.baf
+++ b/test/refactor-trigger/expected/issue-96-or.baf
@@ -1,0 +1,12 @@
+IF
+  See(Player1)
+  OR(4)
+    RandomNum(10,1)
+    RandomNum(10,2)
+    RandomNum(10,9)
+    RandomNum(10,3)
+  See(Player2)
+THEN
+  RESPONSE #100
+    NoAction()
+END

--- a/test/refactor-trigger/expected/issue-96-simple.baf
+++ b/test/refactor-trigger/expected/issue-96-simple.baf
@@ -1,0 +1,11 @@
+IF
+  See(Player1)
+  OR(3)
+    RandomNum(10,1)
+    RandomNum(10,9)
+    RandomNum(10,3)
+  See(Player2)
+THEN
+  RESPONSE #100
+    NoAction()
+END

--- a/test/refactor-trigger/fixtures/negative.baf
+++ b/test/refactor-trigger/fixtures/negative.baf
@@ -1,0 +1,6 @@
+IF
+  !See(Player1)
+THEN
+  RESPONSE #100
+    NoAction()
+END

--- a/test/refactor-trigger/fixtures/or-negative.baf
+++ b/test/refactor-trigger/fixtures/or-negative.baf
@@ -1,0 +1,11 @@
+IF
+  See(Player1)
+  OR(3)
+    RandomNum(10,1)
+    !RandomNum(10,2)
+    RandomNum(10,3)
+  See(Player2)
+THEN
+  RESPONSE #100
+    NoAction()
+END

--- a/test/refactor-trigger/fixtures/or-positive.baf
+++ b/test/refactor-trigger/fixtures/or-positive.baf
@@ -1,0 +1,11 @@
+IF
+  See(Player1)
+  OR(3)
+    RandomNum(10,1)
+    RandomNum(10,2)
+    RandomNum(10,3)
+  See(Player2)
+THEN
+  RESPONSE #100
+    NoAction()
+END

--- a/test/refactor-trigger/fixtures/positive.baf
+++ b/test/refactor-trigger/fixtures/positive.baf
@@ -1,0 +1,6 @@
+IF
+  See(Player1)
+THEN
+  RESPONSE #100
+    NoAction()
+END

--- a/test/refactor-trigger/issue-95.tp2
+++ b/test/refactor-trigger/issue-95.tp2
@@ -1,0 +1,13 @@
+BACKUP ~issue-95-backup~
+AUTHOR ~WeiDU regression tests~
+
+BEGIN ~REFACTOR_TRIGGER negation regression tests~
+
+COPY ~fixtures/negative.baf~ ~results/issue-95-same.baf~
+  REFACTOR_TRIGGER EXACT_MATCH ~See(Player1)~ ~!See(Player1)~
+
+COPY ~fixtures/negative.baf~ ~results/issue-95-different.baf~
+  REFACTOR_TRIGGER EXACT_MATCH ~See(Player1)~ ~!See(Player2)~
+
+COPY ~fixtures/positive.baf~ ~results/issue-95-positive.baf~
+  REFACTOR_TRIGGER EXACT_MATCH ~See(Player1)~ ~!See(Player2)~

--- a/test/refactor-trigger/issue-96.tp2
+++ b/test/refactor-trigger/issue-96.tp2
@@ -1,0 +1,44 @@
+BACKUP ~issue-96-backup~
+AUTHOR ~WeiDU regression tests~
+
+BEGIN ~REFACTOR_TRIGGER ordering regression tests~
+
+COPY ~fixtures/or-positive.baf~ ~results/issue-96-simple.baf~
+  REFACTOR_TRIGGER EXACT_MATCH
+    ~RandomNum(10,2)~
+    ~RandomNum(10,9)~
+
+COPY ~fixtures/or-positive.baf~ ~results/issue-96-conjunction.baf~
+  REFACTOR_TRIGGER EXACT_MATCH
+    ~RandomNum(10,2)~
+    ~RandomNum(10,2) RandomNum(10,9)~
+
+COPY ~fixtures/or-positive.baf~ ~results/issue-96-or.baf~
+  REFACTOR_TRIGGER EXACT_MATCH
+    ~RandomNum(10,2)~
+    ~OR(2) RandomNum(10,2) RandomNum(10,9)~
+
+COPY ~fixtures/or-negative.baf~ ~results/issue-96-negated-simple.baf~
+  REFACTOR_TRIGGER EXACT_MATCH
+    ~RandomNum(10,2)~
+    ~RandomNum(10,9)~
+
+COPY ~fixtures/or-negative.baf~ ~results/issue-96-negated-conjunction.baf~
+  REFACTOR_TRIGGER EXACT_MATCH
+    ~RandomNum(10,2)~
+    ~RandomNum(10,8) RandomNum(10,9)~
+
+COPY ~fixtures/or-negative.baf~ ~results/issue-96-negated-or.baf~
+  REFACTOR_TRIGGER EXACT_MATCH
+    ~RandomNum(10,2)~
+    ~OR(2) RandomNum(10,8) RandomNum(10,9)~
+
+COPY ~fixtures/or-negative.baf~ ~results/issue-96-negated-explicit.baf~
+  REFACTOR_TRIGGER EXACT_MATCH
+    ~RandomNum(10,2)~
+    ~!RandomNum(10,9)~
+
+COPY ~fixtures/or-positive.baf~ ~results/issue-96-backreference.baf~
+  REFACTOR_TRIGGER EVALUATE_REGEXP
+    ~\(RandomNum(10,2)\)~
+    ~\1~

--- a/test/refactor-trigger/run_tests.sh
+++ b/test/refactor-trigger/run_tests.sh
@@ -1,0 +1,107 @@
+#!/bin/sh
+
+set -eu
+
+weidu_bin=${1:-./weidu}
+case "$weidu_bin" in
+  /*) ;;
+  *) weidu_bin="$(pwd)/$weidu_bin" ;;
+esac
+
+script_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+test_root=$(mktemp -d "${TMPDIR:-/tmp}/weidu-refactor-trigger.XXXXXX")
+
+cleanup()
+{
+  if [ -n "${test_root:-}" ] && [ -d "$test_root" ]; then
+    rm -rf -- "$test_root"
+  fi
+}
+trap cleanup EXIT HUP INT TERM
+
+cp "$script_dir"/*.tp2 "$test_root/"
+cp -R "$script_dir/fixtures" "$script_dir/expected" "$test_root/"
+mkdir -p "$test_root/results"
+
+canonicalize()
+{
+  tr '\r' '\n' <"$1" | awk '
+    {
+      for (i = 1; i <= NF; ++i) {
+        if (seen) printf " ";
+        printf "%s", $i;
+        seen = 1;
+      }
+    }
+    END { print "" }
+  ' | sed 's/ (/(/g'
+}
+
+failures=0
+
+run_suite()
+{
+  suite=$1
+  shift
+  suite_failed=0
+  log_file="$test_root/$suite.log"
+
+  if ! (
+    cd "$test_root"
+    "$weidu_bin" --noautoupdate --nogame --no-exit-pause \
+      --force-install 0 "$suite.tp2" </dev/null >"$log_file" 2>&1
+  ); then
+    sed 's/^/| /' "$log_file" >&2
+    echo "$suite installer invocation failed" >&2
+    suite_failed=1
+  fi
+
+  for case_name do
+    actual="$test_root/results/$case_name.baf"
+    expected="$test_root/expected/$case_name.baf"
+    actual_normalized="$test_root/$case_name.actual"
+    expected_normalized="$test_root/$case_name.expected"
+
+    if [ ! -f "$actual" ]; then
+      echo "$case_name did not produce $actual" >&2
+      suite_failed=1
+      continue
+    fi
+
+    canonicalize "$actual" >"$actual_normalized"
+    canonicalize "$expected" >"$expected_normalized"
+    if ! cmp -s "$actual_normalized" "$expected_normalized"; then
+      echo "$case_name produced an unexpected trigger sequence" >&2
+      diff -u "$expected_normalized" "$actual_normalized" >&2 || true
+      suite_failed=1
+    fi
+  done
+
+  if [ "$suite_failed" -eq 0 ]; then
+    echo "$suite: PASS"
+  else
+    echo "$suite: FAIL" >&2
+    failures=$((failures + 1))
+  fi
+}
+
+run_suite issue-95 \
+  issue-95-same \
+  issue-95-different \
+  issue-95-positive
+
+run_suite issue-96 \
+  issue-96-simple \
+  issue-96-conjunction \
+  issue-96-or \
+  issue-96-negated-simple \
+  issue-96-negated-conjunction \
+  issue-96-negated-or \
+  issue-96-negated-explicit \
+  issue-96-backreference
+
+if [ "$failures" -ne 0 ]; then
+  exit 1
+fi
+
+echo "refactor-trigger tests passed"


### PR DESCRIPTION
## Summary

- Preserve a single negation when `REFACTOR_TRIGGER` replaces a negated trigger with an explicitly negated trigger.
- Preserve source and replacement order when substitutions occur inside `OR()` blocks.
- Replace sentinel-based recursive substitution with an ordered CNF transformation that visits only original triggers.
- Add an end-to-end regression target covering both reports and adjacent Boolean cases.
- Document the fixes in the changelog.

## Root cause

`REFACTOR_TRIGGER` previously assembled rewritten `OR()` clauses through reverse accumulators. The matched member was separated from the surrounding alternatives and reinserted after flattening, which moved simple replacements to the end, reversed replacement alternatives, and emitted distributed clauses in reverse order.

Negated substitutions also inverted an explicitly negated replacement back to a positive trigger. The loop guard was encoded by injecting a sentinel into replacement text, so replacements beginning with `!` or `OR(...)` could be parsed incorrectly.

## Implementation

The refactoring path now treats trigger lists as conjunctive normal form:

- plain triggers are single-element clauses;
- `OR()` nodes are ordered multi-element clauses;
- substituting inside `OR()` disjoins the replacement CNF with the surrounding alternatives through an order-preserving distributive product;
- negated matches use an order-preserving De Morgan transformation while retaining one negation for already-negated replacements;
- each original trigger is visited once, so inserted triggers cannot be recursively matched and no textual sentinel is required;
- `TriggerOverride` actor propagation and regexp/backreference replacement remain supported.

## Tests

Added `make test-refactor-trigger`, which runs WeiDU end to end against eleven cases covering:

- the exact issue #95 self-negation report;
- positive-to-negative and negative-to-different-negative substitution;
- simple replacement in the middle of `OR()`;
- conjunction distribution with the original clause before the newly introduced clause;
- ordered flattening of an `OR()` replacement;
- simple, conjunctive, `OR()`, and explicitly negated replacements of negated `OR()` members;
- regexp backreferences without recursive rematching.

A disposable branch-only workflow first confirmed that `devel` reproduces both regressions, then built and ran the regression suite successfully on:

- Ubuntu 22.04;
- macOS ARM;
- macOS Intel;
- Windows Server 2022.

Validation run: https://github.com/4Luke4/weidu/actions/runs/30703939372

The temporary workflow was removed after validation. The final branch differs from the validated candidate only by that workflow deletion.

Fixes #95
Fixes #96