### PR TITLE
Make AUTO_EVAL_STRINGS evaluate COMPILE and EXTEND source buffers

### DIFF
--- a/README-WeiDU-Changes.txt
+++ b/README-WeiDU-Changes.txt
@@ -1,4 +1,6 @@
 Version 251:
+  * AUTO_EVAL_STRINGS evaluates source buffers used by COMPILE and the
+    EXTEND_TOP/EXTEND_BOTTOM action family before applying their patches.
   * CREATE called within CREATE works as expected.
   * CREATE sets SOURCE_* and DEST_* variables.
   * Auto-update does not fail if the filename of the newest WeiDU

--- a/doc/base.tex
+++ b/doc/base.tex
@@ -2912,7 +2912,11 @@ global option to your \ttref{TP2} file. \\
 
     \t{EVALUATE_BUFFER} is used whenever variables are evaluated. In
     particular, you can now "forget" about using it in FUNCTIONs and
-    arrays. Note, TP2 defines multiple instances of
+    arrays. It also implicitly evaluates the source buffers of
+    \ttref{COMPILE}, \ttref{EXTEND_TOP (TP2)},
+    \ttref{EXTEND_BOTTOM (TP2)}, \ttref{EXTEND_TOP_REGEXP}, and
+    \ttref{EXTEND_BOTTOM_REGEXP} before any patches supplied to those
+    actions are applied. Note, TP2 defines multiple instances of
     \t{EVALUATE_BUFFER}, like \ttref{EVALUATE_BUFFER}, but these are
     not affected by \ttref{AUTO_EVAL_STRINGS}. \emph{N.B.} This adds
     an additional level of \t{EVAL} to \ttref{OUTER_TEXT_SPRINT} and
@@ -3204,6 +3208,7 @@ MOVE (~sourceDirectory~ ~^[A-M].*\.itm$~) ~destinationDirectory
       sourceFile is a directory, all \ttref{D} and \ttref{BAF} files within
       that directory are processed individually. If there is \ttref{EVALUATE_BUFFER},
       all \verb+%variables%+ in the files are substituted with their values.
+      \ttref{AUTO_EVAL_STRINGS} performs the same substitution implicitly.
 
       After the special \ttref{EVALUATE_BUFFER} is executed, all other patches are executed.
 
@@ -3339,7 +3344,8 @@ P Q R 3
     folder. User variables in the filenames existingFile and newFile
     are replaced by their values.  Use \ttref{EVALUATE_BUFFER} if you
     want to evaluate variables inside the body of newFile before
-    parsing it. \\
+    parsing it; \ttref{AUTO_EVAL_STRINGS} performs this evaluation
+    implicitly. \\
 
   or & \t{\textbf{EXTEND_BOTTOM}}\index{EXTEND_BOTTOM (TP2)}
   \label{EXTEND_BOTTOM (TP2)} existingBCS newFile \ttref{patch}

--- a/src/tpaction.ml
+++ b/src/tpaction.ml
@@ -1666,6 +1666,10 @@ let rec process_action_real our_lang game this_tp2_filename tp a =
       end
 
       | TP_Compile(eval,dlg_l,pl,tra_l) -> begin
+          (* AUTO_EVAL_STRINGS makes COMPILE follow the same buffer pipeline as
+           * its explicit EVALUATE_BUFFER form: evaluate first, then apply the
+           * action's ordinary patches. *)
+          let eval = eval || tp.is_auto_eval_string in
           let dlg_l =  List.map (fun x -> Var.get_string x) dlg_l in
           let tra_l =  List.map (fun x -> Var.get_string x) tra_l in
           let dlg_l =  List.map (fun x -> Arch.backslash_to_slash x) dlg_l in
@@ -2057,6 +2061,12 @@ let rec process_action_real our_lang game this_tp2_filename tp a =
                  setup.tra\n" src) ;
           let src_script =
             let src_buff = load_file src in
+            (* As with COMPILE, automatic evaluation belongs before the
+             * caller-supplied patch list so both forms have identical
+             * ordering semantics. *)
+            let src_buff =
+              if tp.is_auto_eval_string then Var.get_string src_buff
+              else src_buff in
             if (!has_if_eval_bug) then begin
               (try
                 List.iter (fun p -> process_patch1 src game src_buff p) pl ;

--- a/test/README
+++ b/test/README
@@ -25,3 +25,7 @@ traify/*
 
 tp2/tp2_regression_tests/*
         A collection of tests for TP2 functionality. Install as a WeiDU mod.
+
+tp2/auto_eval_strings/run.sh
+        Verifies that AUTO_EVAL_STRINGS evaluates COMPILE and EXTEND source
+        buffers before their ordinary patch lists.

--- a/test/tp2/auto_eval_strings/compile.baf
+++ b/test/tp2/auto_eval_strings/compile.baf
@@ -1,0 +1,1 @@
+%issue_75_compile_body%

--- a/test/tp2/auto_eval_strings/extend.baf
+++ b/test/tp2/auto_eval_strings/extend.baf
@@ -1,0 +1,1 @@
+%issue_75_extend_body%

--- a/test/tp2/auto_eval_strings/run.sh
+++ b/test/tp2/auto_eval_strings/run.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+script_dir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+repo_root=$(cd -- "$script_dir/../../.." && pwd)
+weidu=${1:-"$repo_root/weidu"}
+
+if [[ ! -x "$weidu" ]]; then
+  echo "WeiDU executable is not available at $weidu" >&2
+  exit 1
+fi
+
+weidu=$(cd -- "$(dirname -- "$weidu")" && pwd)/$(basename -- "$weidu")
+work_dir=$(mktemp -d)
+
+cleanup() {
+  if [[ -n "${work_dir:-}" && -d "$work_dir" ]]; then
+    rm -rf -- "$work_dir"
+  fi
+}
+trap cleanup EXIT HUP INT TERM
+
+mkdir -p "$work_dir/auto-eval-strings"
+cp -- "$script_dir/compile.baf" "$script_dir/extend.baf" \
+  "$work_dir/auto-eval-strings/"
+cp -- "$script_dir/setup-auto-eval-strings.tp2" "$work_dir/"
+
+cd -- "$work_dir"
+"$weidu" setup-auto-eval-strings.tp2 \
+  --nogame \
+  --noautoupdate \
+  --no-exit-pause \
+  --force-install 0
+
+expected_outputs=(
+  override/compile.bcs
+  override/issue75-top.bcs
+  override/issue75-bottom.bcs
+  override/issue75-regexp-top.bcs
+  override/issue75-regexp-bottom.bcs
+)
+
+for output in "${expected_outputs[@]}"; do
+  if [[ ! -f "$output" ]]; then
+    echo "AUTO_EVAL_STRINGS test did not create $output" >&2
+    exit 1
+  fi
+done

--- a/test/tp2/auto_eval_strings/setup-auto-eval-strings.tp2
+++ b/test/tp2/auto_eval_strings/setup-auto-eval-strings.tp2
@@ -1,0 +1,24 @@
+BACKUP ~auto-eval-strings/backup~
+AUTHOR ~WeiDU.org~
+
+AUTO_EVAL_STRINGS
+
+BEGIN ~AUTO_EVAL_STRINGS source-buffer evaluation~
+
+OUTER_SPRINT issue_75_compile_body ~issue-75-compile~
+OUTER_SPRINT issue_75_extend_body ~issue-75-extend~
+
+COMPILE ~auto-eval-strings/compile.baf~
+  REPLACE_TEXTUALLY EXACT_MATCH ~issue-75-compile~ ~// evaluated compile source~
+
+EXTEND_TOP ~issue75-top.bcs~ ~auto-eval-strings/extend.baf~
+  REPLACE_TEXTUALLY EXACT_MATCH ~issue-75-extend~ ~// evaluated extend source~
+
+EXTEND_BOTTOM ~issue75-bottom.bcs~ ~auto-eval-strings/extend.baf~
+  REPLACE_TEXTUALLY EXACT_MATCH ~issue-75-extend~ ~// evaluated extend source~
+
+EXTEND_TOP_REGEXP ~issue75-regexp-top.bcs~ ~auto-eval-strings/extend.baf~
+  REPLACE_TEXTUALLY EXACT_MATCH ~issue-75-extend~ ~// evaluated extend source~
+
+EXTEND_BOTTOM_REGEXP ~issue75-regexp-bottom.bcs~ ~auto-eval-strings/extend.baf~
+  REPLACE_TEXTUALLY EXACT_MATCH ~issue-75-extend~ ~// evaluated extend source~


### PR DESCRIPTION
## Summary

Make `AUTO_EVAL_STRINGS` implicitly evaluate source buffers used by:

- `COMPILE`
- `EXTEND_TOP`
- `EXTEND_BOTTOM`
- `EXTEND_TOP_REGEXP`
- `EXTEND_BOTTOM_REGEXP`

The implicit evaluation occurs before any ordinary patches supplied to the action, matching the established ordering of `COMPILE EVALUATE_BUFFER`.

Behavior remains unchanged when `AUTO_EVAL_STRINGS` is not enabled.

Fixes #75.

## Implementation

For `COMPILE`, combine the action's explicit `EVALUATE_BUFFER` setting with the TP2 file's `AUTO_EVAL_STRINGS` flag and reuse the existing evaluated-buffer pipeline.

For the shared `EXTEND_*` implementation, evaluate the loaded source buffer when `AUTO_EVAL_STRINGS` is enabled, before applying the action's patch list and parsing the resulting script.

This shared path covers both ordinary and regexp variants without duplicating their behavior.

## Regression coverage

Add a standalone no-game regression harness under:

```text
test/tp2/auto_eval_strings
```

The fixture source files initially contain WeiDU variable references. Those variables evaluate to intermediate markers, which subsequent `REPLACE_TEXTUALLY` patches turn into valid script comments.

This verifies both required properties:

1. source-buffer evaluation occurs automatically;
2. evaluation occurs before the ordinary patch list.

The harness verifies generated output for:

- `COMPILE`
- `EXTEND_TOP`
- `EXTEND_BOTTOM`
- `EXTEND_TOP_REGEXP`
- `EXTEND_BOTTOM_REGEXP`

## Documentation

Update:

- the `AUTO_EVAL_STRINGS` reference;
- the `COMPILE` reference;
- the `EXTEND_TOP`/`EXTEND_BOTTOM` reference;
- the changelog;
- the regression-test index.

## Validation

A temporary disposable GitHub Actions workflow completed successfully:

https://github.com/4Luke4/weidu/actions/runs/32664547969

The workflow verified:

- archived OCaml 4.08.1 unsafe-string setup using the repository configuration established by PR #381;
- full WeiDU compilation;
- WeiDU 25201 execution;
- the focused `AUTO_EVAL_STRINGS` regression harness;
- documentation rendering with HeVeA;
- `git diff --check`;
- shell syntax validation of the regression runner.

The platform-independent behavior was tested on Linux. This avoids the unrelated current MinGW `src/reg.c` diagnostics addressed separately by PR #382.

The disposable workflow was removed after validation by rewriting the branch to a single final commit. It is not present in the final tree or branch history.