### PR TITLE
Fix autoupdate to prefer the latest stable WeiDU version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,9 +23,12 @@
 include Configuration
 
 # Just a target to be used by default
-.PHONY: weidu doc all
+.PHONY: weidu doc all test-autoupdate-versions
 all : weidu
 # "make weinstall" if you want weinstall
+
+test-autoupdate-versions:
+	cd test && $(OCAMLDIR)/ocaml -noinit autoupdate-versions.ml
 
 ####
 #### OCAML stuff

--- a/Makefile.ocaml
+++ b/Makefile.ocaml
@@ -344,8 +344,10 @@ $(DEPENDDIR)/%.di: %.mli
 ifneq ($(MAKECMDGOALS),clean)
 ifneq ($(MAKECMDGOALS),doc)
 ifneq ($(MAKECMDGOALS),src_zip)
+ifneq ($(MAKECMDGOALS),test-autoupdate-versions)
 -include $(MODULES:%=$(DEPENDDIR)/%.d)
 -include $(MODULES:%=$(DEPENDDIR)/%.di)
+endif
 endif
 endif
 endif

--- a/src/autoupdate.ml
+++ b/src/autoupdate.ml
@@ -59,23 +59,20 @@ let verify_latest can_spawn = begin
   let this,ext = try split_resref argv_0 with _ -> argv_0,"" in
   let my_real_name = this^(if ext = "" then "" else ".exe") in
 
-  (* head of list is newest element *)
-
-  if (List.length sorted) > 1 then begin
-
-    let newest,newest_t = List.hd sorted in
-    let oldest,oldest_t = List.hd (List.rev sorted) in
-
-    if (newest_t <> oldest_t) then begin
+  match latest_stable_version (List.map snd sorted) with
+  | Some newest_t when List.exists (fun (_, version) ->
+      is_outdated ~latest:newest_t version) sorted ->
+      let newest = fst (List.find (fun (_, version) ->
+        version = newest_t) sorted) in
       (* out-of-synch: time to do updates *)
-      log_and_print "Newest WeiDU is version %d, updating!\n" newest_t ;
+      log_and_print "Newest stable WeiDU is version %d, updating!\n" newest_t ;
       log_and_print "WeiDU files in version order:\n" ;
       List.iter (fun (f,v) -> log_and_print "  [%s] version %d\n" f v ) sorted ;
 
       let newest_buff = load_file newest in
 
       List.iter (fun (target,target_t) ->
-        if (target <> this) && (target_t <> newest_t) then begin
+        if (target <> this) && is_outdated ~latest:newest_t target_t then begin
           (* log_and_print "\tUnlinking [%s]: " target ;        *)
           let unlink_worked = (try Case_ins.unix_unlink target ; true
           with _ -> false) in
@@ -93,16 +90,10 @@ let verify_latest can_spawn = begin
         end
                 ) sorted ;
 
-      if newest_t <> (int_of_string version) then begin
-        let not_this = Case_ins.filename_basename
-            (let file,time = (List.find (fun (f,v) -> f <> this) sorted) in
-            file)
-        in
+      if is_outdated ~latest:newest_t (int_of_string version) then begin
+        let not_this = Case_ins.filename_basename newest in
 
         Sys.argv.(0) <- (Printf.sprintf "\"%s\"" not_this) ;
-
-        let cmd = Array.fold_left (fun acc elt -> acc ^ " " ^ elt)
-            Sys.argv.(0) (Array.sub Sys.argv 1 ((Array.length Sys.argv)-1)) in
 
         let env =
           Array.append [|Printf.sprintf "weiduautoupdate=%s" my_real_name ;
@@ -117,8 +108,8 @@ let verify_latest can_spawn = begin
           exit (return_value StatusSuccess) ;
         end
       end
-    end ;
-  end
+  | Some _
+  | None -> ()
 end
 
 let self () =

--- a/src/version.ml
+++ b/src/version.ml
@@ -24,6 +24,20 @@ let release_type version =
   | 1 -> Development
   | v when v > 1 -> Release_Candidate)
 
+let latest_stable_version versions =
+  List.fold_left (fun latest candidate ->
+    match release_type (string_of_int candidate) with
+    | Stable ->
+        (match latest with
+        | Some current when current >= candidate -> latest
+        | _ -> Some candidate)
+    | Release_Candidate
+    | Development -> latest)
+    None versions
+
+let is_outdated ~latest version =
+  version < latest
+
 (* Historical Comments: *)
 (* 7 let comment = "Underdark Army Knife" *)
 (* 8 let comment = "Meta-Circular Evaluator" *)

--- a/test/autoupdate-versions.ml
+++ b/test/autoupdate-versions.ml
@@ -1,0 +1,38 @@
+#mod_use "../batteries-lite/batList.ml";;
+#mod_use "../hashtbl-4.03.0/myhashtbl.ml";;
+#mod_use "../batteries-lite/batteriesInit.ml";;
+#mod_use "../hashtbl-4.03.0/hashtblinit.ml";;
+#mod_use "../src/version.ml";;
+
+let fail label expected actual =
+  Printf.eprintf "%s: expected %s, got %s\n" label expected actual;
+  exit 1
+
+let string_of_version = function
+  | Some version -> string_of_int version
+  | None -> "none"
+
+let expect_source label expected versions =
+  let actual = Version.latest_stable_version versions in
+  if actual <> expected then
+    fail label (string_of_version expected) (string_of_version actual)
+
+let expect_outdated label expected ~latest versions =
+  let actual = List.filter (Version.is_outdated ~latest) versions in
+  if actual <> expected then
+    fail label
+      (String.concat "," (List.map string_of_int expected))
+      (String.concat "," (List.map string_of_int actual))
+
+let () =
+  expect_source "stable beats a numerically newer release candidate"
+    (Some 25100) [24900; 25100; 25106];
+  expect_source "selection is independent of discovery order"
+    (Some 25100) [25106; 24900; 25100];
+  expect_source "the highest stable version is selected"
+    (Some 25200) [25201; 25100; 25200; 25206];
+  expect_source "a development version is not a stable source"
+    None [25101; 25106];
+  expect_outdated "only versions older than the stable source are replaced"
+    [24900] ~latest:25100 [24900; 25100; 25101; 25106];
+  print_endline "Autoupdate version-selection tests passed"


### PR DESCRIPTION
## Summary

Fix autoupdate so that prerelease and development binaries are never selected as the source for automatic updates.

When versions `24900`, `25100`, and `25106` are present, autoupdate now updates `24900` from stable version `25100` and leaves prerelease version `25106` untouched.

Fixes #345.

## Root cause

`Autoupdate.get_version_list` sorted all detected WeiDU binaries by their raw integer version. `verify_latest` then treated the first entry as the newest release.

Under WeiDU's version scheme:

- a patchlevel ending in `00` is stable;
- a patchlevel ending in `01` is a development version;
- higher patchlevels are release candidates.

Consequently, raw numeric ordering incorrectly placed a version such as `25106` ahead of stable version `25100` and propagated the release candidate to older setup executables.

The restart path used the same ordering to choose a replacement executable, so it could also execute the prerelease binary after copying files.

## Changes

- add a version-selection helper that derives stability from `Version.release_type`;
- select the numerically highest stable version as the autoupdate source;
- update only binaries whose versions are strictly older than that stable source;
- leave numerically newer prerelease and development binaries untouched rather than downgrading or propagating them;
- restart through the exact stable source selected for the update;
- clarify the update message by identifying the selected version as stable;
- remove the obsolete command-string construction from the restart path;
- add a standalone `test-autoupdate-versions` Make target;
- prevent that standalone target from regenerating unrelated project dependency files.

## Resulting behavior

| Detected versions | Selected stable source | Versions replaced |
|---|---:|---|
| `24900`, `25100`, `25106` | `25100` | `24900` |
| `25106`, `24900`, `25100` | `25100` | `24900` |
| `25100`, `25200`, `25201`, `25206` | `25200` | versions older than `25200` |
| `25101`, `25106` | none | none |

Selection is independent of filesystem discovery order.

## Tests

Added regression coverage for:

- a stable release taking precedence over a numerically higher release candidate;
- discovery-order independence;
- selection of the highest stable release;
- refusal to use development or release-candidate versions when no stable source exists;
- replacement of only versions strictly older than the selected stable release.

## Validation

A disposable GitHub Actions workflow validated the change on `ubuntu-22.04` with the project’s intended OCaml 4.08.1 unsafe-string toolchain.

Successful run:

https://github.com/4Luke4/weidu/actions/runs/30814929508

Successful job:

https://github.com/4Luke4/weidu/actions/runs/30814929508/job/91690203308

The workflow verified:

```text
OCaml 4.08.1 archived compiler setup: passed
autoupdate version-selection regressions: passed
full WeiDU compilation and linking: passed
compiled executable smoke test: passed
reported version: 25201
```

To avoid unrelated failures already addressed by open PRs, the disposable CI tip temporarily included the exact compatibility changes from:

- #381 for archived OCaml 4.08.1 resolution;
- #382 for current MinGW Win32 API typing.

Those compatibility changes and the temporary workflow were removed from the branch history after validation.

The final branch is exactly one commit ahead of `devel` and changes only:

```text
Makefile
Makefile.ocaml
src/autoupdate.ml
src/version.ml
test/autoupdate-versions.ml
```