### PR TITLE
Fix TP2 identity during temporary component restoration

### DIFF
--- a/README-WeiDU-Changes.txt
+++ b/README-WeiDU-Changes.txt
@@ -49,6 +49,8 @@ Version 251:
   * Change uninstallation behaviour to prevent re-installation of
     temporarily uninstalled components in another order than the
     original order under certain circumstances.
+  * Do not re-install temporarily uninstalled components whose component
+    requirements are no longer met.
   * Add --unbiff.
   * EXTEND_TOP and friends take when-clauses.
   * --change-log does not fail to resolve, e.g., %MOD_FOLDER% when

--- a/src/tpwork.ml
+++ b/src/tpwork.ml
@@ -729,11 +729,12 @@ let rec handle_tp game this_tp2_filename tp =
 
   let handle_letter_inner tp answer can_uninstall temp_uninst package_name
       m finished i =
+    let tp2_filename = tp.tp_filename in
     let subgroup_already =
       match subcomp_group m with
       | Some(ts) ->
           let res = any_member_of_subcomp_group_installed
-              tp this_tp2_filename ts in
+              tp tp2_filename ts in
           res
       | None ->
           false in
@@ -780,7 +781,7 @@ let rec handle_tp game this_tp2_filename tp =
           log_and_print "\n%s%s%s\n"
             ((get_trans (-1013))) ((Tpstate.subcomp_str game m) ^ package_name)
             ((get_trans (-1014))) ;
-          (if not (uninstall game handle_tp2_filename this_tp2_filename i !interactive) then
+          (if not (uninstall game handle_tp2_filename tp2_filename i !interactive) then
             failwith "uninstallation error");
           log_and_print
             "\n%s [%s]\n\n"
@@ -834,7 +835,7 @@ let rec handle_tp game this_tp2_filename tp =
               (Int32.of_int (if !interactive then 1 else 0)) ;
             let old_silent = !be_silent in
             be_silent := true;
-            process_action_real our_lang game this_tp2_filename tp
+            process_action_real our_lang game tp2_filename tp
               (TP_Include Tph.builtin_definitions);
             be_silent := old_silent;
 
@@ -842,7 +843,7 @@ let rec handle_tp game this_tp2_filename tp =
               !safe_exit then begin
               let old_log = !the_log in
               the_log := !the_log @
-                [((String.uppercase this_tp2_filename), !our_lang_index, i,
+                [((String.uppercase tp2_filename), !our_lang_index, i,
                   Some(package_name), Installed)];
               let old_tp_quick_log = !Tp.quick_log in
               Tp.quick_log := true;
@@ -852,7 +853,7 @@ let rec handle_tp game this_tp2_filename tp =
             end ;
 
             List.iter (fun flag -> match flag with
-            | Always(al) -> List.iter (process_action_real our_lang game this_tp2_filename tp) al
+            | Always(al) -> List.iter (process_action_real our_lang game tp2_filename tp) al
             | TP_No_If_Eval () -> has_if_eval_bug := false ;
             | Define_Action_Macro(str,decl,al) ->
                 Hashtbl.replace macros (str,false) (decl, [TP_PatchInnerAction al])
@@ -869,7 +870,7 @@ let rec handle_tp game this_tp2_filename tp =
                 log_and_print "WARNING: Unable to read readln references from [%s]: %s\n"
                   args_backup_filename (printexc_to_string e)
             end ;
-            List.iter (process_action_real our_lang game this_tp2_filename tp) m.mod_parts ;
+            List.iter (process_action_real our_lang game tp2_filename tp) m.mod_parts ;
             if !interactive then begin
               Mymarshal.write_readln readln_backup_filename (List.rev !readln_strings);
             end ;
@@ -885,7 +886,7 @@ let rec handle_tp game this_tp2_filename tp =
               log_and_print "\n%s%s%s\n"
                 (get_trans (-1064)) ((Tpstate.subcomp_str game m) ^ package_name)
                 (get_trans (-1065)) ;
-              rollback_component game tp this_tp2_filename
+              rollback_component game tp tp2_filename
                 strset_backup_filename tlkpath_backup_filename
                 our_lang_index i m ;
               finished := true ;
@@ -903,7 +904,7 @@ let rec handle_tp game this_tp2_filename tp =
                 ((get_trans (-1017)))
                 ((Tpstate.subcomp_str game m) ^ package_name)
                 ((get_trans (-1018))) ;
-              rollback_component game tp this_tp2_filename
+              rollback_component game tp tp2_filename
                 strset_backup_filename tlkpath_backup_filename
                 our_lang_index i m ;
               raise e
@@ -924,7 +925,7 @@ let rec handle_tp game this_tp2_filename tp =
           begin
             if List.find_all (fun x -> x = TPM_NotInLog) m.mod_flags = [] then
               the_log := !the_log @
-                [((String.uppercase this_tp2_filename),!our_lang_index,i,Some(package_name),Installed)]
+                [((String.uppercase tp2_filename),!our_lang_index,i,Some(package_name),Installed)]
             else (* log_and_print "NOT adding a WeiDU.log record. You cannot uninstall this.\n" *) ()
           end ;
           finished := true
@@ -942,7 +943,7 @@ let rec handle_tp game this_tp2_filename tp =
           ((get_trans (-1022)))
           i
           ((get_trans (-1023))) ;
-        (if not (uninstall game handle_tp2_filename this_tp2_filename i !interactive ) then
+        (if not (uninstall game handle_tp2_filename tp2_filename i !interactive ) then
           failwith "uninstallation error" );
         log_and_print "\n\n%s%s%s%d%s\n"
           (* "\n\nSUCCESSFULLY REMOVED [%s] (component #%d)\n\n" *)

--- a/test/README
+++ b/test/README
@@ -25,3 +25,8 @@ traify/*
 
 tp2/tp2_regression_tests/*
         A collection of tests for TP2 functionality. Install as a WeiDU mod.
+
+tp2/issue-288-temporary-reinstall/run.sh
+        Verifies that stack uninstallation does not restore a component after
+        its REQUIRE_COMPONENT prerequisite has been permanently uninstalled.
+        Pass the path to a built WeiDU executable as the only argument.

--- a/test/tp2/issue-288-temporary-reinstall/dependent.tp2
+++ b/test/tp2/issue-288-temporary-reinstall/dependent.tp2
@@ -1,0 +1,7 @@
+BACKUP ~issue-288-dependent/backup~
+AUTHOR ~WeiDU regression test~
+
+BEGIN ~Independent component~
+
+BEGIN ~Component requiring the prerequisite~
+  REQUIRE_COMPONENT ~prerequisite.tp2~ 0 ~Missing prerequisite component~

--- a/test/tp2/issue-288-temporary-reinstall/prerequisite.tp2
+++ b/test/tp2/issue-288-temporary-reinstall/prerequisite.tp2
@@ -1,0 +1,6 @@
+BACKUP ~issue-288-prerequisite/backup~
+AUTHOR ~WeiDU regression test~
+
+BEGIN ~Prerequisite component~
+
+BEGIN ~Later independent component~

--- a/test/tp2/issue-288-temporary-reinstall/run.sh
+++ b/test/tp2/issue-288-temporary-reinstall/run.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [[ $# -ne 1 ]]; then
+  echo "usage: $0 /path/to/weidu" >&2
+  exit 2
+fi
+
+weidu=$(realpath "$1")
+fixture_dir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+test_dir=$(mktemp -d)
+trap 'rm -rf -- "$test_dir"' EXIT
+
+cp "$fixture_dir/prerequisite.tp2" "$test_dir/prerequisite.tp2"
+cp "$fixture_dir/dependent.tp2" "$test_dir/dependent.tp2"
+cd "$test_dir"
+
+run_weidu() {
+  "$weidu" --nogame --noautoupdate --no-exit-pause "$@"
+}
+
+component_is_installed() {
+  local tp2=$1
+  local component=$2
+  grep -Eq "^~${tp2}~ #0 #${component}([[:space:]]|$)" WeiDU.log
+}
+
+fail_with_log() {
+  local message=$1
+  echo "$message" >&2
+  echo "Current WeiDU.log:" >&2
+  sed -n '1,200p' WeiDU.log >&2
+  exit 1
+}
+
+assert_installed() {
+  local tp2=$1
+  local component=$2
+  component_is_installed "$tp2" "$component" ||
+    fail_with_log "Expected ${tp2} component ${component} to be installed"
+}
+
+assert_not_installed() {
+  local tp2=$1
+  local component=$2
+  if component_is_installed "$tp2" "$component"; then
+    fail_with_log "Expected ${tp2} component ${component} not to be installed"
+  fi
+}
+
+run_weidu prerequisite.tp2 --force-install 0
+run_weidu dependent.tp2 --force-install 0
+run_weidu prerequisite.tp2 --force-install 1
+run_weidu dependent.tp2 --force-install 1
+
+assert_installed PREREQUISITE.TP2 0
+assert_installed DEPENDENT.TP2 0
+assert_installed PREREQUISITE.TP2 1
+assert_installed DEPENDENT.TP2 1
+
+run_weidu prerequisite.tp2 --force-uninstall 0
+
+assert_not_installed PREREQUISITE.TP2 0
+assert_installed DEPENDENT.TP2 0
+assert_installed PREREQUISITE.TP2 1
+assert_not_installed DEPENDENT.TP2 1


### PR DESCRIPTION
## Summary

Fix temporarily uninstalled components being restored even when their `REQUIRE_COMPONENT` prerequisites are no longer installed.

Components restored during stack uninstallation now consistently use the identity of their own TP2 file for installation, uninstallation, logging, rollback, and subgroup-state operations.

Fixes #288.

## Root cause

`handle_letter_inner` receives the parsed TP2 corresponding to the component being processed, but previously continued to use `this_tp2_filename` captured from the outer `handle_tp` invocation.

These normally identify the same TP2. During restoration of temporarily uninstalled components, however, WeiDU may process components from several different TP2 files while still inside the original invocation.

For example, while permanently uninstalling `prerequisite.tp2` component 0:

1. `dependent.tp2` component 0 is temporarily uninstalled;
2. WeiDU restores that component using the parsed `dependent.tp2`;
3. the shared installation path nevertheless records it under the outer `prerequisite.tp2` filename;
4. this creates a false installed entry for `prerequisite.tp2` component 0;
5. a later `dependent.tp2` component with:

   ```text
   REQUIRE_COMPONENT ~prerequisite.tp2~ 0
   ```

   sees the false entry and is incorrectly restored.

This also explains why the issue depended on the affected component's position in the restoration order.

## Changes

- derive the active TP2 filename from `tp.tp_filename` inside the shared component-processing path;
- use that filename consistently for:
  - subgroup installation-state checks;
  - component uninstallation;
  - built-in, `ALWAYS`, and component action processing;
  - safe-exit log entries;
  - rollback handling;
  - final installation log entries;
- add a no-game regression test reproducing the interleaved installation order from issue #288;
- verify that independent components are restored while the component whose prerequisite was removed remains permanently uninstalled;
- document the regression test in `test/README`;
- update the version 251 change log.

## Regression coverage

The test installs components in this order:

```text
prerequisite.tp2 component 0
dependent.tp2 component 0
prerequisite.tp2 component 1
dependent.tp2 component 1 requiring prerequisite.tp2 component 0
```

It then permanently uninstalls `prerequisite.tp2` component 0 and verifies that:

- `prerequisite.tp2` component 0 is not installed;
- `dependent.tp2` component 0 is restored;
- `prerequisite.tp2` component 1 is restored;
- `dependent.tp2` component 1 is not restored because its requirement is no longer met.

## Validation

### Before the fix

The disposable workflow successfully configured the toolchain and built WeiDU, after which the regression test failed with:

```text
Expected DEPENDENT.TP2 component 1 not to be installed
```

The resulting log incorrectly contained:

```text
~DEPENDENT.TP2~ #0 #1 // Component requiring the prerequisite
```

Expected-failure baseline:

https://github.com/4Luke4/weidu/actions/runs/30810596493

### After the fix

The isolated validation workflow completed successfully:

https://github.com/4Luke4/weidu/actions/runs/30811154654

Successful steps:

```text
checkout
fetch Elkhound
set up archived OCaml 4.08.1 unsafe-string compiler
build WeiDU
run the issue #288 regression scenario
```

The final state contained:

```text
PREREQUISITE.TP2 component 0 Permanently_Uninstalled
DEPENDENT.TP2 component 0 Installed
PREREQUISITE.TP2 component 1 Installed
DEPENDENT.TP2 component 1 Permanently_Uninstalled
```

The temporary validation branch incorporated the unrelated CI corrections from PR #381 and PR #382 so those known Linux setup and Windows compilation failures could not be mistaken for regressions caused by this change.

The final feature branch contains neither those unrelated changes nor the disposable workflow. It is exactly one commit ahead of `devel`.