### PR TITLE
Restrict FILE_EXISTS_IN_GAME to game resource locations

### DIFF
--- a/README-WeiDU-Changes.txt
+++ b/README-WeiDU-Changes.txt
@@ -1,4 +1,6 @@
 Version 251:
+  * FILE_EXISTS_IN_GAME only searches game resource locations, rather
+    than also accepting files from unrelated filesystem locations.
   * CREATE called within CREATE works as expected.
   * CREATE sets SOURCE_* and DEST_* variables.
   * Auto-update does not fail if the filename of the newest WeiDU

--- a/doc/base.tex
+++ b/doc/base.tex
@@ -5882,7 +5882,9 @@ directory and exists in the filesystem and evaluates to 0 otherwise.
 or & \DEFINE{FILE_EXISTS_IN_GAME} fileName & Evaluates to 1 if the file
 exists as a game resource and has non-zero size. Evaluates to 0 otherwise.
 \ttref{BIFF}s and the \t{override} directory are searched in the standard
-manner. Evaluates to 0 for a file that does not exist but has been
+manner. Other filesystem locations, including the game directory and the
+current working directory, are not searched; use \ttref{FILE_EXISTS} for
+ordinary files. Evaluates to 0 for a file that does not exist but has been
 \ttref{ALLOW_MISSING}'d.\\
 or & \DEFINE{FILE_MD5} fileName md5sum & Evaluates to 1 if the file exists
 and has the given MD5 checksum. Evaluates to 0 otherwise. Two different

--- a/src/load.ml
+++ b/src/load.ml
@@ -695,20 +695,14 @@ let exists_in_overrides game res ext =
     else acc) false (if (String.uppercase ext) = "IDS" then
       game.ids_path_list else game.override_path_list)
 
-let resource_exists_legacy_check name =
-  (* FILE_EXISTS_IN_GAME used to be implemented through load_resource
-     This function corresponds to the control-flow
-     load_resource > exn > with _ > not ok_missing >
-     and aims to preserve legacy behaviour, nonsense though it may be *)
-  file_exists name
-
 let resource_exists game res ext =
-  let name = res ^ "." ^ ext in
   if (Case_ins.filename_is_implicit res) then begin
-    exists_in_overrides game res ext || Key.resource_exists game.key res ext ||
-    resource_exists_legacy_check name
+    (* A game resource is identified by an implicit resref, never by a path.
+       In particular, do not let a same-named file in the working directory
+       satisfy FILE_EXISTS_IN_GAME after both game-resource lookups fail. *)
+    exists_in_overrides game res ext || Key.resource_exists game.key res ext
   end else
-    file_contains_data name
+    false
 
 open Key
 

--- a/test/tp2/tp2_regression_tests/lib/tests/resource_exists.tpa
+++ b/test/tp2/tp2_regression_tests/lib/tests/resource_exists.tpa
@@ -41,11 +41,15 @@ DEFINE_ACTION_FUNCTION test_resource_exists BEGIN
 END
 
 DEFINE_ACTION_FUNCTION test_resource_fail BEGIN
+  COPY ~%MOD_FOLDER%/resources/file_structure/fl#a.file~ ~fl#cwd.fake~
+
   ACTION_FOR_EACH file IN ~fl#obviously.fake~
                           ~fl#fail.ARE~
+                          ~fl#cwd.fake~
+                          ~%MOD_FOLDER%/resources/file_structure/fl#a.file~
   BEGIN
     ACTION_IF FILE_EXISTS_IN_GAME ~%file%~ BEGIN
-      FAIL "test_resource_exists: intended fake file had return value true"
+      FAIL "test_resource_exists: non-resource file %file% had return value true"
     END
   END
 END


### PR DESCRIPTION
## Summary

Restrict `FILE_EXISTS_IN_GAME` to actual game resource locations.

The predicate now searches only the configured game-resource paths and the resources indexed by `chitin.key`. Ordinary files in the game or working directory, and explicit filesystem paths, no longer satisfy the predicate.

## Root cause

`Load.resource_exists` contained two filesystem fallbacks beyond normal game-resource lookup.

For an implicit resource name, it checked:

1. the override or IDS resource paths;
2. the resource index in `chitin.key`;
3. a legacy `file_exists` fallback against the process working directory.

For a non-implicit name containing directory components, it directly checked whether the filesystem path contained data.

Consequently, expressions such as:

```tp2
FILE_EXISTS_IN_GAME ~unindexed-file.ext~
FILE_EXISTS_IN_GAME ~some/directory/file.ext~
```

could evaluate to true even though the file was neither present in a configured override location nor indexed as a BIFF resource.

## Changes

- remove the legacy working-directory fallback from `Load.resource_exists`;
- reject non-implicit resource names rather than treating them as filesystem paths;
- preserve the existing override, IDS-path, and `chitin.key` lookups;
- add regression coverage for:
  - existing BIFF resources;
  - missing resources;
  - an existing file in the working/game directory;
  - an existing nested filesystem path;
- clarify in the documentation that ordinary files must be checked with `FILE_EXISTS`;
- record the behavior change in the changelog.

## Resulting behavior

`FILE_EXISTS_IN_GAME` now returns true only when an implicit resource identifier resolves through:

- the configured override or IDS resource paths; or
- `chitin.key`, and therefore the corresponding BIFF resource index.

Filesystem paths and unrelated files in the current or game directory return false. `FILE_EXISTS` remains the appropriate predicate for those files.

## Compatibility

This deliberately removes the legacy behavior that treated `FILE_EXISTS_IN_GAME` like `FILE_EXISTS` for implicit names that were not game resources.

The change brings the implementation into agreement with the documented contract that `FILE_EXISTS_IN_GAME` searches game resources, while `FILE_EXISTS` searches the filesystem.

## Validation

A temporary disposable GitHub Actions workflow was added to the feature branch, executed, and then removed from the branch history.

Successful focused workflow:

https://github.com/4Luke4/weidu/actions/runs/31636150312

The workflow used the archived OCaml compiler configuration established by PR #381 and ran only on Linux to avoid the unrelated Windows failures addressed by PR #382.

Verified operations:

```text
Elkhound download and execution: passed
OCaml 4.08.1 archived compiler setup: passed
complete Linux WeiDU build: passed
configured override-resource positive control: passed
working-directory file rejection: passed
nested filesystem-path rejection: passed
focused TPA regression-test parsing: passed
```