### PR TITLE
Fix uninstall-time ACTION_IF evaluation context

### DIFF
--- a/src/tp.ml
+++ b/src/tp.ml
@@ -614,3 +614,18 @@ let the_tp () = match !saved_tp with
 	is_auto_eval_string = false;
 }
 | Some x -> x
+
+(* Evaluation helpers consult [the_tp] for TP2-specific behavior such as
+ * AUTO_EVAL_STRINGS. Preserve the previous value so nested operations (most
+ * notably stack uninstalls) can temporarily select their own TP2 without
+ * corrupting the caller's evaluation context. *)
+let with_tp_context tp f =
+  let previous_tp = !saved_tp in
+  saved_tp := Some tp ;
+  try
+    let result = f () in
+    saved_tp := previous_tp ;
+    result
+  with e ->
+    saved_tp := previous_tp ;
+    raise e

--- a/src/tpuninstall.ml
+++ b/src/tpuninstall.ml
@@ -93,6 +93,20 @@ let record_tlk_path_info game filename =
  * Uninstall a TP2 component
  ************************************************************************)
 let handle_at_uninstall tp2 m do_uninstall do_interactive_uninstall game =
+  let rec has_uninstall_effect al =
+    List.exists (fun action ->
+      match action with
+      | TP_At_Interactive_Uninstall _
+      | TP_At_Interactive_Uninstall_Exit _ -> do_interactive_uninstall
+      | TP_At_Uninstall _
+      | TP_At_Uninstall_Exit _ -> do_uninstall
+      | TP_Biff _
+      | TP_Include _
+      | TP_Reinclude _ -> true
+      | TP_If(_, al1, al2) ->
+          has_uninstall_effect al1 || has_uninstall_effect al2
+      | _ -> false) al
+  in
   let rec handle_al al =
     List.iter (fun a ->
       match a with
@@ -135,17 +149,19 @@ let handle_at_uninstall tp2 m do_uninstall do_interactive_uninstall game =
                 execute_at_exit := (Command(str,exact)) :: !execute_at_exit
           end
       | TP_If(p,al1,al2) ->
-          begin try
+          if has_uninstall_effect al1 || has_uninstall_effect al2 then begin
+            let previous_eval_pe_warn = !eval_pe_warn in
             eval_pe_warn := false ;
-            let res = is_true (eval_pe "" game p) in
-            (* log_or_print "IF evaluates to %b\n" res ; *)
-            if res then begin
-              handle_al al1
-            end else begin
-              handle_al al2
-            end
-          with _ -> () ;
-            eval_pe_warn := true ;
+            (try
+              let res = is_true (eval_pe "" game p) in
+              (* log_or_print "IF evaluates to %b\n" res ; *)
+              if res then begin
+                handle_al al1
+              end else begin
+                handle_al al2
+              end
+            with _ -> ()) ;
+            eval_pe_warn := previous_eval_pe_warn
           end
       | TP_Biff _ ->
           (* re-load the chitin *)
@@ -202,8 +218,9 @@ let handle_at_uninstall tp2 m do_uninstall do_interactive_uninstall game =
       | _ -> ()
               ) fl
   in
-  handle_flag tp2.flags ;
-  handle_al m.mod_parts
+  with_tp_context tp2 (fun () ->
+    handle_flag tp2.flags ;
+    handle_al m.mod_parts)
 
 let validate_uninstall_order tp2 =
   let order = Queue.create() in

--- a/src/tpwork.ml
+++ b/src/tpwork.ml
@@ -956,14 +956,9 @@ let rec handle_tp game this_tp2_filename tp =
   in
 
   let handle_letter tp answer can_uninstall temp_uninst package_name m finished i =
-    saved_tp := Some tp;
-    try
-      let ans = handle_letter_inner tp answer can_uninstall temp_uninst package_name m finished i in
-      saved_tp := None;
-      ans
-    with e ->
-      saved_tp := None;
-      raise e
+    with_tp_context tp (fun () ->
+      handle_letter_inner tp answer can_uninstall temp_uninst package_name
+        m finished i)
   in
 
   let specify = ref false in

--- a/test/README
+++ b/test/README
@@ -25,3 +25,7 @@ traify/*
 
 tp2/tp2_regression_tests/*
         A collection of tests for TP2 functionality. Install as a WeiDU mod.
+
+tp2/uninstall_action_if_context/run.sh
+        Verifies that stack uninstalls skip installation-only ACTION_IF
+        predicates while still evaluating guarded AT_UNINSTALL actions.

--- a/test/tp2/uninstall_action_if_context/inner.tp2
+++ b/test/tp2/uninstall_action_if_context/inner.tp2
@@ -1,0 +1,20 @@
+BACKUP ~uninstall_action_if_context/inner-backup~
+AUTHOR ~WeiDU regression tests~
+
+ALWAYS
+  // This installation-only predicate has no uninstall-time behavior and
+  // depends on state that is intentionally not reconstructed on uninstall.
+  OUTER_SPRINT target_game ~BG1~
+  ACTION_IF GAME_INCLUDES ~%target_game%~ BEGIN
+    PRINT ~The null test game unexpectedly includes BG1.~
+  END
+
+  // A predicate that selects uninstall-time behavior must still be evaluated.
+  ACTION_IF GAME_INCLUDES ~BG1~ BEGIN
+    AT_UNINSTALL ~touch wrong-branch-ran~ EXACT
+  END ELSE BEGIN
+    AT_UNINSTALL ~touch uninstall-branch-ran~ EXACT
+  END
+END
+
+BEGIN ~Inner component~

--- a/test/tp2/uninstall_action_if_context/outer.tp2
+++ b/test/tp2/uninstall_action_if_context/outer.tp2
@@ -1,0 +1,4 @@
+BACKUP ~uninstall_action_if_context/outer-backup~
+AUTHOR ~WeiDU regression tests~
+
+BEGIN ~Outer component~

--- a/test/tp2/uninstall_action_if_context/run.sh
+++ b/test/tp2/uninstall_action_if_context/run.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+script_dir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+repo_root=$(cd -- "$script_dir/../../.." && pwd)
+weidu=${1:-"$repo_root/weidu"}
+
+if [[ ! -x "$weidu" ]]; then
+  echo "WeiDU executable is not available at $weidu" >&2
+  exit 1
+fi
+
+weidu=$(cd -- "$(dirname -- "$weidu")" && pwd)/$(basename -- "$weidu")
+work_dir=$(mktemp -d)
+
+cleanup() {
+  if [[ -n "${work_dir:-}" && -d "$work_dir" ]]; then
+    rm -rf -- "$work_dir"
+  fi
+}
+trap cleanup EXIT HUP INT TERM
+
+cp -- "$script_dir/outer.tp2" "$script_dir/inner.tp2" "$work_dir/"
+cd -- "$work_dir"
+
+common_args=(--nogame --noautoupdate --no-exit-pause)
+
+"$weidu" outer.tp2 "${common_args[@]}" --force-install 0 \
+  --log outer-install.log
+"$weidu" inner.tp2 "${common_args[@]}" --force-install 0 \
+  --log inner-install.log
+"$weidu" outer.tp2 "${common_args[@]}" --force-uninstall 0 \
+  --log outer-uninstall.log
+
+# Removing the older component must temporarily uninstall the newer one.
+grep -Fq "[INNER.TP2] component 0" outer-uninstall.log
+
+if [[ ! -f uninstall-branch-ran || -e wrong-branch-ran ]]; then
+  echo "Stack uninstall did not select the expected guarded AT_UNINSTALL" >&2
+  exit 1
+fi
+
+if grep -Fq "GAME_INCLUDES has no rule for %TARGET_GAME%" \
+    outer-uninstall.log; then
+  echo "Stack uninstall evaluated an installation-only ACTION_IF" >&2
+  exit 1
+fi


### PR DESCRIPTION
## Summary

Fix uninstall-time handling of top-level `ACTION_IF` expressions so that WeiDU does not evaluate installation-only predicates while searching for uninstall actions.

The change also ensures that predicates which genuinely guard uninstall-time behavior are evaluated using the correct TP2 context, including during stack uninstalls.

Fixes #295.

## Root cause

`Tpuninstall.handle_at_uninstall` recursively inspected TP2 actions to locate:

- `AT_UNINSTALL`;
- `AT_INTERACTIVE_UNINSTALL`;
- their corresponding `AT_*_EXIT` variants;
- uninstall-relevant `BIFF`, `INCLUDE`, and `REINCLUDE` actions.

While doing so, it evaluated every encountered `TP_If` predicate, even when neither branch contained any uninstall-time behavior.

Ordinary TP2 setup actions are intentionally not replayed during uninstallation. Consequently, an installation-only predicate could reference variables established earlier during installation but unavailable in the uninstall process.

For example:

```tp2
OUTER_SPRINT target_game ~BG1~

ACTION_IF GAME_INCLUDES ~%target_game%~ BEGIN
  // Installation-only actions
END
```

The uninstall walker previously evaluated this predicate despite having no reason to enter either branch, producing warnings such as:

```text
WARNING: GAME_INCLUDES has no rule for %TARGET_GAME%
WARNING: No rule to identify %TARGET_GAME%
```

A related context problem existed during stack uninstalls: while uninstalling a later component on behalf of an earlier one, evaluation helpers could observe the initiating TP2 through `Tp.saved_tp` rather than the TP2 currently being inspected.

Finally, the predicate evaluator did not reliably restore the previous `eval_pe_warn` state after evaluation.

## Changes

- Add recursive uninstall-effect detection for action lists.
- Evaluate a `TP_If` predicate only when at least one branch can reach behavior handled during uninstallation.
- Recognize nested conditionals recursively.
- Treat `INCLUDE` and `REINCLUDE` conservatively as uninstall-relevant because their loaded action lists may contain uninstall actions.
- Respect the distinction between normal and interactive uninstall actions.
- Add an exception-safe `with_tp_context` helper which:
  - temporarily selects the TP2 being evaluated;
  - preserves nested caller contexts;
  - restores the previous context after success or failure.
- Use the helper for normal component handling and uninstall-action traversal.
- Restore the previous `eval_pe_warn` value after conditional evaluation.
- Add an end-to-end stack-uninstall regression test.

## Behavioral impact

Installation-only top-level predicates are no longer evaluated during uninstallation merely because WeiDU is searching their branches for uninstall actions.

Predicates that actually guard uninstall-time behavior continue to be evaluated, and only the selected branch is traversed.

Existing handling of `AT_UNINSTALL`, interactive uninstall actions, exit actions, `BIFF`, `INCLUDE`, and `REINCLUDE` is preserved.

## Regression coverage

The new regression:

1. installs an outer component;
2. installs a later inner component;
3. uninstalls the outer component, forcing a stack uninstall of the inner component;
4. verifies that an installation-only `GAME_INCLUDES ~%target_game%~` predicate is not evaluated;
5. verifies that a separate predicate guarding `AT_UNINSTALL` is still evaluated;
6. verifies that the expected uninstall branch executes and the opposite branch does not.

## Validation

A temporary disposable GitHub Actions workflow built WeiDU on `ubuntu-22.04` using the archived OCaml 4.08.1 configuration established by #381:

```yaml
ocaml-compiler: ocaml-variants.4.08.1+default-unsafe-string
opam-repositories: |
  default: git+https://github.com/ocaml/opam-repository.git
  archive: git+https://github.com/ocaml/opam-repository-archive.git
```

### Baseline reproduction

Workflow run:

https://github.com/4Luke4/weidu/actions/runs/31506658409

Results:

- OCaml setup: passed
- complete WeiDU build: passed
- guarded `AT_UNINSTALL` positive control: passed
- regression: failed as expected

Observed output:

```text
WARNING: GAME_INCLUDES has no rule for %TARGET_GAME%
WARNING: No rule to identify %TARGET_GAME%
Stack uninstall evaluated an installation-only ACTION_IF
```

### Patched validation

Workflow run:

https://github.com/4Luke4/weidu/actions/runs/31506958294

Results:

- OCaml setup: passed
- complete WeiDU build: passed
- stack uninstall: passed
- guarded `AT_UNINSTALL` branch selection: passed
- installation-only predicate pruning: passed
- workflow cleanup: passed

The disposable workflow was removed completely from the final branch history.

The focused Linux workflow deliberately used the correction from #381.