### PR TITLE
Document empty array keys and dynamic assignment

### DIFF
--- a/doc/base.tex
+++ b/doc/base.tex
@@ -7995,6 +7995,54 @@ The array construct can have any number of keys but only a single result.
 The construct is formed as follows:
 \verb+$variable(key list)+
 
+The array name and every key use normal WeiDU string syntax. String
+delimiters are optional for bare words, so \verb+$~table~(~key~)+ and
+\verb+$table(key)+ are equivalent. Variables in the name and keys are
+evaluated before the array entry is accessed. An array construct may
+therefore use variable substitution in the name or key position. For
+example:
+
+\begin{verbatim}
+OUTER_SPRINT table_name labels
+OUTER_SPRINT selected_key high
+OUTER_SPRINT $labels(low)  "Low priority"
+OUTER_SPRINT $labels(high) "High priority"
+
+OUTER_SPRINT label $"%table_name%"("%selected_key%")
+PRINT "%label%" // Prints "High priority"
+\end{verbatim}
+
+An empty string is a valid key. Since array constructs are represented
+as underscore-separated WeiDU variables, \verb+$selection(~~)+ refers
+to the same value as \verb+%selection_%+. Assigning through the array
+construct additionally registers the empty key with array-aware
+operations such as \ttref{ACTION_PHP_EACH}, \ttref{VARIABLE_IS_IN_ARRAY}
+and \ttref{RET_ARRAY}. Defining \verb+selection_+ directly makes its value
+readable through \verb+$selection(~~)+, but does not by itself register an
+array entry. The backing variable should therefore not be used independently
+for a different purpose.
+
+Empty keys are also useful as a nested source of a dynamic key:
+
+\begin{verbatim}
+OUTER_SPRINT selection_ high
+OUTER_SPRINT $labels($selection(~~)) "High priority"
+\end{verbatim}
+
+Here \verb+selection_+ is an ordinary scalar variable. In the left-hand
+array construct, \verb+$selection(~~)+ is evaluated first, so the assignment
+is equivalent to \verb+OUTER_SPRINT $labels(high) "High priority"+.
+
+Nested constructs are context-sensitive. In a right-hand array lookup,
+use an intermediate variable and normal variable substitution for a
+dynamic key:
+
+\begin{verbatim}
+OUTER_SPRINT selected_key $selection(~~)
+OUTER_SPRINT label $labels("%selected_key%")
+PRINT "%label%" // Prints "High priority"
+\end{verbatim}
+
 The construct can be used to store a result when used on the left-hand
 side of an expression or to retrieve a result when used on the
 right-hand side. For example, the following code snippet illustrates

--- a/test/tp2/tp2_regression_tests/lib/tests/array_tests.tpa
+++ b/test/tp2/tp2_regression_tests/lib/tests/array_tests.tpa
@@ -7,12 +7,94 @@ BEGIN
   PRINT "%message%"
   ACTION_TRY
     LAF test_clear_array END
+    LAF test_empty_and_nested_array_keys END
     OUTER_SET success = 1
   WITH
     DEFAULT
       OUTER_SET success = 0
       OUTER_SPRINT message "tests failed in array_tests: %ERROR_MESSAGE%"
   END
+END
+
+DEFINE_ACTION_FUNCTION test_empty_and_nested_array_keys BEGIN
+  ACTION_CLEAR_ARRAY fl#array_syntax#selector
+  ACTION_CLEAR_ARRAY fl#array_syntax#values
+  ACTION_CLEAR_ARRAY fl#array_syntax#observed
+
+  // The empty-key construct can read a scalar with the corresponding
+  // trailing-underscore name, as in the EE Fixpack usage that prompted this
+  // regression test. A direct scalar assignment does not create array metadata.
+  OUTER_SPRINT fl#array_syntax#direct_ "alpha"
+  OUTER_SPRINT direct $~fl#array_syntax#direct~(~~)
+  ACTION_IF !("%direct%" STR_EQ "alpha") BEGIN
+    FAIL "test_empty_and_nested_array_keys: empty key did not read the backing variable"
+  END
+  ACTION_IF VARIABLE_IS_IN_ARRAY $~fl#array_syntax#direct~(~~) BEGIN
+    FAIL "test_empty_and_nested_array_keys: scalar assignment unexpectedly registered an array entry"
+  END
+
+  // An empty key is retained as array metadata and maps to the trailing-
+  // underscore variable that backs the entry.
+  OUTER_SPRINT $~fl#array_syntax#selector~(~~) "beta"
+  ACTION_IF !("%fl#array_syntax#selector_%" STR_EQ "beta") BEGIN
+    FAIL "test_empty_and_nested_array_keys: empty key did not map to the expected variable"
+  END
+  ACTION_IF !VARIABLE_IS_IN_ARRAY $~fl#array_syntax#selector~(~~) BEGIN
+    FAIL "test_empty_and_nested_array_keys: empty key was not registered as an array entry"
+  END
+
+  LAF return_empty_key_array RET_ARRAY "fl#array_syntax#returned" END
+  ACTION_IF !("%fl#array_syntax#returned_%" STR_EQ "returned") BEGIN
+    FAIL "test_empty_and_nested_array_keys: RET_ARRAY did not preserve the empty-key entry"
+  END
+
+  // String delimiters are valid around array names and keys. In a left-hand
+  // construct, the nested empty-key lookup supplies the value used as the key.
+  OUTER_SPRINT $~fl#array_syntax#values~(~alpha~) "first"
+  OUTER_SPRINT $~fl#array_syntax#values~(~beta~) "second"
+  OUTER_SET $~fl#array_syntax#observed~($~fl#array_syntax#direct~(~~)) = 1
+  ACTION_IF !VARIABLE_IS_IN_ARRAY $~fl#array_syntax#observed~(~alpha~) BEGIN
+    FAIL "test_empty_and_nested_array_keys: nested left-hand array key did not resolve"
+  END
+
+  // Right-hand dynamic lookup uses ordinary variable substitution after the
+  // empty-key value has been read into an intermediate scalar.
+  OUTER_SPRINT selected_key $~fl#array_syntax#selector~(~~)
+  OUTER_SPRINT selected $~fl#array_syntax#values~("%selected_key%")
+  ACTION_IF !("%selected%" STR_EQ "second") BEGIN
+    FAIL "test_empty_and_nested_array_keys: variable-substituted array key did not resolve"
+  END
+
+  OUTER_SPRINT array_name "fl#array_syntax#values"
+  OUTER_SPRINT selected $"%array_name%"("%selected_key%")
+  ACTION_IF !("%selected%" STR_EQ "second") BEGIN
+    FAIL "test_empty_and_nested_array_keys: variable-substituted array name did not resolve"
+  END
+
+  // Iteration must expose the empty string as the key, not merely find the
+  // flattened backing variable by name.
+  OUTER_SET entries = 0
+  ACTION_PHP_EACH fl#array_syntax#selector AS key => value BEGIN
+    ACTION_IF !("%key%" STR_EQ "") BEGIN
+      FAIL "test_empty_and_nested_array_keys: iteration returned an unexpected key"
+    END
+    ACTION_IF !("%value%" STR_EQ "beta") BEGIN
+      FAIL "test_empty_and_nested_array_keys: iteration returned an unexpected value"
+    END
+    OUTER_SET ++entries
+  END
+  ACTION_IF entries != 1 BEGIN
+    FAIL "test_empty_and_nested_array_keys: iteration did not return exactly one entry"
+  END
+END
+
+DEFINE_ACTION_FUNCTION return_empty_key_array
+  RET_ARRAY
+    "fl#array_syntax#returned"
+BEGIN
+  // Defining the entry inside the function verifies that RET_ARRAY carries
+  // both its flattened value and its empty-key array metadata to the caller.
+  OUTER_SPRINT $~fl#array_syntax#returned~(~~) "returned"
 END
 
 DEFINE_ACTION_FUNCTION test_clear_array BEGIN


### PR DESCRIPTION
## Summary

Document WeiDU's supported empty-key array syntax and its relationship to trailing-underscore scalar variables.

Add focused regression coverage for:

- empty-string array keys;
- quoted array names and keys;
- the relationship between `$array(~~)` and the backing `array_` variable;
- array metadata registration;
- nested empty-key evaluation in left-hand assignments;
- variable-substituted array names and keys;
- iteration over an empty-key entry;
- preservation of empty-key entries through `RET_ARRAY`.

## Background

The following EE Fixpack code relies on this behavior:

```tp2
STR_VAR
  "item_" = ~~
  "cre_" = ~~

OUTER_SET $~POLYITEM~($~item~(~~)) = 1
```

The `item_` and `cre_` declarations are ordinary scalar variables. The empty-key construct:

```tp2
$item(~~)
```

refers to the same backing variable as:

```tp2
%item_%
```

In a left-hand array assignment, the nested empty-key construct is evaluated before the outer array entry is created. Consequently:

```tp2
OUTER_SPRINT item_ "sw1h01"
OUTER_SET $POLYITEM($item(~~)) = 1
```

creates the equivalent of:

```tp2
OUTER_SET $POLYITEM(sw1h01) = 1
```

This behavior is implemented by WeiDU's existing parser and evaluator, but was not explained in the array-construct documentation.

## Documentation

Expand the array-construct tutorial to explain:

- optional WeiDU string delimiters around array names and keys;
- variable substitution in array names and keys;
- empty strings as valid keys;
- the backing-variable relationship between `$selection(~~)` and `%selection_%`;
- the difference between assigning through an array construct and assigning the backing scalar directly;
- nested empty-key evaluation in a left-hand array assignment;
- the context sensitivity of nested constructs;
- the recommended intermediate-variable form for right-hand dynamic lookups.

The examples are general-purpose and do not depend on EE Fixpack-specific names or resources.

## Regression coverage

Extend the existing array regression suite to verify that:

1. a directly assigned trailing-underscore scalar is readable through an empty-key construct;
2. direct scalar assignment does not create array metadata;
3. assignment through `$array(~~)` creates both the backing value and empty-key metadata;
4. `VARIABLE_IS_IN_ARRAY` recognizes an empty-key entry;
5. `RET_ARRAY` preserves an empty-key entry and its value;
6. quoted array names and keys are accepted;
7. a nested empty-key construct supplies the dynamic key in a left-hand assignment;
8. variable-substituted keys work in right-hand lookups;
9. variable-substituted array names work in right-hand lookups;
10. `ACTION_PHP_EACH` exposes the empty string as the entry's key.

## Validation

A temporary disposable GitHub Actions workflow validated the corrected complete tree:

https://github.com/4Luke4/weidu/actions/runs/31690388968

The workflow completed successfully on Ubuntu 22.04:

- WeiDU source build: passed
- focused empty-key and dynamic-assignment regression test: passed
- complete documentation build: passed

The validation used OCaml 4.14.2 with default unsafe strings. This intentionally avoids the unrelated archived-compiler resolution failure addressed by PR #381. The focused Linux workflow also avoids the unrelated Windows build failure addressed by PR #382.

After validation, the disposable workflow and all diagnostic commits were removed from branch history.