### PR TITLE
Prefer Elkhound for TP2-family parsing

### DIFF
--- a/README-WeiDU-Changes.txt
+++ b/README-WeiDU-Changes.txt
@@ -63,6 +63,8 @@ Version 251:
   * ADD_SPELL evaluates variables before printing anything.
   * Add REGISTER_UNINSTALL.
   * The contents of %MOD_FOLDER% are case-exact.
+  * TP2, TPA/TPH, and TPP files are parsed by Elkhound first. If that
+    fails, the deprecated OCamlyacc parser is used with a warning.
 
 Version 249:
   * Auto-update is less chatty than in 248.

--- a/src/tparser.in
+++ b/src/tparser.in
@@ -95,6 +95,20 @@ let parse start lexbuf =
   cu
 
 
+let parse_with_fallback filename sort_of_file elkhound_parser ocamlyacc_parser =
+  try
+    parse_file false filename sort_of_file elkhound_parser
+  with _ ->
+    let result = parse_file true filename sort_of_file ocamlyacc_parser in
+    let parsed_filename = match filename with
+    | File filename -> filename
+    | String(filename, _) -> filename
+    in
+    log_and_print
+      "WARNING: [%s] could not be parsed by the Elkhound parser; using the deprecated OCamlyacc parser.\n"
+      parsed_filename ;
+    result
+
 let parse_tp2_file filename =
   let tp_file lexbuf =
     let cu = parse START_FROM_TP lexbuf in
@@ -102,11 +116,8 @@ let parse_tp2_file filename =
     | Tp.Start_From_Tp(a) -> a
     | _ -> failwith "Elkhound internal"
   in
-  try
-    parse_file false filename "Parsing TP2 files"
-      (Toldparser.tp_file Toldlexer.initial)
-  with _ ->
-    parse_file true filename "Parsing TP2 files" tp_file
+  parse_with_fallback filename "Parsing TP2 files" tp_file
+    (Toldparser.tp_file Toldlexer.initial)
 
 let parse_tpa_file filename =
   let tpa_file lexbuf =
@@ -115,11 +126,8 @@ let parse_tpa_file filename =
     | Tp.Start_From_Tpa(a) -> a
     | _ -> failwith "Elkhound internal"
   in
-  try
-    parse_file false filename "Parsing TPA files"
-      (Toldparser.tph_file Toldlexer.initial)
-  with _ ->
-    parse_file true filename "Parsing TPA files" tpa_file
+  parse_with_fallback filename "Parsing TPA files" tpa_file
+    (Toldparser.tph_file Toldlexer.initial)
 
 let parse_tpp_file filename =
   let tpp_file lexbuf =
@@ -128,8 +136,5 @@ let parse_tpp_file filename =
     | Tp.Start_From_Tpp(a) -> a
     | _ -> failwith "Elkhound internal"
   in
-  try
-    parse_file false filename "Parsing TPP files"
-      (Toldparser.tpp_file Toldlexer.initial)
-  with _ ->
-    parse_file true filename "Parsing TPP files" tpp_file
+  parse_with_fallback filename "Parsing TPP files" tpp_file
+    (Toldparser.tpp_file Toldlexer.initial)


### PR DESCRIPTION
## Summary

- use Elkhound as the primary parser for TP2, TPA/TPH, and TPP inputs
- retain the deprecated OCamlyacc parser as a compatibility fallback
- emit a filename-specific warning only when the fallback successfully parses the input
- document the staged parser-migration behavior

## Rationale

Issue #328 proposes retiring the OCamlyacc TP2 parser in stages. The current `devel` implementation still tries OCamlyacc first, which means the proposed observation period has not yet begun.

This PR implements the first stage. It deliberately retains the legacy parser so that compatibility failures can surface before removal is considered.

## Behavior

All three TP2-family entry points now use the same fallback helper:

1. Elkhound parses the input first.
2. If Elkhound fails, OCamlyacc retries with normal verbose diagnostics.
3. If OCamlyacc succeeds, WeiDU emits:

```text
WARNING: [<filename>] could not be parsed by the Elkhound parser; using the deprecated OCamlyacc parser.
```

The warning is emitted only after the fallback succeeds. Inputs rejected by both parsers therefore retain the detailed OCamlyacc error without a misleading fallback-success warning.

## Validation

A temporary branch-only workflow was used for validation and removed from the branch's reachable history afterward.

The [focused CI run](https://github.com/4Luke4/weidu/actions/runs/30706835975) verified:

- a clean Ubuntu 22.04 build with OCaml 4.14.2, unsafe strings, and Elkhound 1.0.3
- Elkhound-only TP2, TPA, and TPP fixtures without fallback warnings
- invalid input rejected by both parsers without a fallback-success warning
- successful parsing of all 51 tracked TP2-family files:
  - 10 TP2 files
  - 40 TPA files
  - 1 TPP file
- deterministic TP2, TPA, and TPP fallback coverage using a CI-only failure injected inside the Elkhound parser callback, followed by a clean rebuild
- successful OCamlyacc parsing and the exact expected warning for every fallback path
- `git diff --check`

### Existing workflow note

The repository's unchanged Linux workflow currently fails during `ocaml/setup-ocaml`, before source compilation, because `4.08.1+default-unsafe-string` is no longer available in the opam repository. The focused workflow used the supported OCaml 4.14.2 unsafe-string selector already used by the repository's macOS and Windows jobs.

Refs #328.