### PR TITLE
Add opt-in PCRE2 regular expression support

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -26,3 +26,5 @@
 *.txt text eol=lf
 *.yaml text eol=lf
 *.yml text eol=lf
+pcre2/version text eol=lf
+pcre2/sources.list text eol=lf

--- a/.github/actions/prepare-pcre2/action.yml
+++ b/.github/actions/prepare-pcre2/action.yml
@@ -1,0 +1,24 @@
+name: Prepare PCRE2
+description: Check out and verify the pinned PCRE2 sources used by WeiDU
+
+runs:
+  using: composite
+  steps:
+    - name: Read pinned PCRE2 revision
+      id: metadata
+      shell: bash
+      run: |
+        . pcre2/version
+        echo "repository=$PCRE2_GITHUB_REPOSITORY" >> "$GITHUB_OUTPUT"
+        echo "commit=$PCRE2_COMMIT" >> "$GITHUB_OUTPUT"
+    - name: Check out pinned PCRE2 revision
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ steps.metadata.outputs.repository }}
+        ref: ${{ steps.metadata.outputs.commit }}
+        path: _deps/pcre2-upstream
+        fetch-depth: 1
+        persist-credentials: false
+    - name: Materialize audited PCRE2 subset
+      shell: bash
+      run: scripts/prepare_pcre2.sh _deps/pcre2-upstream

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -18,6 +18,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@main
+      - uses: ./.github/actions/prepare-pcre2
       - name: fetch elkhound
         run: |
           mkdir -p bin
@@ -40,6 +41,8 @@ jobs:
           opam switch
           eval $(opam env)
           make
+          ./weidu.asm.exe --nogame --noautoupdate --force-install 0 \
+            test/pcre2-regexp/pcre2-regexp.tp2
           make osx_zip
       - uses: actions/upload-artifact@v6
         with:
@@ -51,6 +54,7 @@ jobs:
     steps:
       - name: Checkout the code
         uses: actions/checkout@main
+      - uses: ./.github/actions/prepare-pcre2
       - name: fetch elkhound
         run: |
           mkdir -p bin
@@ -69,6 +73,8 @@ jobs:
           opam switch
           eval $(opam env)
           make
+          ./weidu.asm.exe --nogame --noautoupdate --force-install 0 \
+            test/pcre2-regexp/pcre2-regexp.tp2
           make linux_zip
       - uses: actions/upload-artifact@v6
         with:
@@ -80,6 +86,7 @@ jobs:
     steps:
       - name: Checkout the code
         uses: actions/checkout@main
+      - uses: ./.github/actions/prepare-pcre2
       - name: fetch windows elkhound
         run: |
           curl -Lv https://github.com/The-Mod-Elephant/elkhound/releases/download/1.0.3/elkhound.exe -o elkhound.exe
@@ -95,6 +102,8 @@ jobs:
           opam switch
           (& opam env) -split '\r?\n' | ForEach-Object { Invoke-Expression $_ }
           make
+          .\weidu.asm.exe --nogame --noautoupdate --force-install 0 test/pcre2-regexp/pcre2-regexp.tp2
+          if ($LASTEXITCODE -ne 0) { throw 'PCRE2 regexp regression test failed' }
           make windows_zip
       - name: upload windows artifact
         uses: actions/upload-artifact@v6

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ diffs/*
 WeiDU-Linux
 WeiDU-Windows
 WeiDU-Mac
+_deps/

--- a/Depends
+++ b/Depends
@@ -2,7 +2,7 @@
 # First stuff that makes the executable
 # to add later:
 WEIDU_BASE_MODULES := batList batteriesInit myhashtbl hashtblinit \
-	case_ins stats arch version parsing tph util modder var arch2 xor \
+	case_ins stats arch version parsing tph util pcre2 modder var arch2 xor \
 	key cbif biff tlk load cre \
 	ids idsparser idslexer idslexer2 \
 	bcs bcsparser bcslexer \

--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,7 @@
 ############################################################################
 
 include Configuration
+include pcre2/version
 
 # Just a target to be used by default
 .PHONY: weidu doc all
@@ -47,7 +48,14 @@ DEPENDDIR   := obj/.depend
 
 include Depends
 
-CAMLFLAGS      += -I zlib -I xdiff
+PCRE2_SOURCE_DIR   := _deps/pcre2-$(PCRE2_VERSION)
+PCRE2_SOURCE_STAMP := $(PCRE2_SOURCE_DIR)/.prepared
+
+CAMLFLAGS      += -I zlib -I xdiff \
+                  -ccopt -I$(PCRE2_SOURCE_DIR)/src \
+                  -ccopt -DHAVE_CONFIG_H \
+                  -ccopt -DPCRE2_STATIC \
+                  -ccopt -DPCRE2_CODE_UNIT_WIDTH=8
 
 # Now the rule to make WeiDU
 
@@ -61,6 +69,13 @@ endif
 PROJECT_CMODULES   += zlib adler32 inflate uncompr inftrees zutil inffast $(GLOB) xdiff
 PROJECT_CMODULES   += xemit xpatchi xutils xdiffi xprepare $(ARCH_C_FILES)
 PROJECT_CMODULES   += crc32 compress deflate trees
+# sources.list is the audited transitive closure reached by WeiDU's binding.
+# Derive the modules from its prepared paths so a version update has one source
+# of truth and cannot silently compile a different set of translation units.
+PCRE2_CMODULES      = $(patsubst src/%.c,%,\
+                      $(filter src/%.c,\
+                      $(shell awk '!/^\#/ { print $$2 }' pcre2/sources.list)))
+PROJECT_CMODULES   += pcre2_stubs $(PCRE2_CMODULES)
 
 PROJECT_OCAML_LIBS = unix str #OCaml changed libstr into libcamlstr and "you are not supposed to link with -lstr"
 PROJECT_LIBS       = unix camlstr
@@ -163,6 +178,21 @@ clean:
 	src/toldlexer.mll src/tph.ml
 	find obj -type f -exec rm -f {} \; || true
 
+# Materialize the verified PCRE2 subset used by WeiDU. CI supplies a checkout
+# of the pinned upstream commit; local builds fetch that commit on first use.
+.PHONY: pcre2-source
+pcre2-source: $(PCRE2_SOURCE_STAMP)
+
+$(PCRE2_SOURCE_STAMP): pcre2/version pcre2/sources.list \
+                       scripts/prepare_pcre2.sh pcre2/LICENCE.md
+	PCRE2_UPSTREAM_DIR="$(PCRE2_UPSTREAM_DIR)" scripts/prepare_pcre2.sh
+
+PCRE2_OBJECTS = $(PCRE2_CMODULES:%=$(OBJDIR)/%.$(OBJEXT))
+$(PCRE2_OBJECTS): $(OBJDIR)/%.$(OBJEXT): $(PCRE2_SOURCE_STAMP)
+	@$(NARRATIVE) Compiling C file $(PCRE2_SOURCE_DIR)/src/$*.c
+	$(AT)$(CAMLC) -verbose $(CAMLFLAGS) -c $(PCRE2_SOURCE_DIR)/src/$*.c
+	$(AT)mv -f $*.$(OBJEXT) $(OBJDIR)
+
 
 ###
 ### Distro
@@ -186,6 +216,7 @@ windows_zip : weidu weinstall tolower
 	cp README* WeiDU-Windows
 	rm WeiDU-Windows/README.md
 	cp COPYING WeiDU-Windows
+	cp pcre2/LICENCE.md WeiDU-Windows/PCRE2-LICENCE.md
 	cp --preserve=all -r examples WeiDU-Windows
 	#cp windows_manifests/*.manifest WeiDU-Windows
 	zip -9r WeiDU-Windows-$(VER).zip WeiDU-Windows
@@ -205,6 +236,7 @@ linux_zip : weidu weinstall tolower
 	cp README* WeiDU-Linux
 	rm WeiDU-Linux/README.md
 	cp COPYING WeiDU-Linux
+	cp pcre2/LICENCE.md WeiDU-Linux/PCRE2-LICENCE.md
 	cp -r examples WeiDU-Linux
 	zip -9r WeiDU-Linux-$(VER).zip WeiDU-Linux
 osx_zip : weidu weinstall
@@ -218,6 +250,7 @@ osx_zip : weidu weinstall
 	cp README* WeiDU-Mac
 	rm WeiDU-Mac/README.md
 	cp COPYING WeiDU-Mac
+	cp pcre2/LICENCE.md WeiDU-Mac/PCRE2-LICENCE.md
 	cp -r examples WeiDU-Mac
 	#sed -e's/version_plist=.*/version_plist=\"${VERBIG}\"/g'  'WeiDU-Mac/WeiDU Installer.command' > t
 	#mv t WeiDU-Mac/WeiDU\ Installer.command

--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ can be obtained
 
 - Run make. Relevant build targets are
  * clean
+ * pcre2-source
  * weidu
  * weinstall
  * tolower
@@ -130,3 +131,9 @@ can be obtained
 The *_zip targets produce an archive in `..` that is suitable for
 distribution. If you are not developing WeiDU, you probably want one
 of windows_zip, linux_zip or osx_zip.
+
+The first WeiDU build fetches the exact PCRE2 revision recorded in
+`pcre2/version`, verifies it, and prepares only the source files required by
+WeiDU. The `pcre2-source` target performs this step explicitly. To build from
+an existing PCRE2 checkout without network access, set `PCRE2_UPSTREAM_DIR` to
+that checkout when invoking make.

--- a/doc/base.tex
+++ b/doc/base.tex
@@ -3093,6 +3093,11 @@ global option to your \ttref{TP2} file. \\
        in the game \ttref{BIFF}s will be copied there. Otherwise, toDirOrFile
        will be treated as a file.
 
+       Put \ttref{PCRE2_REGEXP} immediately after
+       \ttref{COPY_EXISTING_REGEXP} to use the opt-in PCRE2 dialect. In that
+       mode, destination captures use \verb+$1+ or \verb+${name}+ rather than
+       the legacy $\backslash$1 form.
+
 
        If \ttref{GLOB} is specified, matching files in \t{override} will
        also be patched and copied. If a file appears in both the
@@ -4239,6 +4244,9 @@ is  & & Uses the WeiDU default (which is undocumented and varies with the action
 or & \DEFINE{EXACT_MATCH} & only the given string is searched for. \\
 or & \DEFINE{EVALUATE_REGEXP} & matching is evaluated following the usual regexp
       conventions. \\
+or & \DEFINE{PCRE2_REGEXP} & where documented, opt in to the bundled PCRE2
+      regexp engine. Existing regexp syntax continues to use WeiDU's legacy
+      engine unless this keyword is present. \\
 
 \\
 
@@ -5193,6 +5201,10 @@ COPY ~nice.baf~ ~mean.baf~
   This \ttref{COPY} \ttref{TP2 Action} would replace \t{Give(10,20)}
   with \t{Take(15)}.  optcase allows you to decide if the matching is
   case-sensitive or not. Matching is case-sensitive by default.  \\
+
+  Insert \ttref{PCRE2_REGEXP} after \ttref{optcase} to use PCRE2 syntax.
+  Named captures are then available as \t{MATCH\_name}; see the regular
+  expression section for replacement syntax and exact capture semantics. \\
 
   or & \DEFINE{ADD_GAM_NPC} npcCRE npcARE xCoord yCoord &
     See the \ahrefloc{sec-add-gam-npc}{\t{ADD_GAM_NPC} tutorial} for more information about this
@@ -10755,6 +10767,61 @@ The following constructs are recognized:
 So spe.* matches "sper01.itm" and "sper.eff" and "special".
 
 Hopefully this is understandable to most people.
+
+\subsection{Opt-in PCRE2 regular expressions}
+
+WeiDU also bundles PCRE2 10.47 for regular expressions that explicitly use
+\DEFINE{PCRE2_REGEXP}. This is an opt-in dialect: omitting the keyword always
+retains the GNU Emacs-style syntax and behaviour described above. In
+particular, existing mod code is never reinterpreted as PCRE2.
+
+PCRE2 mode supports Perl-compatible constructs such as unescaped capture and
+non-capture groups, unescaped alternation, bounded and lazy quantifiers,
+lookahead and lookbehind, atomic groups, pattern backreferences and named
+captures. Refer to the PCRE2 pattern documentation for the complete syntax.
+
+\t{PCRE2_REGEXP} is accepted by the following operations:
+\begin{itemize}
+\item \ttref{REPLACE}, \ttref{REPLACE_TEXTUALLY},
+  \ttref{REPLACE_EVALUATE} and \ttref{COUNT_REGEXP_INSTANCES}, in the
+  \ttref{optexact} position;
+\item \ttref{INDEX}, \ttref{RINDEX}, \ttref{INDEX_BUFFER} and
+  \ttref{RINDEX_BUFFER}, in the \ttref{optexact} position;
+\item \ttref{STRING_MATCHES_REGEXP} and \ttref{STRING_CONTAINS_REGEXP},
+  between the operator and its right-hand pattern;
+\item \ttref{COPY_EXISTING_REGEXP}, immediately after the command name.
+\end{itemize}
+
+For example:
+\begin{verbatim}
+OUTER_PATCH_SAVE result ~Give(10) DestroyItem("gold")~ BEGIN
+  REPLACE_TEXTUALLY CASE_SENSITIVE PCRE2_REGEXP
+    ~Give\((?<amount>\d+)\)(?!\s*TakePartyItem)~
+    ~Take(${amount})~
+END
+
+ACTION_IF ~AR1005~ STRING_MATCHES_REGEXP PCRE2_REGEXP ~^AR\d{4}$~ BEGIN
+  // The comparison matched at offset zero.
+END
+\end{verbatim}
+
+PCRE2 replacement strings use \verb+$0+, \verb+$1+, and so on for numbered
+captures, \verb+${name}+ for named captures, and \verb+$$+ for a literal
+dollar sign. A capture that exists but did not participate expands to the
+empty string; referring to a capture that does not exist is an error.
+\ttref{COPY_EXISTING_REGEXP} uses the same replacement syntax in its
+destination argument when PCRE2 mode is selected.
+
+In PCRE2-mode \ttref{REPLACE_EVALUATE}, numbered captures are exposed as
+\t{MATCH0}, \t{MATCH1}, and so on, and named captures are additionally exposed
+as \t{MATCH_name}. Unmatched captures are set to the empty string. The whole
+match is \t{MATCH0}, as in legacy mode.
+
+WeiDU buffers are byte strings, so PCRE2 matching is byte-oriented by default.
+A pattern may explicitly enable PCRE2 UTF and Unicode-property modes when its
+input is known to be valid UTF-8. PCRE2's built-in match, depth and heap limits
+remain enabled, and JIT is not enabled in the bundled build, so all matching
+uses the bounded interpreter.
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \label{sec-constant}\section{WeiDU \DEFINE{constant}s}

--- a/pcre2/LICENCE.md
+++ b/pcre2/LICENCE.md
@@ -1,0 +1,104 @@
+PCRE2 Licence
+=============
+
+| SPDX-License-Identifier: | BSD-3-Clause WITH PCRE2-exception |
+|---------|-------|
+
+PCRE2 is a library of functions to support regular expressions whose syntax
+and semantics are as close as possible to those of the Perl 5 language.
+
+Releases 10.00 and above of PCRE2 are distributed under the terms of the "BSD"
+licence, as specified below, with one exemption for certain binary
+redistributions. The documentation for PCRE2, supplied in the "doc" directory,
+is distributed under the same terms as the software itself. The data in the
+testdata directory is not copyrighted and is in the public domain.
+
+The basic library functions are written in C and are freestanding. Also
+included in the distribution is a just-in-time compiler that can be used to
+optimize pattern matching. This is an optional feature that can be omitted when
+the library is built. The just-in-time compiler is separately licensed under the
+"2-clause BSD" licence.
+
+
+COPYRIGHT
+---------
+
+### The basic library functions
+
+    Written by:       Philip Hazel
+    Email local part: Philip.Hazel
+    Email domain:     gmail.com
+
+    Retired from University of Cambridge Computing Service,
+    Cambridge, England.
+
+    Copyright (c) 1997-2007 University of Cambridge
+    Copyright (c) 2007-2024 Philip Hazel
+    All rights reserved.
+
+### PCRE2 Just-In-Time compilation support
+
+    Written by:       Zoltan Herczeg
+    Email local part: hzmester
+    Email domain:     freemail.hu
+
+    Copyright (c) 2010-2024 Zoltan Herczeg
+    All rights reserved.
+
+### Stack-less Just-In-Time compiler
+
+    Written by:       Zoltan Herczeg
+    Email local part: hzmester
+    Email domain:     freemail.hu
+
+    Copyright (c) 2009-2024 Zoltan Herczeg
+    All rights reserved.
+
+The code in the `deps/sljit` directory has its own LICENSE file.
+
+### All other contributions
+
+Many other contributors have participated in the authorship of PCRE2. As PCRE2
+has never required a Contributor Licensing Agreement, or other copyright
+assignment agreement, all contributions have copyright retained by each
+original contributor or their employer.
+
+
+THE "BSD" LICENCE
+-----------------
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notices,
+  this list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright
+  notices, this list of conditions and the following disclaimer in the
+  documentation and/or other materials provided with the distribution.
+
+* Neither the name of the University of Cambridge nor the names of any
+  contributors may be used to endorse or promote products derived from this
+  software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.
+
+
+EXEMPTION FOR BINARY LIBRARY-LIKE PACKAGES
+------------------------------------------
+
+The second condition in the BSD licence (covering binary redistributions) does
+not apply all the way down a chain of software. If binary package A includes
+PCRE2, it must respect the condition, but if package B is software that
+includes package A, the condition is not imposed on package B unless it uses
+PCRE2 independently.

--- a/pcre2/README.md
+++ b/pcre2/README.md
@@ -1,0 +1,29 @@
+# Bundled PCRE2
+
+WeiDU statically links a deliberately limited 8-bit PCRE2 build. Upstream
+source is not copied into this repository. The build materializes a verified
+subset under `_deps/` from the release and commit recorded in [`version`](version).
+
+GitHub Actions performs this through the local `prepare-pcre2` composite action
+before each platform build. A local `make` performs the same preparation on
+first use; `make pcre2-source` may be run explicitly. Set `PCRE2_UPSTREAM_DIR`
+to an existing PCRE2 checkout to avoid the fetch.
+
+[`sources.list`](sources.list) is the audited transitive source closure used by
+WeiDU's binding. It excludes unrelated PCRE2 APIs such as DFA matching, JIT,
+pattern conversion, serialization, substitution, and substring helpers. The
+preparation script also enables only the 8-bit and Unicode configurations.
+
+To update PCRE2:
+
+1. Update the version, tag, and exact commit in [`version`](version), and any
+   user-facing version reference in the language documentation.
+2. Compare the binding's referenced symbols with the new release and update
+   [`sources.list`](sources.list) if the transitive closure changed; the
+   Makefile derives its C module list from this file.
+3. Update [`LICENCE.md`](LICENCE.md) if upstream changed it.
+4. Run all platform builds and the PCRE2 regexp regression suite.
+
+The source commit is checked before any file is copied, and the bundled licence
+is checked byte-for-byte against that commit. A version update therefore cannot
+silently use a different upstream tree.

--- a/pcre2/sources.list
+++ b/pcre2/sources.list
@@ -1,0 +1,32 @@
+# Source path in PCRE2 followed by its prepared path. This is the complete
+# transitive source/header closure required by WeiDU's PCRE2 binding.
+src/config.h.generic src/config.h
+src/pcre2.h.generic src/pcre2.h
+src/pcre2_chartables.c.dist src/pcre2_chartables.c
+src/pcre2_auto_possess.c src/pcre2_auto_possess.c
+src/pcre2_chkdint.c src/pcre2_chkdint.c
+src/pcre2_compile.c src/pcre2_compile.c
+src/pcre2_compile.h src/pcre2_compile.h
+src/pcre2_compile_cgroup.c src/pcre2_compile_cgroup.c
+src/pcre2_compile_class.c src/pcre2_compile_class.c
+src/pcre2_context.c src/pcre2_context.c
+src/pcre2_error.c src/pcre2_error.c
+src/pcre2_extuni.c src/pcre2_extuni.c
+src/pcre2_find_bracket.c src/pcre2_find_bracket.c
+src/pcre2_internal.h src/pcre2_internal.h
+src/pcre2_intmodedep.h src/pcre2_intmodedep.h
+src/pcre2_match.c src/pcre2_match.c
+src/pcre2_match_data.c src/pcre2_match_data.c
+src/pcre2_newline.c src/pcre2_newline.c
+src/pcre2_ord2utf.c src/pcre2_ord2utf.c
+src/pcre2_pattern_info.c src/pcre2_pattern_info.c
+src/pcre2_script_run.c src/pcre2_script_run.c
+src/pcre2_string_utils.c src/pcre2_string_utils.c
+src/pcre2_study.c src/pcre2_study.c
+src/pcre2_tables.c src/pcre2_tables.c
+src/pcre2_ucd.c src/pcre2_ucd.c
+src/pcre2_ucp.h src/pcre2_ucp.h
+src/pcre2_ucptables_inc.h src/pcre2_ucptables_inc.h
+src/pcre2_util.h src/pcre2_util.h
+src/pcre2_valid_utf.c src/pcre2_valid_utf.c
+src/pcre2_xclass.c src/pcre2_xclass.c

--- a/pcre2/version
+++ b/pcre2/version
@@ -1,0 +1,6 @@
+# Single source of truth for local and CI dependency preparation.
+PCRE2_VERSION=10.47
+PCRE2_TAG=pcre2-10.47
+PCRE2_COMMIT=f454e231fe5006dd7ff8f4693fd2b8eb94333429
+PCRE2_GITHUB_REPOSITORY=PCRE2Project/pcre2
+PCRE2_REPOSITORY=https://github.com/PCRE2Project/pcre2.git

--- a/scripts/prepare_pcre2.sh
+++ b/scripts/prepare_pcre2.sh
@@ -1,0 +1,136 @@
+#!/bin/sh
+
+# Materialize the audited PCRE2 source subset used by WeiDU. The same script is
+# called by GitHub Actions and local builds so dependency preparation cannot
+# drift between release and developer environments.
+set -eu
+
+script_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+repo_root=$(CDPATH= cd -- "$script_dir/.." && pwd)
+
+# This file deliberately uses syntax understood by both POSIX sh and GNU Make.
+# shellcheck source=../pcre2/version
+. "$repo_root/pcre2/version"
+
+deps_dir="$repo_root/_deps"
+source_dir="$deps_dir/pcre2-$PCRE2_VERSION"
+stamp="$source_dir/.prepared"
+upstream_dir=${PCRE2_UPSTREAM_DIR:-${1:-}}
+temporary_upstream=
+stage=
+
+# Include every repository-controlled preparation input in the stamp. Merely
+# matching the upstream commit is insufficient when the audited subset or the
+# generated configuration changes without a PCRE2 version bump.
+input_checksum=$(
+  CDPATH= cd -- "$repo_root"
+  cksum pcre2/version pcre2/sources.list pcre2/LICENCE.md \
+    scripts/prepare_pcre2.sh |
+    cksum | awk '{ print $1 ":" $2 }'
+)
+expected_stamp="$PCRE2_COMMIT:$input_checksum"
+
+cleanup()
+{
+  if test -n "$stage" && test -d "$stage"; then
+    rm -rf -- "$stage"
+  fi
+  if test -n "$temporary_upstream" && test -d "$temporary_upstream"; then
+    rm -rf -- "$temporary_upstream"
+  fi
+}
+trap cleanup EXIT HUP INT TERM
+
+if test -f "$stamp" && test "$(sed -n '1p' "$stamp")" = "$expected_stamp"; then
+  exit 0
+fi
+
+mkdir -p "$deps_dir"
+
+if test -z "$upstream_dir"; then
+  temporary_upstream=$(mktemp -d "$deps_dir/.pcre2-upstream.XXXXXX")
+  upstream_dir=$temporary_upstream
+  git -C "$upstream_dir" init --quiet
+  git -C "$upstream_dir" remote add origin "$PCRE2_REPOSITORY"
+  git -C "$upstream_dir" fetch --quiet --depth=1 origin "$PCRE2_COMMIT"
+  git -C "$upstream_dir" checkout --quiet --detach FETCH_HEAD
+fi
+
+actual_commit=$(git -C "$upstream_dir" rev-parse HEAD^{commit})
+if test "$actual_commit" != "$PCRE2_COMMIT"; then
+  echo "PCRE2 checkout is $actual_commit; expected $PCRE2_COMMIT ($PCRE2_TAG)" >&2
+  exit 1
+fi
+
+if test "$PCRE2_TAG" != "pcre2-$PCRE2_VERSION"; then
+  echo "PCRE2 tag $PCRE2_TAG does not agree with version $PCRE2_VERSION" >&2
+  exit 1
+fi
+
+# Compare committed blobs rather than checkout bytes: Git for Windows may
+# materialize upstream Markdown with CRLF even though both repositories store
+# the same LF-normalized licence object.
+upstream_licence=$(git -C "$upstream_dir" rev-parse HEAD:LICENCE.md)
+bundled_licence=$(git -C "$repo_root" rev-parse HEAD:pcre2/LICENCE.md)
+if test "$upstream_licence" != "$bundled_licence"; then
+  echo "pcre2/LICENCE.md does not match PCRE2 $PCRE2_TAG" >&2
+  exit 1
+fi
+
+stage=$(mktemp -d "$deps_dir/.pcre2-$PCRE2_VERSION.XXXXXX")
+while read -r upstream_path prepared_path extra; do
+  case "$upstream_path" in
+    ''|'#'*) continue ;;
+  esac
+  if test -n "${extra:-}"; then
+    echo "Invalid entry in pcre2/sources.list: $upstream_path $prepared_path $extra" >&2
+    exit 1
+  fi
+  case "$upstream_path:$prepared_path" in
+    src/*:src/*) ;;
+    *) echo "Unsafe entry in pcre2/sources.list: $upstream_path $prepared_path" >&2; exit 1 ;;
+  esac
+  if test ! -f "$upstream_dir/$upstream_path"; then
+    echo "PCRE2 source is missing $upstream_path" >&2
+    exit 1
+  fi
+  mkdir -p "$stage/$(dirname -- "$prepared_path")"
+  cp "$upstream_dir/$upstream_path" "$stage/$prepared_path"
+done < "$repo_root/pcre2/sources.list"
+
+# PCRE2's generic configuration is intentionally changed in only these two
+# places: WeiDU builds the 8-bit library and preserves Unicode/UTF support.
+awk '
+  /^\/\* #undef SUPPORT_PCRE2_8 \*\/$/ { print "#define SUPPORT_PCRE2_8 1"; next }
+  /^\/\* #undef SUPPORT_UNICODE \*\/$/ { print "#define SUPPORT_UNICODE 1"; next }
+  { print }
+' "$stage/src/config.h" > "$stage/src/config.h.tmp"
+mv "$stage/src/config.h.tmp" "$stage/src/config.h"
+
+header_version=$(awk '
+  /^#define PCRE2_MAJOR / { major = $3 }
+  /^#define PCRE2_MINOR / { minor = $3 }
+  END { print major "." minor }
+' "$stage/src/pcre2.h")
+if test "$header_version" != "$PCRE2_VERSION"; then
+  echo "PCRE2 header is version $header_version; expected $PCRE2_VERSION" >&2
+  exit 1
+fi
+
+if test "$(grep -c '^#define SUPPORT_PCRE2_8 1$' "$stage/src/config.h")" -ne 1 ||
+   test "$(grep -c '^#define SUPPORT_UNICODE 1$' "$stage/src/config.h")" -ne 1; then
+  echo "Failed to configure the PCRE2 8-bit Unicode build" >&2
+  exit 1
+fi
+
+printf '%s\n%s\n' "$expected_stamp" "$PCRE2_TAG" > "$stage/.prepared"
+
+# source_dir is derived from the fixed repository manifest and is constrained
+# to _deps above, so replacement cannot target an arbitrary user path.
+case "$source_dir" in
+  "$deps_dir"/pcre2-*) ;;
+  *) echo "Unsafe PCRE2 output directory: $source_dir" >&2; exit 1 ;;
+esac
+rm -rf -- "$source_dir"
+mv "$stage" "$source_dir"
+stage=

--- a/src/pcre2.ml
+++ b/src/pcre2.ml
@@ -1,0 +1,249 @@
+(*
+ * PCRE2 support for explicitly opted-in TP2 regular expressions.
+ *
+ * WeiDU's established regexp language is OCaml Str.  This module deliberately
+ * does not attempt to translate or replace that language: callers select it
+ * only after the parser has seen PCRE2_REGEXP.  Keeping the implementation in
+ * a separate module also prevents PCRE2's match data from depending on Str's
+ * process-global "last match" state.
+ *)
+
+type code
+
+external compile_raw : string -> bool -> code = "weidu_pcre2_compile"
+
+external exec_raw :
+  code -> string -> int -> bool -> bool -> int array option
+  = "weidu_pcre2_exec"
+
+external capture_names_raw : code -> (string * int) array
+  = "weidu_pcre2_capture_names"
+
+external utf_raw : code -> bool = "weidu_pcre2_utf"
+
+type regexp = {
+  code : code;
+  capture_names : (string * int) array;
+  utf : bool;
+}
+
+type match_result = {
+  regexp : regexp;
+  subject : string;
+  offsets : int array;
+}
+
+let compile ~case_sensitive pattern =
+  let code = compile_raw pattern case_sensitive in
+  { code; capture_names = capture_names_raw code; utf = utf_raw code }
+
+let search ?(anchored = false) ?(notempty_at_start = false)
+    regexp subject start =
+  match exec_raw regexp.code subject start anchored notempty_at_start with
+  | None -> None
+  | Some offsets -> Some { regexp; subject; offsets }
+
+let capture_count result = (Array.length result.offsets / 2) - 1
+
+let valid_group_number result number =
+  number >= 0 && ((number * 2) + 1) < Array.length result.offsets
+
+let group result number =
+  if not (valid_group_number result number) then
+    invalid_arg (Printf.sprintf "PCRE2 capture group %d does not exist" number)
+  else
+    let first = result.offsets.(number * 2) in
+    let last = result.offsets.((number * 2) + 1) in
+    if first < 0 || last < 0 then None
+    else Some (String.sub result.subject first (last - first))
+
+let named_group result name =
+  let found = ref false in
+  let value = ref None in
+  Array.iter
+    (fun (candidate, number) ->
+      if !value = None && candidate = name then begin
+        found := true;
+        value := group result number
+      end)
+    result.regexp.capture_names;
+  if not !found then
+    invalid_arg (Printf.sprintf "PCRE2 named capture group %s does not exist" name)
+  else
+    !value
+
+let named_groups result =
+  let seen = Hashtbl.create (Array.length result.regexp.capture_names) in
+  let groups = ref [] in
+  Array.iter
+    (fun (name, _) ->
+      if not (Hashtbl.mem seen name) then begin
+        Hashtbl.add seen name ();
+        groups := (name, named_group result name) :: !groups
+      end)
+    result.regexp.capture_names;
+  List.rev !groups
+
+let match_start result = result.offsets.(0)
+let match_end result = result.offsets.(1)
+
+let advance_after_empty regexp subject offset =
+  let subject_length = String.length subject in
+  if offset >= subject_length then offset
+  else if not regexp.utf then offset + 1
+  else begin
+    let next = ref (offset + 1) in
+    (* PCRE2 has already validated the UTF-8 subject. Continuation bytes have
+       the binary prefix 10, so skip them to the next code-point boundary. *)
+    while !next < subject_length &&
+          (Char.code subject.[!next] land 0xc0) = 0x80 do
+      incr next
+    done;
+    !next
+  end
+
+let add_capture buffer result number =
+  match group result number with
+  | None -> ()
+  | Some value -> Buffer.add_string buffer value
+
+let add_named_capture buffer result name =
+  match named_group result name with
+  | None -> ()
+  | Some value -> Buffer.add_string buffer value
+
+let all_digits value =
+  let rec loop index =
+    index = String.length value ||
+    (match value.[index] with
+    | '0' .. '9' -> loop (index + 1)
+    | _ -> false)
+  in
+  String.length value > 0 && loop 0
+
+(*
+ * PCRE2 replacements use $0, $1, ... and ${name}; $$ emits a literal dollar
+ * sign.  Captures that exist but did not participate expand to the empty
+ * string.  Invalid capture references are errors rather than silent data
+ * corruption.
+ *)
+let expand_replacement result replacement =
+  let length = String.length replacement in
+  let buffer = Buffer.create length in
+  let rec loop index =
+    if index >= length then ()
+    else if replacement.[index] <> '$' then begin
+      Buffer.add_char buffer replacement.[index];
+      loop (index + 1)
+    end else if index + 1 >= length then begin
+      Buffer.add_char buffer '$';
+      loop (index + 1)
+    end else
+      match replacement.[index + 1] with
+      | '$' ->
+          Buffer.add_char buffer '$';
+          loop (index + 2)
+      | '0' .. '9' ->
+          let last = ref (index + 2) in
+          while !last < length &&
+                replacement.[!last] >= '0' && replacement.[!last] <= '9' do
+            incr last
+          done;
+          let number = int_of_string
+              (String.sub replacement (index + 1) (!last - index - 1)) in
+          add_capture buffer result number;
+          loop !last
+      | '{' ->
+          let closing = try String.index_from replacement (index + 2) '}'
+            with Not_found ->
+              invalid_arg "unterminated ${...} PCRE2 replacement reference" in
+          let reference =
+            String.sub replacement (index + 2) (closing - index - 2) in
+          if reference = "" then
+            invalid_arg "empty ${...} PCRE2 replacement reference"
+          else if all_digits reference then
+            add_capture buffer result (int_of_string reference)
+          else
+            add_named_capture buffer result reference;
+          loop (closing + 1)
+      | _ ->
+          (* A dollar sign has no special meaning unless it starts one of the
+             documented forms above.  This keeps ordinary TP2 text intact. *)
+          Buffer.add_char buffer '$';
+          loop (index + 1)
+  in
+  loop 0;
+  Buffer.contents buffer
+
+let replace_match result replacement =
+  let first = match_start result in
+  let last = match_end result in
+  let expanded = expand_replacement result replacement in
+  let buffer = Buffer.create
+      (String.length result.subject - (last - first) + String.length expanded) in
+  Buffer.add_substring buffer result.subject 0 first;
+  Buffer.add_string buffer expanded;
+  Buffer.add_substring buffer result.subject last
+    (String.length result.subject - last);
+  Buffer.contents buffer
+
+(*
+ * PCRE2's documented global-matching algorithm retries an empty match at the
+ * same offset with ANCHORED|NOTEMPTY_ATSTART.  If that fails, it advances one
+ * character. WeiDU buffers are byte strings, but when a pattern explicitly
+ * enables UTF mode the retry advances to the next UTF-8 code-point boundary.
+ *)
+let iter_matches regexp subject callback =
+  let subject_length = String.length subject in
+  let rec loop start retry_nonempty =
+    let result = search ~anchored:retry_nonempty
+        ~notempty_at_start:retry_nonempty regexp subject start in
+    match result with
+    | Some matched ->
+        callback matched;
+        let first = match_start matched in
+        let last = match_end matched in
+        loop last (first = last)
+    | None when retry_nonempty && start < subject_length ->
+        loop (advance_after_empty regexp subject start) false
+    | None -> ()
+  in
+  loop 0 false
+
+let global_replace regexp replacement subject =
+  let buffer = Buffer.create (String.length subject) in
+  let copied_until = ref 0 in
+  iter_matches regexp subject (fun matched ->
+    let first = match_start matched in
+    let last = match_end matched in
+    Buffer.add_substring buffer subject !copied_until (first - !copied_until);
+    Buffer.add_string buffer (expand_replacement matched replacement);
+    copied_until := last);
+  Buffer.add_substring buffer subject !copied_until
+    (String.length subject - !copied_until);
+  Buffer.contents buffer
+
+let count regexp subject =
+  let result = ref 0 in
+  iter_matches regexp subject (fun _ -> incr result);
+  !result
+
+(* PCRE2 has no reverse-search API. Advance from each match's start rather
+   than its end so the forward scan preserves RINDEX's overlapping-match
+   semantics (for example, /aa/ in "aaa") without probing every byte. *)
+let search_backward regexp subject start =
+  if start < 0 || start > String.length subject then
+    invalid_arg "PCRE2 reverse-search offset is outside the subject"
+  else
+    let rec loop position best =
+      if position > start || position > String.length subject then best
+      else match search regexp subject position with
+        | None -> best
+        | Some result when match_start result > start -> best
+        | Some result ->
+            let next = advance_after_empty regexp subject
+                (match_start result) in
+            if next = match_start result then Some result
+            else loop next (Some result)
+    in
+    loop 0 None

--- a/src/pcre2_stubs.c
+++ b/src/pcre2_stubs.c
@@ -1,0 +1,210 @@
+/*
+ * Minimal OCaml binding for WeiDU's bundled PCRE2 8-bit engine.
+ *
+ * Only compilation, matching, and capture metadata cross this boundary.
+ * Replacement and global-match policy stay in OCaml, where their interaction
+ * with TP2 variables is explicit and testable.
+ */
+
+#define CAML_NAME_SPACE
+#define PCRE2_CODE_UNIT_WIDTH 8
+#define PCRE2_STATIC
+
+#include <stdio.h>
+
+#include <caml/alloc.h>
+#include <caml/custom.h>
+#include <caml/fail.h>
+#include <caml/memory.h>
+#include <caml/mlvalues.h>
+
+#include "pcre2.h"
+
+typedef struct {
+  pcre2_code *code;
+} weidu_pcre2_code;
+
+#define Code_val(value) (((weidu_pcre2_code *)Data_custom_val(value))->code)
+
+static void weidu_pcre2_finalize(value wrapped)
+{
+  pcre2_code *code = Code_val(wrapped);
+  if (code != NULL) {
+    pcre2_code_free(code);
+  }
+}
+
+static struct custom_operations weidu_pcre2_code_operations = {
+  "org.weidu.pcre2.code",
+  weidu_pcre2_finalize,
+  custom_compare_default,
+  custom_hash_default,
+  custom_serialize_default,
+  custom_deserialize_default,
+  custom_compare_ext_default
+};
+
+static void weidu_pcre2_raise_error(const char *operation, int error_code)
+{
+  PCRE2_UCHAR message[256];
+  char full_message[320];
+  int result = pcre2_get_error_message(error_code, message, sizeof(message));
+
+  if (result < 0) {
+    snprintf(full_message, sizeof(full_message),
+             "PCRE2 %s failed with error %d", operation, error_code);
+  } else {
+    snprintf(full_message, sizeof(full_message),
+             "PCRE2 %s failed: %s", operation, (char *)message);
+  }
+  caml_failwith(full_message);
+}
+
+CAMLprim value weidu_pcre2_compile(value pattern, value case_sensitive)
+{
+  CAMLparam2(pattern, case_sensitive);
+  CAMLlocal1(wrapped);
+  int error_code;
+  PCRE2_SIZE error_offset;
+  uint32_t options = Bool_val(case_sensitive) ? 0 : PCRE2_CASELESS;
+  pcre2_code *code;
+
+  wrapped = caml_alloc_custom(&weidu_pcre2_code_operations,
+                              sizeof(weidu_pcre2_code), 0, 1);
+  Code_val(wrapped) = NULL;
+
+  code = pcre2_compile((PCRE2_SPTR)String_val(pattern),
+                       (PCRE2_SIZE)caml_string_length(pattern),
+                       options, &error_code, &error_offset, NULL);
+  if (code == NULL) {
+    PCRE2_UCHAR message[256];
+    char full_message[384];
+    int result = pcre2_get_error_message(error_code, message, sizeof(message));
+
+    if (result < 0) {
+      snprintf(full_message, sizeof(full_message),
+               "PCRE2 compilation failed at offset %lu with error %d",
+               (unsigned long)error_offset, error_code);
+    } else {
+      snprintf(full_message, sizeof(full_message),
+               "PCRE2 compilation failed at offset %lu: %s",
+               (unsigned long)error_offset, (char *)message);
+    }
+    caml_failwith(full_message);
+  }
+
+  Code_val(wrapped) = code;
+  CAMLreturn(wrapped);
+}
+
+CAMLprim value weidu_pcre2_exec(value wrapped, value subject, value start,
+                                value anchored, value notempty_at_start)
+{
+  CAMLparam5(wrapped, subject, start, anchored, notempty_at_start);
+  CAMLlocal3(result, offsets, some);
+  pcre2_code *code = Code_val(wrapped);
+  pcre2_match_data *match_data;
+  PCRE2_SIZE *ovector;
+  mlsize_t subject_length = caml_string_length(subject);
+  intnat start_offset = Long_val(start);
+  uint32_t options = 0;
+  int match_count;
+  uint32_t capture_count;
+  uint32_t index;
+
+  if (start_offset < 0 || (uintnat)start_offset > (uintnat)subject_length) {
+    caml_invalid_argument("PCRE2 search offset is outside the subject");
+  }
+  if (Bool_val(anchored)) {
+    options |= PCRE2_ANCHORED;
+  }
+  if (Bool_val(notempty_at_start)) {
+    options |= PCRE2_NOTEMPTY_ATSTART;
+  }
+
+  match_data = pcre2_match_data_create_from_pattern(code, NULL);
+  if (match_data == NULL) {
+    caml_raise_out_of_memory();
+  }
+
+  match_count = pcre2_match(code, (PCRE2_SPTR)String_val(subject),
+                            (PCRE2_SIZE)subject_length,
+                            (PCRE2_SIZE)start_offset, options,
+                            match_data, NULL);
+  if (match_count == PCRE2_ERROR_NOMATCH) {
+    pcre2_match_data_free(match_data);
+    CAMLreturn(Val_int(0));
+  }
+  if (match_count < 0) {
+    pcre2_match_data_free(match_data);
+    weidu_pcre2_raise_error("match", match_count);
+  }
+
+  if (pcre2_pattern_info(code, PCRE2_INFO_CAPTURECOUNT, &capture_count) != 0) {
+    pcre2_match_data_free(match_data);
+    caml_failwith("PCRE2 failed to report the capture count");
+  }
+
+  ovector = pcre2_get_ovector_pointer(match_data);
+  offsets = caml_alloc((capture_count + 1) * 2, 0);
+  for (index = 0; index <= capture_count; ++index) {
+    PCRE2_SIZE first = index < (uint32_t)match_count
+      ? ovector[index * 2] : PCRE2_UNSET;
+    PCRE2_SIZE last = index < (uint32_t)match_count
+      ? ovector[(index * 2) + 1] : PCRE2_UNSET;
+    Store_field(offsets, index * 2,
+                first == PCRE2_UNSET ? Val_int(-1) : Val_long(first));
+    Store_field(offsets, (index * 2) + 1,
+                last == PCRE2_UNSET ? Val_int(-1) : Val_long(last));
+  }
+  pcre2_match_data_free(match_data);
+
+  some = caml_alloc(1, 0);
+  Store_field(some, 0, offsets);
+  result = some;
+  CAMLreturn(result);
+}
+
+CAMLprim value weidu_pcre2_utf(value wrapped)
+{
+  CAMLparam1(wrapped);
+  uint32_t options;
+
+  if (pcre2_pattern_info(Code_val(wrapped), PCRE2_INFO_ALLOPTIONS,
+                         &options) != 0) {
+    caml_failwith("PCRE2 failed to report compiled-pattern options");
+  }
+  CAMLreturn(Val_bool((options & PCRE2_UTF) != 0));
+}
+
+CAMLprim value weidu_pcre2_capture_names(value wrapped)
+{
+  CAMLparam1(wrapped);
+  CAMLlocal4(result, pair, name, number);
+  pcre2_code *code = Code_val(wrapped);
+  uint32_t name_count;
+  uint32_t entry_size;
+  PCRE2_SPTR name_table;
+  uint32_t index;
+
+  if (pcre2_pattern_info(code, PCRE2_INFO_NAMECOUNT, &name_count) != 0 ||
+      pcre2_pattern_info(code, PCRE2_INFO_NAMEENTRYSIZE, &entry_size) != 0 ||
+      pcre2_pattern_info(code, PCRE2_INFO_NAMETABLE, &name_table) != 0) {
+    caml_failwith("PCRE2 failed to report named-capture metadata");
+  }
+
+  result = caml_alloc(name_count, 0);
+  for (index = 0; index < name_count; ++index) {
+    PCRE2_SPTR entry = name_table + (index * entry_size);
+    uint32_t group_number = ((uint32_t)entry[0] << 8) | entry[1];
+
+    name = caml_copy_string((const char *)(entry + 2));
+    number = Val_long(group_number);
+    pair = caml_alloc_tuple(2);
+    Store_field(pair, 0, name);
+    Store_field(pair, 1, number);
+    Store_field(result, index, pair);
+  }
+
+  CAMLreturn(result);
+}

--- a/src/toldlexer.in
+++ b/src/toldlexer.in
@@ -99,6 +99,7 @@ let _ = List.iter
       ("END", END) ;
       ("EQUIP", EQUIP);
       ("EVALUATE_REGEXP", EVALUATE_REGEXP);
+      ("PCRE2_REGEXP", PCRE2_REGEXP);
       ("EXACT_MATCH", EXACT_MATCH);
       ("EXTEND",EXTEND_BOTTOM) ;
       ("EXTEND_BOTTOM", EXTEND_BOTTOM) ;

--- a/src/toldparser.mly
+++ b/src/toldparser.mly
@@ -98,6 +98,7 @@ open Load
   %token NOTEQUALS
   %token EQUALSGREATER
   %token EVALUATE_REGEXP
+  %token PCRE2_REGEXP
   %token EXACT_MATCH
   %token EXTEND_BOTTOM
   %token EXTEND_BOTTOM_REGEXP
@@ -473,6 +474,7 @@ optional_evaluate :
     { Tp.TP_Copy(
       { Tp.copy_get_existing = false;
         Tp.copy_use_regexp = false;
+        Tp.copy_regexp_engine = Tp.Legacy_regexp;
         Tp.copy_use_glob = $3 ;
         Tp.copy_file_list = $4 ;
         Tp.copy_patch_list = $5 ;
@@ -494,6 +496,7 @@ optional_evaluate :
     { Tp.TP_Copy(
       { Tp.copy_get_existing = true;
         Tp.copy_use_regexp = false;
+        Tp.copy_regexp_engine = Tp.Legacy_regexp;
         Tp.copy_use_glob = false;
         Tp.copy_file_list = $3 ;
         Tp.copy_patch_list = $4 ;
@@ -502,17 +505,18 @@ optional_evaluate :
         Tp.copy_at_end = false ;
         Tp.copy_save_inlined = ($2 = 2) ;
       } ) }
-| COPY_EXISTING_REGEXP optional_backup optional_glob str_str_list tp_patch_list tp_when_list
+| COPY_EXISTING_REGEXP optional_regexp_engine optional_backup optional_glob str_str_list tp_patch_list tp_when_list
     { Tp.TP_Copy(
       { Tp.copy_get_existing = true;
         Tp.copy_use_regexp = true;
+        Tp.copy_regexp_engine = $2;
         Tp.copy_use_glob = true;
-        Tp.copy_file_list = $4 ;
-        Tp.copy_patch_list = $5 ;
-        Tp.copy_constraint_list = $6 ;
-        Tp.copy_backup = not ($2 = 1) ;
+        Tp.copy_file_list = $5 ;
+        Tp.copy_patch_list = $6 ;
+        Tp.copy_constraint_list = $7 ;
+        Tp.copy_backup = not ($3 = 1) ;
         Tp.copy_at_end = false ;
-        Tp.copy_save_inlined = ($2 = 2) ;
+        Tp.copy_save_inlined = ($3 = 2) ;
       } ) }
 | COPY_RANDOM copy_random_string_list tp_patch_list tp_when_list { Tp.TP_CopyRandom($2,$3,$4) }
 | COPY_RANDOM STRING string_list tp_patch_list tp_when_list { Tp.TP_CopyRandom([$2::$3],$4,$5) }
@@ -704,8 +708,10 @@ optional_evaluate :
 | patch_STRING_right STRING_COMPARE_CASE patch_STRING_right    { Tp.PE_StringEqual($1,$3,true,false) }
 | patch_STRING_right STRING_EQUAL patch_STRING_right    { Tp.PE_StringEqual($1,$3,false,true) }
 | patch_STRING_right STRING_EQUAL_CASE patch_STRING_right    { Tp.PE_StringEqual($1,$3,true,true) }
-| patch_STRING_right STRING_MATCHES_REGEXP patch_STRING_right { Tp.PE_StringRegexp($1,$3,true) }
-| patch_STRING_right STRING_CONTAINS_REGEXP patch_STRING_right { Tp.PE_StringRegexp($1,$3,false) }
+| patch_STRING_right STRING_MATCHES_REGEXP patch_STRING_right { Tp.PE_StringRegexp($1,$3,true,Tp.Legacy_regexp) }
+| patch_STRING_right STRING_MATCHES_REGEXP PCRE2_REGEXP patch_STRING_right { Tp.PE_StringRegexp($1,$4,true,Tp.Pcre2_regexp) }
+| patch_STRING_right STRING_CONTAINS_REGEXP patch_STRING_right { Tp.PE_StringRegexp($1,$3,false,Tp.Legacy_regexp) }
+| patch_STRING_right STRING_CONTAINS_REGEXP PCRE2_REGEXP patch_STRING_right { Tp.PE_StringRegexp($1,$4,false,Tp.Pcre2_regexp) }
 | RANDOM LPAREN patch_exp patch_exp RPAREN { Tp.PE_Random($3,$4) }
 | FILE_CONTAINS_EVALUATED LPAREN patch_STRING_right patch_STRING_right RPAREN
     { Tp.PE_FileContainsEvaluated($3,$4) }
@@ -778,6 +784,16 @@ optional_evaluate :
 | EVALUATE_REGEXP      { Some(false) }
     ;
 
+  optional_regexp_match : { (None, Tp.Legacy_regexp) }
+| EXACT_MATCH          { (Some(true), Tp.Legacy_regexp) }
+| EVALUATE_REGEXP      { (Some(false), Tp.Legacy_regexp) }
+| PCRE2_REGEXP         { (Some(false), Tp.Pcre2_regexp) }
+    ;
+
+  optional_regexp_engine : { Tp.Legacy_regexp }
+| PCRE2_REGEXP              { Tp.Pcre2_regexp }
+    ;
+
   optional_null_terminated : { false }
 | NULL { true }
 
@@ -785,13 +801,14 @@ optional_evaluate :
 | SAY patch_exp lse { Tp.TP_PatchStrRef($2,$3) }
 | SAY_EVALUATED patch_exp STRING { Tp.TP_PatchStrRefEvaluated($2,$3) }
 | LAUNCH_PATCH_MACRO STRING { Tp.TP_Launch_Patch_Macro ($2,true) }
-| REPLACE optional_case_sensitive optional_match_exact STRING lse { Tp.TP_PatchString($2,$3,$4,$5) }
-| REPLACE_TEXTUALLY optional_case_sensitive optional_match_exact STRING STRING
-    { Tp.TP_PatchStringTextually($2,$3,$4,$5,None) }
+| REPLACE optional_case_sensitive optional_regexp_match STRING lse
+    { let match_exact, engine = $3 in Tp.TP_PatchString($2,match_exact,engine,$4,$5) }
+| REPLACE_TEXTUALLY optional_case_sensitive optional_regexp_match STRING STRING
+    { let match_exact, engine = $3 in Tp.TP_PatchStringTextually($2,match_exact,engine,$4,$5,None) }
 | REPLACE_TEXTUALLY optional_case_sensitive optional_match_exact STRING STRING LPAREN patch_exp RPAREN
-    { Tp.TP_PatchStringTextually($2,Some(false),$4,$5,Some($7)) }
-| REPLACE_EVALUATE optional_case_sensitive STRING BEGIN tp_patch_list END STRING
-    { Tp.TP_PatchStringEvaluate($2,$3,$5,$7) }
+    { Tp.TP_PatchStringTextually($2,Some(false),Tp.Legacy_regexp,$4,$5,Some($7)) }
+| REPLACE_EVALUATE optional_case_sensitive optional_regexp_engine STRING BEGIN tp_patch_list END STRING
+    { Tp.TP_PatchStringEvaluate($2,$3,$4,$6,$8) }
 | REPLACE_BCS_BLOCK STRING STRING { Tp.TP_PatchReplaceBCSBlock($2,$3,None,false,None) }
 | REPLACE_BCS_BLOCK_REGEXP STRING STRING { Tp.TP_PatchReplaceBCSBlockRE($2,$3,None) }
 | REPLACE_CRE_ITEM STRING string_ref_or_pe  string_ref_or_pe  string_ref_or_pe  STRING  STRING  optional_equip  optional_2h
@@ -937,8 +954,9 @@ optional_evaluate :
 | COUNT_2DA_COLS STRING { Tp.TP_Get2DACols(Tp.PE_LiteralString $2) }
 | PRETTY_PRINT_2DA patch_exp { Tp.TP_PrettyPrint2DA($2) }
 | PRETTY_PRINT_2DA { Tp.TP_PrettyPrint2DA(Tp.get_pe_int "2") }
-| COUNT_REGEXP_INSTANCES optional_case_sensitive optional_match_exact STRING STRING
-    { Tp.TP_CountRegexpInstances($2,$3,$4,Tp.PE_LiteralString $5) }
+| COUNT_REGEXP_INSTANCES optional_case_sensitive optional_regexp_match STRING STRING
+    { let match_exact, engine = $3 in
+      Tp.TP_CountRegexpInstances($2,match_exact,engine,$4,Tp.PE_LiteralString $5) }
 | READ_2DA_ENTRY patch_exp patch_exp patch_exp STRING { Tp.TP_Read2DA($2,$3,$4,Tp.PE_LiteralString $5) }
 | READ_2DA_ENTRIES_NOW STRING patch_exp { Tp.TP_Read2DANow($2,$3) }
 | READ_2DA_ENTRY_FORMER STRING patch_exp patch_exp STRING { Tp.TP_Read2DAFormer($2,$3,$4,$5) }

--- a/src/tp.ml
+++ b/src/tp.ml
@@ -39,6 +39,13 @@ let conf : (string, string) Hashtbl.t ref = ref (Hashtbl.create 5)
 
 exception Abort of string
 
+(* Existing TP2 regular expressions always use Legacy_regexp.  Pcre2_regexp
+   is carried explicitly in the AST, so no legacy pattern can be silently
+   reinterpreted by the modern engine. *)
+type regexp_engine =
+  | Legacy_regexp
+  | Pcre2_regexp
+
 type tp_flag =
   | Version of Dlg.tlk_string
   | Auto_Tra of string * string option
@@ -111,6 +118,7 @@ and component = {
 and tp_copy_args = {
     copy_get_existing    : bool ;  (* get from biffs? *)
     copy_use_regexp      : bool ;
+    copy_regexp_engine   : regexp_engine ;
     copy_use_glob        : bool ;
     copy_file_list       : ( string * string ) list ; (* (source,dest) list *)
     copy_patch_list      : tp_patch list ;
@@ -341,9 +349,9 @@ and tp_patch =
   | TP_PatchForEach of tp_pe_string * string list * tp_patch list
   | TP_PatchStrRef of tp_patchexp * Dlg.tlk_string (* offset + text *)
   | TP_PatchStrRefEvaluated of tp_patchexp * string
-  | TP_PatchString of (bool option) * (bool option) * string * Dlg.tlk_string (* regexp + text *)
-  | TP_PatchStringTextually of (bool option) * (bool option) * string * string * (tp_patchexp option) (* regexp + text *)
-  | TP_PatchStringEvaluate of (bool option) * string * (tp_patch list) * string (* see below *)
+  | TP_PatchString of (bool option) * (bool option) * regexp_engine * string * Dlg.tlk_string (* regexp + text *)
+  | TP_PatchStringTextually of (bool option) * (bool option) * regexp_engine * string * string * (tp_patchexp option) (* regexp + text *)
+  | TP_PatchStringEvaluate of (bool option) * regexp_engine * string * (tp_patch list) * string (* see below *)
   | TP_PatchReplaceBCSBlock of string * string * tp_patch list option * bool * (bool option) (* old + new *)
   | TP_PatchReplaceBCSBlockRE of string * string * tp_patch list option (* old + new *)
   | TP_PatchApplyBCSPatch of string (* patch *) * (string option) (* copyover *)
@@ -376,7 +384,7 @@ and tp_patch =
   | TP_Read2DAFormer of string * tp_patchexp * tp_patchexp * string
   | TP_Get2DARows of tp_patchexp * tp_pe_string
   | TP_Get2DACols of tp_pe_string
-  | TP_CountRegexpInstances of (bool option) * (bool option) * string * tp_pe_string
+  | TP_CountRegexpInstances of (bool option) * (bool option) * regexp_engine * string * tp_pe_string
   | TP_PatchPrint of Dlg.tlk_string
   | TP_PatchLog of Dlg.tlk_string
   | TP_PatchReraise
@@ -508,7 +516,7 @@ and tp_patchexp =
   | PE_Int of int
   | PE_String of tp_pe_string
   | PE_StringEqual of tp_pe_string * tp_pe_string * bool * bool (* ignore-case? * returns bool vs. 1,-1,0 *)
-  | PE_StringRegexp of tp_pe_string * tp_pe_string * bool (* match exactly?  *)
+  | PE_StringRegexp of tp_pe_string * tp_pe_string * bool * regexp_engine (* match exactly?  *)
   | PE_Not of tp_patchexp
   | PE_Add of tp_patchexp * tp_patchexp
   | PE_Sub of tp_patchexp * tp_patchexp
@@ -537,7 +545,7 @@ and tp_patchexp =
   | PE_Random of tp_patchexp * tp_patchexp
   | PE_Buffer_Length
   | PE_String_Length of tp_pe_string
-  | PE_Index of bool * bool option * bool option * tp_pe_string * tp_patchexp option * tp_pe_string option
+  | PE_Index of bool * bool option * bool option * regexp_engine * tp_pe_string * tp_patchexp option * tp_pe_string option
   | PE_FileContainsEvaluated of tp_pe_string * tp_pe_string
   | PE_ResourceContains of tp_pe_string * tp_pe_string
 

--- a/src/tpaction.ml
+++ b/src/tpaction.ml
@@ -107,6 +107,7 @@ let rec process_action_real our_lang game this_tp2_filename tp a =
                           get_pe_int unused_class)], []) in
         TP_Copy ({copy_get_existing = true ;
                   copy_use_regexp = false ;
+                  copy_regexp_engine = Legacy_regexp ;
                   copy_use_glob = false ;
                   copy_file_list = ["kitlist.2da", "override"] ;
                   copy_patch_list = [patch] ;
@@ -636,6 +637,7 @@ let rec process_action_real our_lang game this_tp2_filename tp a =
             let copy_args = {
               copy_get_existing = true;
               copy_use_regexp = false;
+              copy_regexp_engine = Legacy_regexp;
               copy_use_glob = false;
               copy_file_list = sdlist ;
               copy_patch_list = plist ;
@@ -651,6 +653,7 @@ let rec process_action_real our_lang game this_tp2_filename tp a =
           let my_copy_args = {
             copy_get_existing = true;
             copy_use_regexp = false;
+            copy_regexp_engine = Legacy_regexp;
             copy_use_glob = false ;
             copy_file_list = [ ("baldur.gam", "override") ] ;
             copy_patch_list = pl ;
@@ -680,6 +683,7 @@ let rec process_action_real our_lang game this_tp2_filename tp a =
           let my_copy_args = {
             copy_get_existing = false;
             copy_use_regexp = false;
+            copy_regexp_engine = Legacy_regexp;
             copy_use_glob = false ;
             copy_file_list = gam_list ;
             copy_patch_list = pl ;
@@ -720,25 +724,39 @@ let rec process_action_real our_lang game this_tp2_filename tp a =
               (if get_existing = true && use_reg = true then begin
                 let files_in_chitin = Key.list_of_key_resources game.Load.key use_glob in
                 let new_list = List.map (fun (s,p) ->
-                  let regexp = Str.regexp_case_fold s in
                   let matches = ref [] in
-                  List.iter (fun possible ->
-                    if Str.string_match regexp possible 0 then begin
-                      (try
-                        let dest = (Arch.backslash_to_slash
-                                      (Str.replace_matched p possible)) in
-                        let file_pattern = (Str.regexp ".+\\..+$") in
-                        if not (Str.string_match file_pattern dest 0) ||
-                        is_directory dest then begin
-                          matches :=
-                            (possible, dest ^ "/" ^ possible) :: !matches
-                        end else begin
-                          matches := (possible, dest) :: !matches
-                        end
-                      with | Failure s ->
-                        failwith (Printf.sprintf
-                                    "COPY_EXISTING_REGEXP failed: %s" s)) ;
-                    end) files_in_chitin;
+                  let add_match possible dest =
+                    let dest = Arch.backslash_to_slash dest in
+                    let file_pattern = Str.regexp ".+\\..+$" in
+                    if not (Str.string_match file_pattern dest 0) ||
+                    is_directory dest then
+                      matches := (possible, dest ^ "/" ^ possible) :: !matches
+                    else
+                      matches := (possible, dest) :: !matches
+                  in
+                  (match copy_args.copy_regexp_engine with
+                  | Legacy_regexp ->
+                      let regexp = Str.regexp_case_fold s in
+                      List.iter (fun possible ->
+                        if Str.string_match regexp possible 0 then
+                          (try add_match possible (Str.replace_matched p possible)
+                           with Failure message ->
+                             failwith (Printf.sprintf
+                               "COPY_EXISTING_REGEXP failed: %s" message)))
+                        files_in_chitin
+                  | Pcre2_regexp ->
+                      let regexp = Pcre2.compile ~case_sensitive:false s in
+                      List.iter (fun possible ->
+                        match Pcre2.search ~anchored:true regexp possible 0 with
+                        | None -> ()
+                        | Some matched ->
+                            (try add_match possible
+                                   (Pcre2.expand_replacement matched p)
+                             with Invalid_argument message ->
+                               failwith (Printf.sprintf
+                                 "COPY_EXISTING_REGEXP PCRE2_REGEXP failed: %s"
+                                 message)))
+                        files_in_chitin);
                   let matches = List.sort compare !matches in
                   if (matches = []) then
                     [(s,p)]
@@ -964,6 +982,7 @@ let rec process_action_real our_lang game this_tp2_filename tp a =
                 let copy_args = {
                   copy_get_existing = false;
                   copy_use_regexp = false;
+                  copy_regexp_engine = Legacy_regexp;
                   copy_use_glob = use_glob;
                   copy_file_list = [(src,dest)] ;
                   copy_patch_list = [] ;
@@ -1038,6 +1057,7 @@ let rec process_action_real our_lang game this_tp2_filename tp a =
             let a2 = TP_Copy(
               {copy_get_existing = false;
                 copy_use_regexp = false;
+                copy_regexp_engine = Legacy_regexp;
                 copy_use_glob = false;
                 copy_file_list = [(mus_file,dest_music_file)] ;
                 copy_patch_list = [] ;
@@ -1149,6 +1169,7 @@ let rec process_action_real our_lang game this_tp2_filename tp a =
             let a2 = TP_Copy(
               {copy_get_existing = false;
                 copy_use_regexp = false;
+                copy_regexp_engine = Legacy_regexp;
                 copy_use_glob = false;
                 copy_file_list = [(p.pro_file, dest_pro_file)] ;
                 copy_patch_list = [] ;
@@ -1242,6 +1263,7 @@ let rec process_action_real our_lang game this_tp2_filename tp a =
             let a = TP_Copy(
               {copy_get_existing = true ;
                 copy_use_regexp = false;
+                copy_regexp_engine = Legacy_regexp;
                 copy_use_glob = false;
                 copy_file_list = [(which ^ ".2da","override")] ;
                 copy_patch_list = [] ;
@@ -1351,6 +1373,7 @@ let rec process_action_real our_lang game this_tp2_filename tp a =
             let a7 = TP_Copy(
               {copy_get_existing = false ;
                 copy_use_regexp = false;
+                copy_regexp_engine = Legacy_regexp;
                 copy_use_glob = false;
                 copy_file_list = [(k.ability_file,dest_abil_file)] ;
                 copy_patch_list = [] ;
@@ -1405,6 +1428,7 @@ let rec process_action_real our_lang game this_tp2_filename tp a =
             let fix2da1 =
               TP_Copy ({copy_get_existing = true;
                          copy_use_regexp = false;
+                         copy_regexp_engine = Legacy_regexp;
                          copy_use_glob = false;
                          copy_file_list = ["weapprof.2da", "override";
                                             "25stweap.2da", "override";] ;
@@ -1428,6 +1452,7 @@ let rec process_action_real our_lang game this_tp2_filename tp a =
             let fix2da1a =
               TP_Copy ({copy_get_existing = true;
                          copy_use_regexp = false;
+                         copy_regexp_engine = Legacy_regexp;
                          copy_use_glob = false;
                          copy_file_list = ["kitlist.2da", "override"] ;
                          copy_patch_list =
@@ -1454,6 +1479,7 @@ let rec process_action_real our_lang game this_tp2_filename tp a =
             let fix2da2 =
               TP_Copy ({copy_get_existing = true;
                          copy_use_regexp = false;
+                         copy_regexp_engine = Legacy_regexp;
                          copy_use_glob = false;
                          copy_file_list = ["weapprof.2da", "override";
                                             "25stweap.2da", "override";] ;
@@ -1462,7 +1488,7 @@ let rec process_action_real our_lang game this_tp2_filename tp a =
                              (PE_GT
                                 (get_pe_int "%SOURCE_SIZE%", get_pe_int "0"),[
                               TP_PatchStringTextually
-                                (None,None,"^%tb#kit_temp2%",
+                                (None,None,Legacy_regexp,"^%tb#kit_temp2%",
                                  String.make
                                    (String.length
                                       (Var.get_string_exact "%tb#kit_temp2%")) ' ',None);],[])] ;
@@ -1474,6 +1500,7 @@ let rec process_action_real our_lang game this_tp2_filename tp a =
             let fix2da2a =
               TP_Copy ({copy_get_existing = true;
                          copy_use_regexp = false;
+                         copy_regexp_engine = Legacy_regexp;
                          copy_use_glob = false;
                          copy_file_list = ["kitlist.2da", "override"] ;
                          copy_patch_list =
@@ -1481,7 +1508,7 @@ let rec process_action_real our_lang game this_tp2_filename tp a =
                              (PE_GT
                                 (get_pe_int "%SOURCE_SIZE%", get_pe_int "0"),[
                               TP_PatchStringTextually
-                                (None,None,"^%tb#kit_temp2a%",
+                                (None,None,Legacy_regexp,"^%tb#kit_temp2a%",
                                  String.make
                                    (String.length
                                       (Var.get_string_exact "%tb#kit_temp2a%")) ' ',None);],[])] ;

--- a/src/tphelp.ml
+++ b/src/tphelp.ml
@@ -30,9 +30,10 @@ let rec pe_to_str pe = "(" ^ (match pe with
       (pe_str_str s1) (if c then "STRING_EQUAL" else
       "STRING_COMPARE") (if b then "_CASE" else "")
       (pe_str_str s2)
-| PE_StringRegexp(s1,s2,b) -> Printf.sprintf "%s %s %s"
+| PE_StringRegexp(s1,s2,b,engine) -> Printf.sprintf "%s %s %s%s"
       (pe_str_str s1) (if b then "STRING_MATCHES_REGEXP"
       else "STRING_CONTAINS_REGEXP")
+      (if engine = Pcre2_regexp then "PCRE2_REGEXP " else "")
       (pe_str_str s2)
 | PE_Not(e) -> Printf.sprintf "NOT %s" (pe_to_str e)
 | TP_PE_Byte_At(e) -> Printf.sprintf "BYTE_AT %s" (pe_to_str e)
@@ -82,10 +83,11 @@ let rec pe_to_str pe = "(" ^ (match pe with
       (pe_to_str e1) (pe_to_str e2)
 | PE_Buffer_Length -> "BUFFER_LENGTH"
 | PE_String_Length(e1) -> Printf.sprintf "STRING_LENGTH %s" (pe_str_str e1)
-| PE_Index(e0,e1,e2,e3,e4,e5) -> Printf.sprintf "%sINDEX (%s %s %s%s%s)"
+| PE_Index(e0,e1,e2,engine,e3,e4,e5) -> Printf.sprintf "%sINDEX (%s %s %s%s%s)"
       (if e0 then "" else "R")
       (if e1 = Some true then "CASE_SENSITIVE" else "CASE_INSENSITIVE")
-      (if e2 = Some true then "EXACT_MATCH" else "EVALUATE_REGEXP")
+      (if engine = Pcre2_regexp then "PCRE2_REGEXP" else
+       if e2 = Some true then "EXACT_MATCH" else "EVALUATE_REGEXP")
       (pe_str_str e3)
       (match e4 with
       | None -> ""

--- a/src/tppatch.ml
+++ b/src/tppatch.ml
@@ -129,7 +129,7 @@ let rec process_patch1 patch_filename game buff p =
         in
         Var.set_int32 var_name (Int32.of_int (num_cols lines 0))
 
-    | TP_CountRegexpInstances(case_sens,match_exact,find, var_name) ->
+    | TP_CountRegexpInstances(case_sens,match_exact,engine,find, var_name) ->
         let find = Var.get_string find in
         let var_name = Var.get_string (eval_pe_str var_name) in
         let case_sens = match case_sens with
@@ -140,15 +140,23 @@ let rec process_patch1 patch_filename game buff p =
         | None -> false
         | Some(x) -> x
         in
-        let my_regexp = match case_sens, match_exact with
-        | false, false -> Str.regexp_case_fold find
-        | true , false -> Str.regexp find
-        | false, true -> Str.regexp_string_case_fold find
-        | true , true -> Str.regexp_string find
+        let count = match engine with
+        | Legacy_regexp ->
+            let my_regexp = match case_sens, match_exact with
+            | false, false -> Str.regexp_case_fold find
+            | true , false -> Str.regexp find
+            | false, true -> Str.regexp_string_case_fold find
+            | true , true -> Str.regexp_string find in
+            let split = Str.split_delim my_regexp buff in
+            (List.length split) - 1
+        | Pcre2_regexp ->
+            if match_exact then
+              failwith "PCRE2_REGEXP cannot be combined with EXACT_MATCH";
+            if buff = "" then -1
+            else Pcre2.count
+              (Pcre2.compile ~case_sensitive:case_sens find) buff
         in
-        let split = Str.split_delim my_regexp buff in
-        let length = List.length split in
-        Var.set_int32 var_name (Int32.of_int (length - 1))
+        Var.set_int32 var_name (Int32.of_int count)
 
     | TP_Read2DA(row, col, req_col, var_name) ->
         let var_name = Var.get_string (eval_pe_str var_name) in
@@ -1077,7 +1085,7 @@ let rec process_patch2_real process_action tp our_lang patch_filename game buff 
             "" entries
            *)
 
-    | TP_PatchStringTextually(case_sens,match_exact,find,what,length) ->
+    | TP_PatchStringTextually(case_sens,match_exact,engine,find,what,length) ->
         let find = Var.get_string find in
         let what = Var.get_string what in
         let find_ref = ref find in
@@ -1112,55 +1120,113 @@ let rec process_patch2_real process_action tp our_lang patch_filename game buff 
         end ;
         end ;
         let find = !find_ref in
-        let my_regexp = match case_sens, match_exact with
-        | false, false -> Str.regexp_case_fold find
-        | true , false -> Str.regexp find
-        | false, true -> Str.regexp_string_case_fold find
-        | true , true -> Str.regexp_string find in
         let what = !what_ref in
-        Str.global_replace my_regexp what buff
+        (match engine with
+        | Legacy_regexp ->
+            let my_regexp = match case_sens, match_exact with
+            | false, false -> Str.regexp_case_fold find
+            | true , false -> Str.regexp find
+            | false, true -> Str.regexp_string_case_fold find
+            | true , true -> Str.regexp_string find in
+            Str.global_replace my_regexp what buff
+        | Pcre2_regexp ->
+            if match_exact then
+              failwith "PCRE2_REGEXP cannot be combined with EXACT_MATCH";
+            let regexp = Pcre2.compile ~case_sensitive:case_sens find in
+            Pcre2.global_replace regexp what buff)
 
-    | TP_PatchStringEvaluate(case_sens,find, pl, replace) ->
+    | TP_PatchStringEvaluate(case_sens,engine,find, pl, replace) ->
         (* REPLACE_EVALUATE ~Give(\([0-9]+\))~
            SET "RESULT" = "%MATCH1%"
            ~Give(%RESULT%)~
            ( "%MATCH%" / 2 ) *)
         let find = Var.get_string find in
-        let my_regexp = match case_sens with
-        | None -> Str.regexp find
-        | Some(true) -> Str.regexp find
-        | Some(false) -> Str.regexp_case_fold find in
-        let i = ref 0 in
-        let work_buff = ref buff in
-        let finished = ref false in
-        while not !finished do
-          let start_idx = try
-            Str.search_forward my_regexp !work_buff !i
-          with
-            Not_found -> finished := true; -1 in
-          if not !finished then begin
-            for j = 0 to 200 do
-              let v = Printf.sprintf "MATCH%d" j in
-              (* Var.remove_var v ;  *)
-              (try let group = Str.matched_group j !work_buff in
-              Var.set_string v group ;
-              with _ -> ())
-            done ;
-            let tmp_buff = ref (String.copy !work_buff) in
-            ignore (List.fold_left (fun acc elt ->
-              process_patch2 patch_filename game acc elt) !tmp_buff pl) ;
-            let this_replacement = Var.get_string replace in
-            let old_before = Str.string_before !work_buff start_idx in
-            let old_after = Str.string_after !work_buff start_idx in
-            let new_after =
-              Str.replace_first my_regexp this_replacement old_after in
-            work_buff := (old_before ^ new_after) ;
-            i := start_idx + String.length this_replacement
-          end
-        done;
-        !work_buff
+        (match engine with
+        | Legacy_regexp ->
+            let my_regexp = match case_sens with
+            | None -> Str.regexp find
+            | Some(true) -> Str.regexp find
+            | Some(false) -> Str.regexp_case_fold find in
+            let i = ref 0 in
+            let work_buff = ref buff in
+            let finished = ref false in
+            while not !finished do
+              let start_idx = try
+                Str.search_forward my_regexp !work_buff !i
+              with
+                Not_found -> finished := true; -1 in
+              if not !finished then begin
+                for j = 0 to 200 do
+                  let v = Printf.sprintf "MATCH%d" j in
+                  (* Preserve the historical behaviour of leaving an
+                     unmatched legacy capture variable unchanged. *)
+                  (try let group = Str.matched_group j !work_buff in
+                  Var.set_string v group ;
+                  with _ -> ())
+                done ;
+                let tmp_buff = ref (String.copy !work_buff) in
+                ignore (List.fold_left (fun acc elt ->
+                  process_patch2 patch_filename game acc elt) !tmp_buff pl) ;
+                let this_replacement = Var.get_string replace in
+                let old_before = Str.string_before !work_buff start_idx in
+                let old_after = Str.string_after !work_buff start_idx in
+                let new_after =
+                  Str.replace_first my_regexp this_replacement old_after in
+                work_buff := (old_before ^ new_after) ;
+                i := start_idx + String.length this_replacement
+              end
+            done;
+            !work_buff
+        | Pcre2_regexp ->
+            let case_sensitive = match case_sens with
+            | None | Some(true) -> true
+            | Some(false) -> false in
+            let regexp = Pcre2.compile ~case_sensitive find in
+            let work_buff = ref buff in
+            let search_offset = ref 0 in
+            let retry_nonempty = ref false in
+            let finished = ref false in
+            while not !finished do
+              match Pcre2.search ~anchored:!retry_nonempty
+                  ~notempty_at_start:!retry_nonempty regexp !work_buff
+                  !search_offset with
+              | None when !retry_nonempty &&
+                          !search_offset < String.length !work_buff ->
+                  search_offset := Pcre2.advance_after_empty regexp
+                    !work_buff !search_offset;
+                  retry_nonempty := false
+              | None -> finished := true
+              | Some matched ->
+                  for j = 0 to Pcre2.capture_count matched do
+                    let value = match Pcre2.group matched j with
+                    | None -> ""
+                    | Some group -> group in
+                    Var.set_string (Printf.sprintf "MATCH%d" j) value
+                  done;
+                  List.iter (fun (name, group) ->
+                    Var.set_string ("MATCH_" ^ name)
+                      (match group with None -> "" | Some value -> value))
+                    (Pcre2.named_groups matched);
+                  let tmp_buff = ref (String.copy !work_buff) in
+                  ignore (List.fold_left (fun acc elt ->
+                    process_patch2 patch_filename game acc elt) !tmp_buff pl);
+                  let this_replacement = Var.get_string replace in
+                  let expanded =
+                    Pcre2.expand_replacement matched this_replacement in
+                  let empty_match =
+                    Pcre2.match_start matched = Pcre2.match_end matched in
+                  work_buff := Pcre2.replace_match matched this_replacement;
+                  search_offset :=
+                    Pcre2.match_start matched + String.length expanded;
+                  (* Retrying at the logical match position is required even
+                     when replacement text was inserted. Otherwise the next
+                     unanchored search can rediscover the same zero-width
+                     match immediately before the original character. *)
+                  retry_nonempty := empty_match
+            done;
+            !work_buff)
 
-    | TP_PatchString(case_sens,match_exact,find,what) ->
+    | TP_PatchString(case_sens,match_exact,engine,find,what) ->
         let find = Var.get_string find in
         let case_sens = match case_sens with
         | None -> false
@@ -1168,11 +1234,6 @@ let rec process_patch2_real process_action tp our_lang patch_filename game buff 
         let match_exact = match match_exact with
         | None -> false
         | Some(x) -> x in
-        let my_regexp = match case_sens, match_exact with
-        | false, false -> Str.regexp_case_fold find
-        | true , false -> Str.regexp find
-        | false, true -> Str.regexp_string_case_fold find
-        | true , true -> Str.regexp_string find in
         let what = begin match what with
         | Dlg.Trans_String(a) -> what
         | Dlg.Local_String(lse) ->
@@ -1190,7 +1251,19 @@ let rec process_patch2_real process_action tp our_lang patch_filename game buff 
         | _ -> log_and_print
               "ERROR: cannot resolve REPLACE patch\n" ; failwith "resolve" in
         let new_string = Printf.sprintf "%d" new_index in
-        Str.global_replace my_regexp new_string buff
+        (match engine with
+        | Legacy_regexp ->
+            let my_regexp = match case_sens, match_exact with
+            | false, false -> Str.regexp_case_fold find
+            | true , false -> Str.regexp find
+            | false, true -> Str.regexp_string_case_fold find
+            | true , true -> Str.regexp_string find in
+            Str.global_replace my_regexp new_string buff
+        | Pcre2_regexp ->
+            if match_exact then
+              failwith "PCRE2_REGEXP cannot be combined with EXACT_MATCH";
+            let regexp = Pcre2.compile ~case_sensitive:case_sens find in
+            Pcre2.global_replace regexp new_string buff)
 
     | TP_PatchByte(where',what) ->
         let where = Int32.to_int (eval_pe buff game where') in

--- a/src/tppe.ml
+++ b/src/tppe.ml
@@ -194,7 +194,7 @@ let rec eval_pe buff game p =
   | PE_Buffer_Length ->
       Int32.of_int (String.length buff)
 
-  | PE_Index(from_end,case_sens,match_exact,what,start,where) ->
+  | PE_Index(from_end,case_sens,match_exact,engine,what,start,where) ->
       let case_sens = match case_sens with
       | None -> false
       | Some(x) -> x
@@ -204,12 +204,6 @@ let rec eval_pe buff game p =
       | Some(x) -> x
       in
       let find = Var.get_string (eval_pe_str what) in
-      let my_regexp = match case_sens, match_exact with
-      | false, false -> Str.regexp_case_fold        find
-      | true , false -> Str.regexp                  find
-      | false, true  -> Str.regexp_string_case_fold find
-      | true , true  -> Str.regexp_string           find
-      in
       let where = match where with
       | None -> buff
       | Some x -> Var.get_string (eval_pe_str x)
@@ -219,8 +213,29 @@ let rec eval_pe buff game p =
       | true, None -> String.length where
       | _, Some x -> Int32.to_int (eval_pe where game x)
       in
-      Int32.of_int (try (if from_end then Str.search_backward else
-      Str.search_forward) my_regexp where start with _ -> 0 - 1)
+      let index = match engine with
+      | Legacy_regexp ->
+          let my_regexp = match case_sens, match_exact with
+          | false, false -> Str.regexp_case_fold        find
+          | true , false -> Str.regexp                  find
+          | false, true  -> Str.regexp_string_case_fold find
+          | true , true  -> Str.regexp_string           find in
+          (try (if from_end then Str.search_backward else
+            Str.search_forward) my_regexp where start
+           with _ -> -1)
+      | Pcre2_regexp ->
+          if match_exact then
+            failwith "PCRE2_REGEXP cannot be combined with EXACT_MATCH";
+          let regexp = Pcre2.compile ~case_sensitive:case_sens find in
+          let result = if from_end then
+            Pcre2.search_backward regexp where start
+          else
+            Pcre2.search regexp where start in
+          (match result with
+          | None -> -1
+          | Some matched -> Pcre2.match_start matched)
+      in
+      Int32.of_int index
 
   | PE_FileContainsEvaluated(filename, reg) ->
       begin
@@ -333,18 +348,24 @@ let rec eval_pe buff game p =
         true
       with Not_found -> false)
 
-  | PE_StringRegexp(s1,s2,exact) ->
+  | PE_StringRegexp(s1,s2,exact,engine) ->
       let s1 = eval_pe_str s1 in
       let s2 = eval_pe_str s2 in
       let s1 = Var.get_string s1 in
       let s2 = Var.get_string s2 in
-      let r = Str.regexp_case_fold s2 in
-      let b =
-        if exact then Str.string_match r s1 0
-        else try
-          let _ = Str.search_forward r s1 0 in
-          true
-        with _ -> false
+      let b = match engine with
+      | Legacy_regexp ->
+          let r = Str.regexp_case_fold s2 in
+          if exact then Str.string_match r s1 0
+          else (try
+            let _ = Str.search_forward r s1 0 in
+            true
+          with _ -> false)
+      | Pcre2_regexp ->
+          let regexp = Pcre2.compile ~case_sensitive:false s2 in
+          (match Pcre2.search ~anchored:exact regexp s1 0 with
+          | None -> false
+          | Some _ -> true)
       in
       if b then 0l else 1l
 

--- a/src/trealparserin.in
+++ b/src/trealparserin.in
@@ -383,6 +383,7 @@ nonterm(Tp.tp_action) Tp_Action {
   -> COPY e1:Optional_Backup e2:Optional_Glob e3:Str_Str_List e4:Tp_Patch_List e5:Tp_When_List
        [ Tp.TP_Copy { Tp.copy_get_existing = false;
                       Tp.copy_use_regexp = false;
+                      Tp.copy_regexp_engine = Tp.Legacy_regexp;
                       Tp.copy_use_glob = (match e2 with Some x -> x | None -> false) ;
                       Tp.copy_file_list = e3 ;
                       Tp.copy_patch_list = e4 ;
@@ -403,6 +404,7 @@ nonterm(Tp.tp_action) Tp_Action {
   -> COPY_EXISTING e1:Optional_Backup e3:Str_Str_List e4:Tp_Patch_List e5:Tp_When_List
        [ Tp.TP_Copy { Tp.copy_get_existing = true;
                       Tp.copy_use_regexp = false;
+                      Tp.copy_regexp_engine = Tp.Legacy_regexp;
                       Tp.copy_use_glob = false ;
                       Tp.copy_file_list = e3 ;
                       Tp.copy_patch_list = e4 ;
@@ -411,9 +413,10 @@ nonterm(Tp.tp_action) Tp_Action {
                       Tp.copy_at_end = false ;
                       Tp.copy_save_inlined = (e1 = 2) ;
                     }]
-  -> COPY_EXISTING_REGEXP e1:Optional_Backup e2:Optional_Glob e3:Str_Str_List e4:Tp_Patch_List e5:Tp_When_List
+  -> COPY_EXISTING_REGEXP e0:Optional_Regexp_Engine e1:Optional_Backup e2:Optional_Glob e3:Str_Str_List e4:Tp_Patch_List e5:Tp_When_List
        [ Tp.TP_Copy { Tp.copy_get_existing = true;
                       Tp.copy_use_regexp = true;
+                      Tp.copy_regexp_engine = e0;
                       Tp.copy_use_glob =  (match e2 with Some x -> x | None -> true) ;
                       Tp.copy_file_list = e3 ;
                       Tp.copy_patch_list = e4 ;
@@ -1001,9 +1004,13 @@ nonterm (Tp.tp_patchexp) Patch_Exp {
   -> e1:Patch_String_Right STRING_EQUAL_CASE e2:Patch_String_Right
        [ Tp.PE_StringEqual(e1,e2,true,true) ]
   -> e1:Patch_String_Right STRING_MATCHES_REGEXP e2:Patch_String_Right
-       [ Tp.PE_StringRegexp(e1,e2,true) ]
+       [ Tp.PE_StringRegexp(e1,e2,true,Tp.Legacy_regexp) ]
+  -> e1:Patch_String_Right STRING_MATCHES_REGEXP PCRE2_REGEXP e2:Patch_String_Right
+       [ Tp.PE_StringRegexp(e1,e2,true,Tp.Pcre2_regexp) ]
   -> e1:Patch_String_Right STRING_CONTAINS_REGEXP e2:Patch_String_Right
-       [ Tp.PE_StringRegexp(e1,e2,false) ]
+       [ Tp.PE_StringRegexp(e1,e2,false,Tp.Legacy_regexp) ]
+  -> e1:Patch_String_Right STRING_CONTAINS_REGEXP PCRE2_REGEXP e2:Patch_String_Right
+       [ Tp.PE_StringRegexp(e1,e2,false,Tp.Pcre2_regexp) ]
   -> BYTE_AT e1:Patch_Exp   [ Tp.TP_PE_Byte_At(e1) ]
   -> SBYTE_AT e1:Patch_Exp  [ Tp.TP_PE_SByte_At(e1) ]
   -> SHORT_AT e1:Patch_Exp  [ Tp.TP_PE_Short_At(e1) ]
@@ -1014,10 +1021,10 @@ nonterm (Tp.tp_patchexp) Patch_Exp {
        [ Tp.PE_Random(e1,e2) ]
   -> BUFFER_LENGTH [ Tp.PE_Buffer_Length ]
   -> STRING_LENGTH e1:Patch_String_Right [ Tp.PE_String_Length e1 ]
-  -> INDEX LPAREN e1:Optional_Case_Sensitive e2:Optional_Match_Exact e4:Patch_String_Right e5:Patch_String_Right e3:Optional_Patch_Exp RPAREN [ Tp.PE_Index(false,e1,e2,e4,e3,Some e5) ]
-  -> RINDEX LPAREN e1:Optional_Case_Sensitive e2:Optional_Match_Exact e4:Patch_String_Right e5:Patch_String_Right e3:Optional_Patch_Exp RPAREN [ Tp.PE_Index(true,e1,e2,e4,e3,Some e5) ]
-  -> INDEX_BUFFER LPAREN e1:Optional_Case_Sensitive e2:Optional_Match_Exact e4:Patch_String_Right e3:Optional_Patch_Exp RPAREN [ Tp.PE_Index(false,e1,e2,e4,e3,None) ]
-  -> RINDEX_BUFFER LPAREN e1:Optional_Case_Sensitive e2:Optional_Match_Exact e4:Patch_String_Right e3:Optional_Patch_Exp RPAREN [ Tp.PE_Index(true,e1,e2,e4,e3,None) ]
+  -> INDEX LPAREN e1:Optional_Case_Sensitive e2:Optional_Regexp_Match e4:Patch_String_Right e5:Patch_String_Right e3:Optional_Patch_Exp RPAREN [ let match_exact, engine = e2 in Tp.PE_Index(false,e1,match_exact,engine,e4,e3,Some e5) ]
+  -> RINDEX LPAREN e1:Optional_Case_Sensitive e2:Optional_Regexp_Match e4:Patch_String_Right e5:Patch_String_Right e3:Optional_Patch_Exp RPAREN [ let match_exact, engine = e2 in Tp.PE_Index(true,e1,match_exact,engine,e4,e3,Some e5) ]
+  -> INDEX_BUFFER LPAREN e1:Optional_Case_Sensitive e2:Optional_Regexp_Match e4:Patch_String_Right e3:Optional_Patch_Exp RPAREN [ let match_exact, engine = e2 in Tp.PE_Index(false,e1,match_exact,engine,e4,e3,None) ]
+  -> RINDEX_BUFFER LPAREN e1:Optional_Case_Sensitive e2:Optional_Regexp_Match e4:Patch_String_Right e3:Optional_Patch_Exp RPAREN [ let match_exact, engine = e2 in Tp.PE_Index(true,e1,match_exact,engine,e4,e3,None) ]
   -> FILE_CONTAINS_EVALUATED LPAREN e1:Patch_String_Right e2:Patch_String_Right RPAREN
        [ Tp.PE_FileContainsEvaluated(e1,e2) ]
   -> RESOURCE_CONTAINS e1:Patch_String_Right e2: Patch_String_Right
@@ -1122,6 +1129,18 @@ nonterm (bool option) Optional_Match_Exact {
   -> EVALUATE_REGEXP [ Some false ]
 }
 
+nonterm (bool option * Tp.regexp_engine) Optional_Regexp_Match {
+  -> [ None, Tp.Legacy_regexp ]
+  -> EXACT_MATCH [ Some true, Tp.Legacy_regexp ]
+  -> EVALUATE_REGEXP [ Some false, Tp.Legacy_regexp ]
+  -> PCRE2_REGEXP [ Some false, Tp.Pcre2_regexp ]
+}
+
+nonterm (Tp.regexp_engine) Optional_Regexp_Engine {
+  -> [ Tp.Legacy_regexp ]
+  -> PCRE2_REGEXP [ Tp.Pcre2_regexp ]
+}
+
 nonterm (bool) Optional_Exact {
   -> [ false ]
   -> EXACT [ true ]
@@ -1159,15 +1178,15 @@ nonterm (Tp.tp_patch) Tp_Patch {
   -> LAUNCH_PATCH_FUNCTION e1:STRING e2:LaunchFunctionIntVar
      e3:LaunchFunctionStrVar e4:LaunchFunctionRet e5:LaunchFunctionRetArray END
        [ Tp.TP_Launch_Patch_Function(e1,true,e2,e3,e4,e5) ]
-  -> REPLACE e1:Optional_Case_Sensitive e2:Optional_Match_Exact e3:STRING e4:Lse
-       [ Tp.TP_PatchString(e1,e2,e3,e4) ]
-  -> REPLACE_TEXTUALLY e1:Optional_Case_Sensitive e2:Optional_Match_Exact e3:STRING e4:STRING
-       [ Tp.TP_PatchStringTextually(e1,e2,e3,e4,None) ]
+  -> REPLACE e1:Optional_Case_Sensitive e2:Optional_Regexp_Match e3:STRING e4:Lse
+       [ let match_exact, engine = e2 in Tp.TP_PatchString(e1,match_exact,engine,e3,e4) ]
+  -> REPLACE_TEXTUALLY e1:Optional_Case_Sensitive e2:Optional_Regexp_Match e3:STRING e4:STRING
+       [ let match_exact, engine = e2 in Tp.TP_PatchStringTextually(e1,match_exact,engine,e3,e4,None) ]
   -> REPLACE_TEXTUALLY e1:Optional_Case_Sensitive ignore:Optional_Match_Exact e2:STRING e3:STRING LPAREN e4:Patch_Exp_Safe RPAREN
-       [ if ignore = Some(false) then failwith "cannot EVALUATE_REGEXP "; Tp.TP_PatchStringTextually(e1,None,e2,e3,Some e4) ]
-  -> REPLACE_EVALUATE e1:Optional_Case_Sensitive e2:STRING BEGIN e3:Tp_Patch_List END
+       [ if ignore = Some(false) then failwith "cannot EVALUATE_REGEXP "; Tp.TP_PatchStringTextually(e1,None,Tp.Legacy_regexp,e2,e3,Some e4) ]
+  -> REPLACE_EVALUATE e1:Optional_Case_Sensitive e0:Optional_Regexp_Engine e2:STRING BEGIN e3:Tp_Patch_List END
        e4:STRING
-       [ Tp.TP_PatchStringEvaluate(e1,e2,e3,e4) ]
+       [ Tp.TP_PatchStringEvaluate(e1,e0,e2,e3,e4) ]
   -> REPLACE_BCS_BLOCK e3:Optional_Evaluate e4:Optional_Case_Sensitive e1:STRING e2:STRING [ Tp.TP_PatchReplaceBCSBlock(e1,e2,None,e3,e4) ]
   -> REPLACE_BCS_BLOCK_REGEXP e1:STRING e2:STRING [ Tp.TP_PatchReplaceBCSBlockRE(e1,e2,None) ]
   -> REPLACE_BCS_BLOCK e4:Optional_Evaluate e5:Optional_Case_Sensitive e1:STRING e2:STRING ON_MISMATCH e3:Tp_Patch_List END [ Tp.TP_PatchReplaceBCSBlock(e1,e2,Some e3,e4,e5) ]
@@ -1364,8 +1383,9 @@ nonterm (Tp.tp_patch) Tp_Patch {
   -> COUNT_2DA_COLS e1:Patch_String_Left [ Tp.TP_Get2DACols(e1) ]
   -> PRETTY_PRINT_2DA LPAREN e1:Patch_Exp RPAREN [ Tp.TP_PrettyPrint2DA(e1) ]
   -> PRETTY_PRINT_2DA [ Tp.TP_PrettyPrint2DA(Tp.get_pe_int "2") ]
-  -> COUNT_REGEXP_INSTANCES e1:Optional_Case_Sensitive e2:Optional_Match_Exact e3:STRING e4:Patch_String_Left
-       [ Tp.TP_CountRegexpInstances(e1,e2,e3,e4) ]
+  -> COUNT_REGEXP_INSTANCES e1:Optional_Case_Sensitive e2:Optional_Regexp_Match e3:STRING e4:Patch_String_Left
+       [ let match_exact, engine = e2 in
+         Tp.TP_CountRegexpInstances(e1,match_exact,engine,e3,e4) ]
   -> READ_2DA_ENTRY e1:Patch_Exp e2:Patch_Exp e3:Patch_Exp e4:Patch_String_Left
        [ Tp.TP_Read2DA(e1,e2,e3,e4) ]
   -> READ_2DA_ENTRIES_NOW e1:STRING e2:Patch_Exp [ Tp.TP_Read2DANow(e1,e2) ]

--- a/test/pcre2-regexp/pcre2-regexp.tp2
+++ b/test/pcre2-regexp/pcre2-regexp.tp2
@@ -1,0 +1,109 @@
+BACKUP ~test/pcre2-regexp/backup~
+AUTHOR ~WeiDU maintainers~
+
+BEGIN ~PCRE2 regexp regression tests~
+
+// Lookbehind, lookahead, bounded repetition, named captures and named
+// replacement references are all unavailable in the legacy Str dialect.
+OUTER_PATCH_SAVE result ~id=12; id=345;~ BEGIN
+  REPLACE_TEXTUALLY CASE_SENSITIVE PCRE2_REGEXP
+    ~(?<=id=)(?<number>\d{2,3})(?=;)~
+    ~[${number}]~
+END
+ACTION_IF ~%result%~ STR_CMP ~id=[12]; id=[345];~ BEGIN
+  FAIL ~PCRE2 named replacement test produced "%result%"~
+END
+
+// REPLACE_EVALUATE exposes both numbered and named captures. Its patch list
+// may derive a distinct replacement for every match.
+OUTER_PATCH_SAVE result ~Give(10) Give(25)~ BEGIN
+  REPLACE_EVALUATE CASE_SENSITIVE PCRE2_REGEXP
+    ~Give\((?<amount>\d+)\)~
+    BEGIN
+      SET doubled = MATCH_amount * 2
+    END
+    ~Take(%doubled%)~
+END
+ACTION_IF ~%result%~ STR_CMP ~Take(20) Take(50)~ BEGIN
+  FAIL ~PCRE2 evaluated replacement test produced "%result%"~
+END
+
+// A zero-width lookahead must advance after every empty match. This both
+// checks COUNT_REGEXP_INSTANCES and guards against an infinite loop.
+OUTER_PATCH ~~ BEGIN
+  COUNT_REGEXP_INSTANCES CASE_SENSITIVE PCRE2_REGEXP ~(?=(aa))~ count
+  PATCH_IF count != 2 BEGIN
+    PATCH_FAIL ~PCRE2 zero-width count was %count%, expected 2~
+  END
+END
+
+// Empty-match advancement respects UTF-8 code-point boundaries when the
+// pattern explicitly enables UTF mode.
+OUTER_PATCH_SAVE result ~é~ BEGIN
+  REPLACE_TEXTUALLY CASE_SENSITIVE PCRE2_REGEXP ~(*UTF)(?=.)~ ~_~
+END
+ACTION_IF ~%result%~ STR_CMP ~_é~ BEGIN
+  FAIL ~PCRE2 UTF empty-match test produced "%result%"~
+END
+
+// REPLACE_EVALUATE must apply the same anchored retry after an empty match
+// even when the evaluated replacement inserts text. Otherwise it can keep
+// matching immediately before the same original character indefinitely.
+OUTER_PATCH_SAVE result ~ab~ BEGIN
+  REPLACE_EVALUATE CASE_SENSITIVE PCRE2_REGEXP ~(?=.)~
+    BEGIN
+    END
+    ~_~
+END
+ACTION_IF ~%result%~ STR_CMP ~_a_b~ BEGIN
+  FAIL ~PCRE2 evaluated empty-match test produced "%result%"~
+END
+
+// STRING_MATCHES_REGEXP remains anchored at offset zero rather than requiring
+// a whole-string match. Named pattern backreferences exercise PCRE2 syntax.
+ACTION_IF ~Test-Test suffix~ STRING_MATCHES_REGEXP PCRE2_REGEXP
+    ~^(?<word>[A-Za-z]+)-\k<word>~ BEGIN
+  FAIL ~PCRE2 STRING_MATCHES_REGEXP did not match at offset zero~
+END
+
+ACTION_IF ~prefix:value:suffix~ STRING_CONTAINS_REGEXP PCRE2_REGEXP
+    ~(?<=:)value(?=:)~ BEGIN
+  FAIL ~PCRE2 STRING_CONTAINS_REGEXP did not find a lookaround match~
+END
+
+OUTER_SET first = INDEX (CASE_SENSITIVE PCRE2_REGEXP
+  ~(?<=:)foo(?=:)~ ~x:foo:y~)
+ACTION_IF first != 2 BEGIN
+  FAIL ~PCRE2 INDEX returned %first%, expected 2~
+END
+
+// Reverse search must retain overlapping-match semantics: /aa/ starts at
+// both offsets zero and one in "aaa".
+OUTER_SET last = RINDEX (CASE_SENSITIVE PCRE2_REGEXP ~aa~ ~aaa~)
+ACTION_IF last != 1 BEGIN
+  FAIL ~PCRE2 RINDEX returned %last%, expected 1~
+END
+
+// Preserve the legacy INDEX convention: an invalid starting offset returns
+// -1 rather than exposing Str's Invalid_argument exception to TP2 code.
+OUTER_SET legacy_invalid_index = INDEX (
+  CASE_SENSITIVE EVALUATE_REGEXP ~x~ ~x~ 2)
+ACTION_IF legacy_invalid_index != -1 BEGIN
+  FAIL ~Legacy INDEX returned %legacy_invalid_index%, expected -1~
+END
+
+// Keep a direct characterization of the established Str replacement path.
+// The modern engine must not reinterpret this escaped-group syntax.
+OUTER_PATCH_SAVE legacy ~foo~ BEGIN
+  REPLACE_TEXTUALLY CASE_SENSITIVE EVALUATE_REGEXP ~\(foo\)~ ~[\1]~
+END
+ACTION_IF ~%legacy%~ STR_CMP ~[foo]~ BEGIN
+  FAIL ~Legacy regexp replacement changed; produced "%legacy%"~
+END
+
+// Parse and construct the PCRE2 resource-selection AST without requiring a
+// game key in this self-contained --nogame test.
+ACTION_IF 0 BEGIN
+  COPY_EXISTING_REGEXP PCRE2_REGEXP GLOB
+    ~^(?<resource>.+)\.ITM$~ ~override/${resource}.ITM~
+END


### PR DESCRIPTION
## Summary

Add opt-in PCRE2 regular-expression support while preserving the existing OCaml/Str engine as the default.

PCRE2 is prepared reproducibly from an immutable upstream commit. Its source is no longer copied verbatim into this repository.

## Regular-expression support

- Preserve existing regular-expression behavior unless PCRE2 is explicitly selected.
- Support PCRE2 matching, captures, and replacement expansion.
- Build PCRE2 in 8-bit Unicode mode.
- Keep JIT disabled.
- Apply explicit matching limits.
- Link PCRE2 statically, so packaged WeiDU executables have no additional runtime dependency.

## Reproducible PCRE2 preparation

The dependency metadata is centralized in `pcre2/version`, including:

- PCRE2 version
- release tag
- immutable upstream commit
- GitHub repository
- canonical Git repository URL

`pcre2/sources.list` defines the audited source map used by both the Makefile and the preparation script.

The selected source closure contains 22 translation units. It was derived from the symbols required by WeiDU's PCRE2 bindings and excludes unused API areas such as conversion, DFA matching, JIT compilation, serialization, substitution, substring helpers, and custom table generation.

The preparation process verifies:

- the checked-out upstream commit;
- the relationship between release tag and version;
- the version declared by the upstream headers;
- the bundled license against the corresponding upstream Git blob;
- the exact source manifest.

Local builds and CI use the same `scripts/prepare_pcre2.sh` implementation. Local builds may fetch the pinned upstream commit automatically or use an existing checkout through `PCRE2_UPSTREAM_DIR` for offline/reproducible builds.

The permanent CI workflow prepares the dependency before Linux, macOS, and Windows builds and runs the PCRE2 regression test before packaging.

## Size impact

### Source and repository footprint

| Measurement | Before | After | Reduction |
|---|---:|---:|---:|
| Prepared PCRE2 source bytes | 2,381,204 | 1,645,067 | 736,137 (30.91%) |
| Prepared PCRE2 source lines | 67,514 | 44,174 | 23,340 (34.57%) |
| Tracked `pcre2` directory bytes | 2,385,935 | 7,146 | 2,378,789 (99.70%) |
| Tracked `pcre2` directory lines | 67,632 | 170 | 67,462 (99.75%) |

Compared with the previous untrimmed implementation, the complete tracked repository tree is reduced from 5,621,281 to 3,249,610 bytes: a reduction of 2,371,671 bytes, or 42.19%.

Compared with `devel`, the final tracked tree adds 46,916 bytes, or approximately 1.46%.

### Generated artifacts

| Platform | Raw executable | Packaged executable | Release ZIP |
|---|---:|---:|---:|
| Linux | −290,400 B (−2.14%) | −31,756 B (−1.58%) | −31,878 B (−1.17%) |
| macOS Intel | −76,840 B (−0.77%) | −70,736 B (−0.81%) | −34,400 B (−1.59%) |
| macOS ARM64 | −56,800 B (−0.56%) | −50,656 B (−0.57%) | −30,089 B (−1.24%) |
| Windows | −305,753 B (−2.33%) | −29,184 B (−1.89%) | −28,692 B (−1.25%) |

## Documentation

Update the language reference, compilation instructions, dependency metadata, PCRE2 maintenance documentation, and licensing references.

The maintenance documentation describes how to update PCRE2 to a later release and how to revalidate the selected source closure.

## Validation

The dedicated cross-platform validation run passed:

- documentation build;
- Linux with the OCaml configuration archived in PR #381;
- macOS Intel;
- macOS ARM64;
- Windows with the PR #382 compatibility patch applied only inside the disposable comparison workspace;
- PCRE2 TP2 regression tests;
- release packaging;
- before/after artifact measurement.

Validation run: https://github.com/4Luke4/weidu/actions/runs/31526985489

The disposable validation workflow and its temporary status locator are not present in the final tree or commit history.