### PR TITLE
Add REQUIRE_LABEL and FORBID_LABEL component requirements

### DIFF
--- a/README-WeiDU-Changes.txt
+++ b/README-WeiDU-Changes.txt
@@ -1,4 +1,6 @@
 Version 251:
+  * Add REQUIRE_LABEL and FORBID_LABEL component flags for testing whether
+    any installed component provides a LABEL.
   * CREATE called within CREATE works as expected.
   * CREATE sets SOURCE_* and DEST_* variables.
   * Auto-update does not fail if the filename of the newest WeiDU

--- a/doc/base.tex
+++ b/doc/base.tex
@@ -2980,6 +2980,20 @@ global option to your \ttref{TP2} file. \\
       component is \emph{not} installed. This does the opposite of
       \ttref{REQUIRE_COMPONENT}.  \\
 
+  or & \DEFINE{REQUIRE_LABEL} componentLabel \ttref{String} &
+      Make this component so that it can only be installed if at least one
+      currently installed component has a \ttref{LABEL} equal to
+      componentLabel. If no matching component is installed, the
+      \ttref{String} will be displayed and the user will not get a chance
+      to install this component. WeiDU resolves labels from the TP2 files
+      named in \t{WeiDU.log}; the same label may therefore be provided by
+      components in different mods. Label matching is case-sensitive. \\
+
+  or & \DEFINE{FORBID_LABEL} componentLabel \ttref{String} &
+      Make this component so that it can only be installed if no currently
+      installed component has a \ttref{LABEL} equal to componentLabel. This
+      does the opposite of \ttref{REQUIRE_LABEL}. \\
+
   or & \DEFINE{REQUIRE_PREDICATE} \ttref{value} \ttref{String} &
       This component can only be installed if the \ttref{value}
       evaluates to true (non-zero). \\

--- a/src/tp.ml
+++ b/src/tp.ml
@@ -87,6 +87,8 @@ and tp_mod_flag =
   | TPM_Deprecated of Dlg.tlk_string (* should be uninstalled when encountered *)
   | TPM_RequireComponent of string * int * Dlg.tlk_string
   | TPM_ForbidComponent of string * int * Dlg.tlk_string
+  | TPM_RequireLabel of string * Dlg.tlk_string
+  | TPM_ForbidLabel of string * Dlg.tlk_string
   | TPM_RequirePredicate of tp_patchexp * Dlg.tlk_string
   | TPM_SubComponents of Dlg.tlk_string * tp_patchexp * bool (* is forced? *)
   | TPM_Designated of int

--- a/src/tpstate.ml
+++ b/src/tpstate.ml
@@ -228,6 +228,32 @@ let already_installed tp2 i =
   | hd :: tl -> is_installed tl
   in is_installed !the_log
 
+let label_is_installed handle_tp2_filename label =
+  let component_has_label tp2_filename component =
+    try
+      let base_name =
+        Util.tp2_name
+          (Case_ins.filename_basename
+             (try Case_ins.filename_chop_extension tp2_filename
+              with _ -> tp2_filename)) in
+      (* Prefer the path recorded in WeiDU.log. The conventional alternatives
+         preserve the same setup-/directory compatibility as component checks
+         when an installed mod has subsequently moved its TP2 file. *)
+      let candidates = tp2_filename :: Util.all_possible_tp2s base_name in
+      let filename = List.find Util.file_exists candidates in
+      let tp2 = handle_tp2_filename filename in
+      let tp_mod = get_nth_module tp2 component false in
+      List.exists (fun flag -> match flag with
+      | TPM_Label candidate -> candidate = label
+      | _ -> false) tp_mod.mod_flags
+    with _ ->
+      false in
+  (* Temporarily uninstalled components must not satisfy a requirement: they
+     are absent while WeiDU decides whether dependent components may return. *)
+  List.exists (fun (tp2_filename,_,component,_,status) ->
+    status = Installed && component_has_label tp2_filename component)
+    !the_log
+
 let installed_lang_index tp2 =
   let rec is_installed lst = match lst with
   | [] -> None

--- a/src/tpwork.ml
+++ b/src/tpwork.ml
@@ -46,10 +46,16 @@ let module_groups_ok m =
     | _ -> false) m.mod_flags
   else true
 
+let label_is_installed label =
+  Tpstate.label_is_installed
+    (fun filename -> handle_tp2_filename_caching filename true) label
+
 let comp_flag_p tp m =
   List.exists (fun f -> match f with
   | TPM_RequireComponent(s, i, warn) -> not (already_installed s i)
   | TPM_ForbidComponent(s, i, warn) -> (already_installed s i)
+  | TPM_RequireLabel(label, warn) -> not (label_is_installed label)
+  | TPM_ForbidLabel(label, warn) -> label_is_installed label
   | TPM_Deprecated(warn) -> true
   | TPM_RequirePredicate(p,warn) ->
       not (is_true (eval_pe "" (Load.the_game ()) p))
@@ -1336,6 +1342,19 @@ let rec handle_tp game this_tp2_filename tp =
           begin
             if already_installed s i &&
               not (temporarily_uninstalled s i) then
+              preproc_fail "SKIPPING" warn can_uninstall true
+            else
+              () (* good! *)
+          end
+      | TPM_RequireLabel(label,warn) ->
+          begin
+            if label_is_installed label then
+              () (* good! *)
+            else preproc_fail "SKIPPING" warn can_uninstall false
+          end
+      | TPM_ForbidLabel(label,warn) ->
+          begin
+            if label_is_installed label then
               preproc_fail "SKIPPING" warn can_uninstall true
             else
               () (* good! *)

--- a/src/trealparserin.in
+++ b/src/trealparserin.in
@@ -274,6 +274,8 @@ nonterm(Tp.tp_mod_flag) Tp_Mod_Flag {
   -> REQUIRE_COMPONENT e1:STRING e2:STRING e3:Lse [ Tp.TPM_RequireComponent(e1,my_int_of_string e2,e3) ]
   -> INSTALL_BY_DEFAULT [ Tp.TPM_InstallByDefault ]
   -> FORBID_COMPONENT e1:STRING e2:STRING e3:Lse [ Tp.TPM_ForbidComponent(e1,my_int_of_string e2,e3) ]
+  -> REQUIRE_LABEL e1:STRING e2:Lse [ Tp.TPM_RequireLabel(e1,e2) ]
+  -> FORBID_LABEL e1:STRING e2:Lse [ Tp.TPM_ForbidLabel(e1,e2) ]
   -> REQUIRE_PREDICATE e1:Patch_Exp e2:Lse [ Tp.TPM_RequirePredicate(e1,e2) ]
   -> GROUP e1:Lse e2:Patch_Exp [ Tp.TPM_Group (e1,e2) ]
   -> GROUP e1:Lse [ Tp.TPM_Group (e1,Tp.Pred_True) ]

--- a/test/README
+++ b/test/README
@@ -25,3 +25,8 @@ traify/*
 
 tp2/tp2_regression_tests/*
         A collection of tests for TP2 functionality. Install as a WeiDU mod.
+
+tp2/issue-319-label-requirements/run.sh
+        Verifies REQUIRE_LABEL and FORBID_LABEL against missing labels and
+        equivalent labels provided by different mods. Pass the path to a
+        built WeiDU executable as the only argument.

--- a/test/tp2/issue-319-label-requirements/consumer.tp2
+++ b/test/tp2/issue-319-label-requirements/consumer.tp2
@@ -1,0 +1,14 @@
+BACKUP ~issue-319-consumer/backup~
+AUTHOR ~WeiDU regression test~
+
+BEGIN ~Requires the shared feature~
+  REQUIRE_LABEL ~issue-319-shared-feature~ ~The shared feature is required~
+
+BEGIN ~Requires an absent feature~
+  REQUIRE_LABEL ~issue-319-absent-feature~ ~The absent feature is required~
+
+BEGIN ~Forbids the shared feature~
+  FORBID_LABEL ~issue-319-shared-feature~ ~The shared feature is forbidden~
+
+BEGIN ~Forbids an absent feature~
+  FORBID_LABEL ~issue-319-absent-feature~ ~The absent feature is forbidden~

--- a/test/tp2/issue-319-label-requirements/provider-a.tp2
+++ b/test/tp2/issue-319-label-requirements/provider-a.tp2
@@ -1,0 +1,6 @@
+BACKUP ~issue-319-provider-a/backup~
+AUTHOR ~WeiDU regression test~
+
+BEGIN ~First provider~
+  LABEL ~issue-319-provider-a~
+  LABEL ~issue-319-shared-feature~

--- a/test/tp2/issue-319-label-requirements/provider-b.tp2
+++ b/test/tp2/issue-319-label-requirements/provider-b.tp2
@@ -1,0 +1,5 @@
+BACKUP ~issue-319-provider-b/backup~
+AUTHOR ~WeiDU regression test~
+
+BEGIN ~Alternative provider~
+  LABEL ~issue-319-shared-feature~

--- a/test/tp2/issue-319-label-requirements/run.sh
+++ b/test/tp2/issue-319-label-requirements/run.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [[ $# -ne 1 ]]; then
+  echo "usage: $0 /path/to/weidu" >&2
+  exit 2
+fi
+
+weidu=$(realpath "$1")
+fixture_dir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+test_root=$(mktemp -d)
+trap 'rm -rf -- "$test_root"' EXIT
+
+new_case() {
+  local name=$1
+  local case_dir="$test_root/$name"
+
+  mkdir -p "$case_dir"
+  cp "$fixture_dir"/*.tp2 "$case_dir/"
+  printf '%s\n' "$case_dir"
+}
+
+run_weidu() {
+  local case_dir=$1
+  shift
+  (
+    cd "$case_dir"
+    "$weidu" --nogame --noautoupdate --no-exit-pause "$@"
+  )
+}
+
+component_is_installed() {
+  local case_dir=$1
+  local tp2=$2
+  local component=$3
+
+  [[ -f "$case_dir/WeiDU.log" ]] &&
+    grep -Eq "^~${tp2}~ #0 #${component}([[:space:]]|$)" \
+      "$case_dir/WeiDU.log"
+}
+
+assert_installed() {
+  local case_dir=$1
+  local tp2=$2
+  local component=$3
+
+  if ! component_is_installed "$case_dir" "$tp2" "$component"; then
+    echo "Expected ${tp2} component ${component} to be installed" >&2
+    [[ ! -f "$case_dir/WeiDU.log" ]] || sed -n '1,200p' "$case_dir/WeiDU.log" >&2
+    exit 1
+  fi
+}
+
+assert_not_installed() {
+  local case_dir=$1
+  local tp2=$2
+  local component=$3
+
+  if component_is_installed "$case_dir" "$tp2" "$component"; then
+    echo "Expected ${tp2} component ${component} not to be installed" >&2
+    sed -n '1,200p' "$case_dir/WeiDU.log" >&2
+    exit 1
+  fi
+}
+
+missing_case=$(new_case missing)
+run_weidu "$missing_case" consumer.tp2 --force-install 0 \
+  >"$missing_case/require-missing.out" 2>&1
+assert_not_installed "$missing_case" CONSUMER.TP2 0
+grep -Fq "The shared feature is required" "$missing_case/require-missing.out"
+
+run_weidu "$missing_case" consumer.tp2 --force-install 3
+assert_installed "$missing_case" CONSUMER.TP2 3
+
+provider_a_case=$(new_case provider-a)
+run_weidu "$provider_a_case" provider-a.tp2 --force-install 0
+run_weidu "$provider_a_case" consumer.tp2 --force-install 0
+assert_installed "$provider_a_case" CONSUMER.TP2 0
+
+run_weidu "$provider_a_case" consumer.tp2 --force-install 2 \
+  >"$provider_a_case/forbid-present.out" 2>&1
+assert_not_installed "$provider_a_case" CONSUMER.TP2 2
+grep -Fq "The shared feature is forbidden" "$provider_a_case/forbid-present.out"
+
+provider_b_case=$(new_case provider-b)
+run_weidu "$provider_b_case" provider-b.tp2 --force-install 0
+run_weidu "$provider_b_case" consumer.tp2 --force-install 0
+assert_installed "$provider_b_case" CONSUMER.TP2 0
+
+echo "Issue #319 label requirement tests passed"


### PR DESCRIPTION
## Summary

Add `REQUIRE_LABEL` and `FORBID_LABEL` component flags, allowing component dependencies and conflicts to be expressed through stable textual `LABEL`s instead of TP2 filenames and numerical component identifiers.

A label may be provided by components from different mods. This supports interchangeable providers without requiring consumers to enumerate every possible TP2 file and component number.

Fixes #319.

## Motivation

`REQUIRE_COMPONENT` and `FORBID_COMPONENT` identify a component using its TP2 filename and numerical component number. This couples dependent mods to provider-specific file names and component numbering, which may change as mods evolve.

WeiDU already supports stable component `LABEL`s, but component requirement flags could not use them directly.

## Changes

- add `REQUIRE_LABEL componentLabel warningString`;
- add `FORBID_LABEL componentLabel warningString`;
- add dedicated TP2 AST variants for both flags;
- extend the Elkhound TP2 grammar with both forms;
- evaluate label requirements in both component-selection paths;
- resolve labels against active entries in `WeiDU.log`;
- parse and cache referenced TP2 files when examining their component labels;
- prefer the TP2 path recorded in `WeiDU.log`, with WeiDU's conventional TP2 filename alternatives as fallbacks;
- treat temporarily and permanently uninstalled components as absent;
- document the syntax, matching rules, and cross-mod provider semantics;
- update the changelog and regression-test index;
- add focused end-to-end regression fixtures.

## Semantics

Label matching is case-sensitive, consistently with existing `LABEL` and `ID_OF_LABEL` behaviour.

`REQUIRE_LABEL` permits installation when at least one currently installed component has the requested label.

`FORBID_LABEL` permits installation only when no currently installed component has the requested label.

The same label may intentionally be used by components in different mods. Any active provider satisfies `REQUIRE_LABEL` and activates `FORBID_LABEL`.

Temporarily uninstalled components do not satisfy a label requirement while WeiDU determines whether dependent components may be restored.

## Validation

A temporary disposable GitHub Actions workflow built WeiDU and ran the new installation-level regression suite on Ubuntu 22.04.

Successful run:

https://github.com/4Luke4/weidu/actions/runs/31605623555

The workflow verified:

- Elkhound grammar generation;
- compilation with OCaml 4.08.1 and unsafe strings;
- successful Linux executable linking;
- `REQUIRE_LABEL` rejecting a missing label;
- `REQUIRE_LABEL` accepting an installed provider;
- `FORBID_LABEL` accepting an absent label;
- `FORBID_LABEL` rejecting an installed provider;
- a shared label satisfying the requirement when supplied by either of two different mods;
- multiple labels on a provider component.

The Linux setup used the archived compiler configuration established by PR #381. The focused workflow avoided conflating this platform-independent change with the unrelated Windows source failure addressed by PR #382.

After validation, the disposable workflow and all CI-only commits were removed from branch history. The final branch is exactly one commit ahead of `devel`.