### PR TITLE
CI: restore remote Linux release builds

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -60,7 +60,10 @@ jobs:
       - name: Set-up OCaml
         uses: ocaml/setup-ocaml@v3.5.1
         with:
-          ocaml-compiler: 4.08.1+default-unsafe-string
+          ocaml-compiler: ocaml-variants.4.08.1+default-unsafe-string
+          opam-repositories: |
+            default: git+https://github.com/ocaml/opam-repository.git
+            archive: git+https://github.com/ocaml/opam-repository-archive.git
       - name: build weidu
         run: |
           export PATH="$PATH:$PWD/bin"


### PR DESCRIPTION
## Summary

Restore the remote Linux release build by making the legacy OCaml compiler selection resolvable through the current opam repository layout.

The Linux job intentionally remains on OCaml 4.08.1 with unsafe strings enabled. This change does not upgrade the compiler or alter the generated release format.

## Root cause

The Linux job configured `ocaml/setup-ocaml@v3.5.1` with:

```yaml
ocaml-compiler: 4.08.1+default-unsafe-string
```

The setup action failed before the WeiDU build began:

```text
Error: Could not find any OCaml compiler version matching
'4.08.1+default-unsafe-string' in the opam-repository.
```

OCaml 4.08.1 packages have been moved from the primary opam repository to the official `ocaml/opam-repository-archive` repository.

Additionally, the previous value was not the complete opam package name expected when selecting this archived compiler variant directly.

## Changes

Update the Linux setup step to:

1. select the compiler by its exact package name:

   ```yaml
   ocaml-variants.4.08.1+default-unsafe-string
   ```

2. retain the primary opam repository;
3. add OCaml's official archive repository as a secondary source.

The resulting configuration is:

```yaml
- name: Set-up OCaml
  uses: ocaml/setup-ocaml@v3.5.1
  with:
    ocaml-compiler: ocaml-variants.4.08.1+default-unsafe-string
    opam-repositories: |
      default: git+https://github.com/ocaml/opam-repository.git
      archive: git+https://github.com/ocaml/opam-repository-archive.git
```

## Rationale

This is deliberately narrower than upgrading the Linux toolchain:

- it preserves the compiler version previously selected by the project;
- it preserves the compiler's default unsafe-string configuration;
- it avoids introducing unrelated source-compatibility or release-compatibility changes;
- it uses the official OCaml package archive rather than an unofficial mirror or arbitrary repository snapshot;
- it leaves the macOS and Windows jobs unchanged.

## Validation

A temporary disposable GitHub Actions workflow reproduced the Linux release-build sequence on `ubuntu-22.04`:

```text
download and execute Elkhound
set up OCaml
make
make linux_zip
verify WeiDU-Linux-*.zip
upload the release archive
```

### Configuration validation

Workflow run `30737048052` completed successfully:

- OCaml setup: passed
- WeiDU build: passed
- Linux archive creation: passed
- artifact verification: passed
- artifact upload: passed

Produced artifact:

```text
Name: discussion-363-linux
Size: 2,546,223 bytes
SHA-256: dcb2d425e2d03758f1237ce3e0afaab87e1530d7a6ad9924fc6210174d9d7704
```

### Production-change validation

After applying the same configuration to `.github/workflows/main.yaml`, workflow run `30737232597` also completed successfully:

- OCaml setup: passed
- WeiDU build: passed
- Linux archive creation: passed
- artifact verification: passed
- artifact upload: passed

Produced artifact:

```text
Name: discussion-363-linux
Size: 2,547,023 bytes
SHA-256: d0fe4daf726d17c98dd4ab98fcd7c9c51025ec2a9f9532bff0b7168d390f7146
```

Addresses discussion #363.