### PR TITLE
Document repeatable EVAL substitution passes

### DIFF
--- a/doc/base.tex
+++ b/doc/base.tex
@@ -4427,7 +4427,9 @@ EXTEND_TOP ~sola.bcs~ ~.../mymod-inlined/script.baf~
 or & \DEFINE{EVALUATE_BUFFER} &
   Any WeiDU variables (like \t{\%myvar\%}) inside the current file (which
   should probably be a plain text file in order for this to make much sense)
-  are replaced by their values. Example:
+  are replaced by their values. This patch operation performs one substitution
+  pass. Consecutive instances perform consecutive passes over the result of the
+  preceding instance. Example:
 \begin{verbatim}
 <<<<<<<< .../mymod-inlined/script.baf
 IF
@@ -4444,8 +4446,10 @@ EXTEND_TOP ~sola.bcs~ ~.../mymod-inlined/script.baf~
   Those two actions extend the top of \t{sola.bcs} with the script
   block \t{IF See("Anomen") THEN RESPONSE \#100 Kill("Anomen") END}.
   You can also use \ttref{EVALUATE_BUFFER} in \ttref{COMPILE} actions
-  or before strings in \ttref{value}s. You may use \DEFINE{EVAL} as
-  a synonym for \t{EVALUATE_BUFFER}.
+  or as a prefix before strings in \ttref{value}s. In the prefix form,
+  successive \t{EVALUATE_BUFFER} or \t{EVAL} keywords request successive
+  substitution passes; see the \ttref{value} entry for details and examples.
+  You may use \DEFINE{EVAL} as a synonym for \t{EVALUATE_BUFFER}.
   \\
 
 or & \DEFINE{APPLY_BCS_PATCH} patchFile &
@@ -5956,8 +5960,26 @@ SET EVALUATE_BUFFER "%x%" += 77
 PATCH_PRINT "y is %y% ; z is %z%"
 \end{verbatim}
     This prints out \t{y is 82 ; z is tricky 5}. You may also do hackery like
-    \t{FILE_SIZE "myfile" "\%\%indirection\%\%"}. Be very careful with this
-    feature. \\
+    \t{FILE_SIZE "myfile" "\%\%indirection\%\%"}.
+
+    The prefix may be repeated as many times as required. Each occurrence
+    adds exactly one substitution pass, and nested prefixes are evaluated from
+    the innermost occurrence outwards. For example:
+\begin{verbatim}
+OUTER_SPRINT first  "%second%"
+OUTER_SPRINT second "%third%"
+OUTER_SPRINT third  "finished"
+
+OUTER_SPRINT result EVAL EVAL EVAL "%first%"
+PRINT "%result%" // prints: finished
+\end{verbatim}
+    There is no language-defined maximum nesting depth, although source files
+    remain subject to ordinary parser and runtime resource limits. Repetition
+    does not mean ``evaluate until stable'': the number of passes is fixed by
+    the number of prefixes. Unset variables remain unchanged during a pass,
+    and cyclic references are not detected or followed automatically. The
+    long \t{EVALUATE_BUFFER} spelling and the \t{EVAL} alias may be mixed.
+    Be very careful with this feature. \\
 or & \label{array construct}\verb+$array(index list)+ &
     The so-called \emph{array construct}. See the \ahrefloc{sec-array-construct}{tutorial}.
 \\

--- a/test/tp2/tp2_regression_tests/lib/tests/repeated_eval.tpa
+++ b/test/tp2/tp2_regression_tests/lib/tests/repeated_eval.tpa
@@ -1,0 +1,52 @@
+/*
+ * Verify that EVAL/EVALUATE_BUFFER prefixes can be nested without a
+ * language-defined fixed limit and that every prefix adds one substitution
+ * pass.
+ */
+DEFINE_ACTION_FUNCTION test_repeated_eval BEGIN
+  // Assign each reference before its target exists. This preserves the
+  // indirection chain despite OUTER_SPRINT's normal evaluation pass.
+  OUTER_SPRINT eval_level_1 "%eval_level_2%"
+  OUTER_SPRINT eval_level_2 "%eval_level_3%"
+  OUTER_SPRINT eval_level_3 "eval_target"
+  OUTER_SET eval_target = 41
+
+  // Three passes resolve the variable name at the end of the chain.
+  OUTER_SET EVAL EVAL EVAL "%eval_level_1%" += 1
+  ACTION_IF eval_target != 42 BEGIN
+    FAIL "test_repeated_eval failed to evaluate a variable name three times"
+  END
+
+  OUTER_SPRINT eval_result EVAL EVAL EVAL "%eval_level_1%"
+  ACTION_IF "%eval_result%" STRING_COMPARE_CASE "eval_target" BEGIN
+    FAIL "test_repeated_eval produced an unexpected nested EVAL result"
+  END
+
+  // A longer sequence guards against imposing a small fixed nesting limit.
+  OUTER_SPRINT eval_long_result EVAL EVAL EVAL EVAL EVAL EVAL EVAL EVAL "%eval_level_1%"
+  ACTION_IF "%eval_long_result%" STRING_COMPARE_CASE "eval_target" BEGIN
+    FAIL "test_repeated_eval failed to accept eight EVAL prefixes"
+  END
+
+  OUTER_SPRINT eval_long_name EVALUATE_BUFFER EVALUATE_BUFFER EVALUATE_BUFFER "%eval_level_1%"
+  ACTION_IF "%eval_long_name%" STRING_COMPARE_CASE "eval_target" BEGIN
+    FAIL "test_repeated_eval failed with the EVALUATE_BUFFER spelling"
+  END
+END
+
+DEFINE_ACTION_FUNCTION run
+  RET
+    success
+    message
+BEGIN
+  OUTER_SPRINT message "test_repeated_eval"
+  PRINT "%message%"
+  ACTION_TRY
+    LAF test_repeated_eval END
+    OUTER_SET success = 1
+  WITH
+    DEFAULT
+      OUTER_SET success = 0
+      OUTER_SPRINT message "tests failed in repeated_eval: %ERROR_MESSAGE%"
+  END
+END


### PR DESCRIPTION
## Summary

Document the existing WeiDU behavior that permits `EVAL` and
`EVALUATE_BUFFER` prefixes to be repeated for multiple variable-substitution
passes.

Add focused regression coverage to preserve the supported behavior.

## Verified semantics

The implementation confirms that repeated evaluation is deliberately supported:

- `EVAL` is registered as an alias of `EVALUATE_BUFFER`;
- both the current Elkhound grammar and the legacy parser grammar recursively
  accept another evaluable string after each prefix;
- every resulting `PE_Evaluate` node performs one `Var.get_string`
  substitution pass after evaluating its inner expression.

Consequently:

- `EVAL EVAL EVAL string` performs three additional substitution passes;
- nested prefixes are evaluated from the innermost occurrence outward;
- each prefix adds exactly one pass;
- repetition does not mean “evaluate until stable”;
- unset variables remain unchanged during a pass;
- cyclic references are not detected or automatically followed;
- `EVAL` and `EVALUATE_BUFFER` may be mixed;
- there is no language-defined maximum nesting depth, although normal parser
  and runtime resource limits still apply.

This is distinct from using `EVALUATE_BUFFER` as a standalone patch operation
on the current file buffer, where each consecutive operation likewise performs
one substitution pass.

## Changes

- expand the `EVALUATE_BUFFER` patch-operation documentation to explain
  consecutive substitution passes;
- document repeatable prefix evaluation in the `value` grammar;
- provide a general-purpose three-level indirection example;
- clarify evaluation order, fixed-pass behavior, unset-variable behavior,
  cyclic references, aliases, and practical resource limits;
- add a TP2 regression test covering:
  - three-pass variable-name indirection;
  - three nested `EVAL` prefixes on a string;
  - eight nested `EVAL` prefixes, guarding against a small fixed limit;
  - the full `EVALUATE_BUFFER` spelling.

## Validation

A temporary disposable GitHub Actions workflow validated the change:

https://github.com/4Luke4/weidu/actions/runs/31695453606

Successful steps:

```text
archived OCaml 4.08.1 unsafe-string setup
serial WeiDU build
repeated_eval.tpa parse-check
executable repeated-EVAL regression test
HTML documentation build
validation-artifact upload
```

The executable test reported:

```text
test_repeated_eval
SUCCESSFULLY INSTALLED      Repeated EVAL regression test
```

The disposable workflow used the archived compiler configuration established
by PR #381, avoiding the known Linux compiler-resolution failure in the
current `devel` workflow. PR #382’s separate Windows `src/reg.c` build issue
was also reviewed and is unrelated to this documentation and regression-test
change.

The temporary workflow and its test driver were removed from the branch
history after successful validation.