### PR TITLE
Fix Win32 registry API calls for current MinGW builds

### DIFF
--- a/src/reg.c
+++ b/src/reg.c
@@ -20,102 +20,77 @@
 
 CAMLprim value get_bg2main_path(void)
 {
-  int result;
-  char buf[SIZE] = { '.', 0 } ;
-#ifdef __CYGWIN__
-  long size = SIZE; 
-#else
-  int size = SIZE; 
-#endif
+  char buf[SIZE] = { '.', 0 };
+  LONG size = (LONG)sizeof(buf);
 
-  result = RegQueryValueA(HKEY_LOCAL_MACHINE, "Software\\Microsoft\\Windows\\CurrentVersion\\App Paths\\BG2Main.Exe", buf, &size); 
+  RegQueryValueA(HKEY_LOCAL_MACHINE, "Software\\Microsoft\\Windows\\CurrentVersion\\App Paths\\BG2Main.Exe", buf, &size);
 
   // "buf" now contains the path to BG2Main.exe
 
-  return copy_string(buf); 
+  return copy_string(buf);
 }
 
 CAMLprim value get_bgmain_path(void)
 {
-  int result;
-  char buf[SIZE] = { '.', 0 } ;
-#ifdef __CYGWIN__
-  long size = SIZE; 
-#else
-  int size = SIZE; 
-#endif
+  char buf[SIZE] = { '.', 0 };
+  LONG size = (LONG)sizeof(buf);
 
-  result = RegQueryValueA(HKEY_LOCAL_MACHINE, "Software\\Microsoft\\Windows\\CurrentVersion\\App Paths\\BGMain.Exe", buf, &size); 
+  RegQueryValueA(HKEY_LOCAL_MACHINE, "Software\\Microsoft\\Windows\\CurrentVersion\\App Paths\\BGMain.Exe", buf, &size);
 
   // "buf" now contains the path to BG2Main.exe
 
-  return copy_string(buf); 
+  return copy_string(buf);
 }
 
 CAMLprim value get_iwdmain_path(void)
 {
-  int result;
-  char buf[SIZE] = { '.', 0 } ;
-#ifdef __CYGWIN__
-  long size = SIZE; 
-#else
-  int size = SIZE; 
-#endif
+  char buf[SIZE] = { '.', 0 };
+  LONG size = (LONG)sizeof(buf);
 
-  result = RegQueryValueA(HKEY_LOCAL_MACHINE, "Software\\Microsoft\\Windows\\CurrentVersion\\App Paths\\IDMain.Exe", buf, &size); 
+  RegQueryValueA(HKEY_LOCAL_MACHINE, "Software\\Microsoft\\Windows\\CurrentVersion\\App Paths\\IDMain.Exe", buf, &size);
 
   // "buf" now contains the path to BG2Main.exe
 
-  return copy_string(buf); 
+  return copy_string(buf);
 }
 
 CAMLprim value get_pstmain_path(void)
 {
-  int result;
-  char buf[SIZE] = { '.', 0 } ;
-#ifdef __CYGWIN__
-  long size = SIZE; 
-#else
-  int size = SIZE; 
-#endif
+  char buf[SIZE] = { '.', 0 };
+  LONG size = (LONG)sizeof(buf);
 
-  result = RegQueryValueA(HKEY_LOCAL_MACHINE, "Software\\Microsoft\\Windows\\CurrentVersion\\App Paths\\Torment.Exe", buf, &size); 
+  RegQueryValueA(HKEY_LOCAL_MACHINE, "Software\\Microsoft\\Windows\\CurrentVersion\\App Paths\\Torment.Exe", buf, &size);
 
   // "buf" now contains the path to BG2Main.exe
 
-  return copy_string(buf); 
+  return copy_string(buf);
 }
 
 CAMLprim value get_iwd2main_path(void)
 {
-  int result;
-  char buf[SIZE] = { '.', 0 } ;
-#ifdef __CYGWIN__
-  long size = SIZE; 
-#else
-  int size = SIZE; 
-#endif
+  char buf[SIZE] = { '.', 0 };
+  LONG size = (LONG)sizeof(buf);
 
-  result = RegQueryValueA(HKEY_LOCAL_MACHINE, "Software\\Microsoft\\Windows\\CurrentVersion\\App Paths\\IWD2.Exe", buf, &size); 
+  RegQueryValueA(HKEY_LOCAL_MACHINE, "Software\\Microsoft\\Windows\\CurrentVersion\\App Paths\\IWD2.Exe", buf, &size);
 
   // "buf" now contains the path to BG2Main.exe
 
-  return copy_string(buf); 
+  return copy_string(buf);
 }
 
 CAMLprim value get_user_personal_dir(void)
 {
   HKEY hKey = 0;
   char unexpBuf[SIZE] = {'.', 0};
-  DWORD unexpBufSize = sizeof(unexpBuf);
+  DWORD unexpBufSize = (DWORD)sizeof(unexpBuf);
   DWORD type = REG_EXPAND_SZ;
   const char* subkey = "Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\User Shell Folders";
   char expBuf[SIZE] = {'.', 0};
-  DWORD expBufSize = sizeof(expBuf);
+  DWORD expBufSize = (DWORD)sizeof(expBuf);
 
-  RegOpenKeyEx(HKEY_CURRENT_USER, subkey, 0, KEY_QUERY_VALUE, &hKey);
+  RegOpenKeyExA(HKEY_CURRENT_USER, subkey, 0, KEY_QUERY_VALUE, &hKey);
   RegQueryValueExA(hKey, "Personal", 0, &type, (BYTE*)unexpBuf, &unexpBufSize);
-  ExpandEnvironmentStrings(&unexpBuf, (BYTE*)expBuf, &expBufSize);
+  ExpandEnvironmentStringsA(unexpBuf, expBuf, expBufSize);
   RegCloseKey(hKey);
 
   return copy_string(expBuf);


### PR DESCRIPTION
## Summary

Restore Windows builds with the current MinGW toolchain by correcting invalid Win32 API argument types in `src/reg.c`.

The change is limited to the Windows registry and environment-expansion native stubs. It does not suppress compiler diagnostics, relax warning policies, change the Windows build toolchain, or alter the release packaging process.

## Root cause

The Windows build failed while compiling `src/reg.c` under MinGW GCC 14.4.0:

```text
error: passing argument 4 of 'RegQueryValueA' from incompatible pointer type
```

and:

```text
error: passing argument 1 of 'ExpandEnvironmentStringsA' from incompatible pointer type
error: passing argument 2 of 'ExpandEnvironmentStringsA' from incompatible pointer type
error: passing argument 3 of 'ExpandEnvironmentStringsA' makes integer from pointer without a cast
```

Failed job:

https://github.com/4Luke4/weidu/actions/runs/30737301555/job/91468369812#step:6:1

These diagnostics exposed pre-existing mismatches between the native stub and the Win32 API declarations.

### `RegQueryValueA`

The fourth argument is declared as:

```c
PLONG lpcbData
```

The five registry-path helpers instead declared the size as `int` and passed an `int *`.

Although `int` and `LONG` are both commonly 32-bit on this target, pointers to those types are not interchangeable under the C type system. Each helper now uses the API's declared `LONG` type:

```c
LONG size = (LONG)sizeof(buf);
```

### `ExpandEnvironmentStringsA`

The function is declared conceptually as:

```c
DWORD ExpandEnvironmentStringsA(
  LPCSTR lpSrc,
  LPSTR  lpDst,
  DWORD  nSize
);
```

The previous call supplied:

```c
ExpandEnvironmentStrings(&unexpBuf, (BYTE*)expBuf, &expBufSize);
```

This passed:

- a pointer to the complete source array rather than a character pointer;
- a byte pointer rather than the declared destination character pointer;
- a pointer to the destination size rather than the destination size value.

The call now follows the declared ANSI API contract:

```c
ExpandEnvironmentStringsA(unexpBuf, expBuf, expBufSize);
```

## Changes

- use `LONG` for every `RegQueryValueA` buffer-length argument;
- initialize buffer lengths from `sizeof` rather than repeating the buffer constant;
- use `DWORD` casts where a Win32 size parameter is required;
- call `RegOpenKeyExA` and `ExpandEnvironmentStringsA` explicitly, matching the other ANSI registry calls in the file;
- pass the source buffer, destination buffer, and destination capacity to `ExpandEnvironmentStringsA` with their declared types;
- remove unused local result variables.

The existing fallback buffers and error-handling behavior are otherwise unchanged.

## Rationale

This approach fixes the source-level API violations directly rather than working around them through:

- warning suppression;
- compiler downgrades;
- permissive compiler flags;
- casts between incompatible pointer types;
- changes to the hosted runner or MinGW package selection.

Using the Win32 declarations as the source of truth keeps the native boundary type-correct and compatible with current compiler diagnostics.

## Validation

A temporary disposable GitHub Actions workflow reproduced the complete Windows release path on `windows-2022`.

Successful workflow:

https://github.com/4Luke4/weidu/actions/runs/30738752403

Successful Windows job:

https://github.com/4Luke4/weidu/actions/runs/30738752403/job/91472208293

Uploaded artifact:

https://github.com/4Luke4/weidu/actions/runs/30738752403/artifacts/8830667558

The workflow performed the following operations:

```text
checkout
download Windows Elkhound
set up OCaml 4.14.2 with default unsafe strings
install ZIP and UPX
report the active MinGW GCC version
make
make windows_zip
verify WeiDU-Windows-*.zip
calculate the archive SHA-256 digest
upload the release archive
```

### Toolchain verified

```text
x86_64-w64-mingw32-gcc (GCC) 14.4.0
```

### Build results

```text
src/reg.c compilation: passed
native executable linking: passed
Windows release packaging: passed
archive verification: passed
artifact upload: passed
```

The build produced:

```text
WeiDU-Windows-25201.zip
```

Archive metadata:

```text
Size:    2,153,774 bytes
SHA-256: 3D0CC1349606B6BE973651190BB70D6913BC86C6DFB9DD8DDE8A9E81A1A5368B
```

GitHub Actions artifact metadata:

```text
Artifact name: temporary-windows-registry-build
Artifact ID:   8830667558
Size:          2,141,826 bytes
Digest:        sha256:465028a1d30f24c11d3e628382cbf44bb8785360823844a155b9ea5b8241aa4d
```