### PR TITLE
Docs: tabulate standard macro and function interfaces

### DIFF
--- a/doc/base.tex
+++ b/doc/base.tex
@@ -28,6 +28,17 @@
 \def\Ob{{\color{red} [ }}
 \def\Oe{{\color{red} ] }}
 
+% Keep the standard-library parameter documentation structurally consistent.
+% A dedicated environment also gives the HTML renderer one stable table shape
+% for every macro and function, instead of relying on prose-list conventions.
+\newenvironment{weiduarguments}
+  {\begin{tabular}{|l|l|p{5in}|l|}
+   \hline
+   \textbf{Variable type} & \textbf{Variable name} & \textbf{Description} & \textbf{Default value} \\
+   \hline}
+  {\hline
+   \end{tabular}}
+
 % This is to make hevea happy (indexing)
 \def\textexcl{!}
 \def\textpipe{|}
@@ -8928,318 +8939,360 @@ END
 
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-\label{sec-macros-listing}\section{Macros Listing}
+\label{sec-macros-listing}\section{Standard Macros and Functions}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-These macros are automatically shipped with WeiDU.
+These macros and functions are automatically shipped with WeiDU.
+
+The parameter tables distinguish integer variables, string variables,
+associative arrays and return values. Function inputs are formal arguments
+unless explicitly identified as caller-scope variables. Macro inputs are
+always caller-scope variables. When an entry is available both as a macro and
+as a function, the default-value column describes the function; macro callers
+must initialise their inputs unless the entry says otherwise. Caller-scope
+variables must be defined before launching a function and must not be listed
+in its \verb+INT_VAR+ or \verb+STR_VAR+ block. This distinction is significant
+when \ttref{MODDER} \verb+fun_args+ checking is enabled.
+\emph{Not specified} means the implementation does not declare a function
+default and the legacy documentation does not state one. Return values and
+arrays have no input default and are marked \emph{Not applicable}.
 
 \verb+tb#factorial+: computes the factorial of a number. \\
 This is a PATCH macro.
-\begin{itemize}
-\item SET \verb+tb#factorial_index+ to the factorial you'd like to compute.
-\item SET \verb+tb#factorial_result+ to 1;
-\item The result is \verb+tb#factorial_result+.
-\end{itemize}
+\begin{weiduarguments}
+Integer variable & \verb+tb#factorial_index+ & the factorial you'd like to compute. & \emph{Not specified} \\
+Integer variable & \verb+tb#factorial_result+ & 1; & \emph{Not specified} \\
+Return value & \verb+tb#factorial_result+ & Result produced by the macro. & Not applicable \\
+\end{weiduarguments}
+
 
 \verb+tb#fix_file_size+: overwrites all files matching a certain regexp with a
 certain standard file, if they are under a certain size. \\
 This is an ACTION macro.
-\begin{itemize}
-\item SET \verb+tb#fix_file_size_min+ to the maximum allowed size
-(files whose size is exactly this value are NOT overwritten).
-\item SPRINT \verb+tb#fix_file_size_target+ to the standard file used to replace file(s) that match the regexp.
-\item SPRINT \verb+tb#fix_file_size_category+ to a descriptive name.
-\item SPRINT \verb+tb#fix_file_size_regexp+ to the regexp for the file(s) to be checked for a match.
-\end{itemize}
+\begin{weiduarguments}
+Integer variable & \verb+tb#fix_file_size_min+ & the maximum allowed size (files whose size is exactly this value are NOT overwritten). & \emph{Not specified} \\
+String variable & \verb+tb#fix_file_size_target+ & the standard file used to replace file(s) that match the regexp. & \emph{Not specified} \\
+String variable & \verb+tb#fix_file_size_category+ & a descriptive name. & \emph{Not specified} \\
+String variable & \verb+tb#fix_file_size_regexp+ & the regexp for the file(s) to be checked for a match. & \emph{Not specified} \\
+\end{weiduarguments}
+
 
 \\
 
-Note that, differently from the standalone versions, for these macros you \emph{need}
-to set all the needed values - they aren't initialized automatically. This is untrue functions
-(they are initialized to either 0 or the empty string, except for \verb+probability1+ which is initialized to 100).
+Unlike the function forms, macros do not initialise their parameters. Macro
+callers therefore need to set every required value before launching the macro.
 
 \verb+DELETE_SPELL_EFFECT+: deletes all extended effects with specified opcode from a spell.
 This is a PATCH macro and function.
-\begin{itemize}
-\item SET \verb+opcode_to_delete+ to the opcode of the effect you want to delete. Opcode of (-1) will match all effects.
-\end{itemize}
+\begin{weiduarguments}
+Integer variable & \verb+opcode_to_delete+ & the opcode of the effect you want to delete. Opcode of (-1) will match all effects. & \verb+0+ \\
+\end{weiduarguments}
+
 
 \verb+DELETE_ITEM_EFFECT+: deletes all extended effects with specified opcode from an item.
 This is a PATCH macro and function.
-\begin{itemize}
-\item SET \verb+opcode_to_delete+ to the opcode of the effect you want to delete. Opcode of (-1) will match all effects.
-\end{itemize}
+\begin{weiduarguments}
+Integer variable & \verb+opcode_to_delete+ & the opcode of the effect you want to delete. Opcode of (-1) will match all effects. & \verb+0+ \\
+\end{weiduarguments}
+
 
 \verb+DELETE_ITEM_EQEFFECT+: deletes all equipping effects with specified opcode from an item.
 This is a PATCH macro and function.
-\begin{itemize}
-\item SET \verb+opcode_to_delete+ to the opcode of the effect you want to delete. Opcode of (-1) will match all effects.
-\end{itemize}
+\begin{weiduarguments}
+Integer variable & \verb+opcode_to_delete+ & the opcode of the effect you want to delete. Opcode of (-1) will match all effects. & \verb+0+ \\
+\end{weiduarguments}
+
 
 \verb+DELETE_CRE_EFFECT+: deletes all effects with specified opcode from a creature. (Warning: doesn't check EFF version)
 This is a PATCH macro and function.
-\begin{itemize}
-\item SET \verb+opcode_to_delete+ to the opcode of the effect you want to delete. Opcode of (-1) will match all effects.
-\end{itemize}
+\begin{weiduarguments}
+Integer variable & \verb+opcode_to_delete+ & the opcode of the effect you want to delete. Opcode of (-1) will match all effects. & \verb+0+ \\
+\end{weiduarguments}
+
 
 \verb+ITEM_EFFECT_TO_SPELL+: copies all extended effects from the current item to the first extended header of a spell.
 This is a PATCH macro and function.
-\begin{itemize}
-\item SET \verb+type+ to the header type to copy the effect from (use 99 to specify 'all types').
-\item SET \verb+header+ to number of extended header the effect should be copied from (use 99 to specify 'every header').
-\item SET \verb+insert_point+ to the index into the spell file at which the effects should be inserted. A value of 0 will have the effects inserted as the first effects of the spell. Effects are inserted as the last effects by default.
-\item SPRINT \verb+new_itm_spl+ to a spell you want to copy effects to.
-\end{itemize}
+\begin{weiduarguments}
+Integer variable & \verb+type+ & the header type to copy the effect from (use 99 to specify 'all types'). & \verb+3+ \\
+Integer variable & \verb+header+ & number of extended header the effect should be copied from (use 99 to specify 'every header'). & \verb+99+ \\
+Integer variable & \verb+insert_point+ & the index into the spell file at which the effects should be inserted. A value of 0 will have the effects inserted as the first effects of the spell. Effects are inserted as the last effects by default. & \verb+-1+ \\
+String variable & \verb+new_itm_spl+ & a spell you want to copy effects to. & \verb+0+ \\
+\end{weiduarguments}
+
 
 \verb+ADD_SPELL_EFFECT+: adds an extended effect to a spell. All variables except \verb+probability1+ and \verb+insert_point+ are 0 by default.
 This is a PATCH macro and function.
-\begin{itemize}
-\item SET \verb+opcode+ to opcode
-\item SET \verb+target+ to target type
-\item SET \verb+timing+ to timing type
-\item SET \verb+parameter1+ to first parameter
-\item SET \verb+parameter2+ to second parameter
-\item SET \verb+power+ to power
-\item SET \verb+resist_dispel+ to magic resistance/dispel type
-\item SET \verb+duration+ to duration
-\item SET \verb+probability1+ to probability 1 (default 100)
-\item SET \verb+probability2+ to probability 2
-\item SPRINT \verb+resource+ to resource (8 chars max)
-\item SET \verb+dicenumber+ to number of dices to be thrown
-\item SET \verb+dicesize+ to size of dices to be thrown
-\item SET \verb+savingthrow+ to type of savingthrow to be allowed against the effect
-\item SET \verb+savebonus+ to saving throw bonus
-\item SET \verb+special+ to the special parameter (only valid for functions; not macros)
-\item SET \verb+header+ to number of extended header (starting from 1) the effect should be added to (by default the effect is added to every header).
-\item SET \verb+insert_point+ to the position of the effect. If this variable is 0 the effect will be inserted as the first effect of the extended header. If this variable is negative or greater than the number of effects, the effect will be inserted as the last effect. The effect is added as the last effect by default.
-\end{itemize}
+\begin{weiduarguments}
+Integer variable & \verb+opcode+ & opcode & \verb+0+ \\
+Integer variable & \verb+target+ & target type & \verb+0+ \\
+Integer variable & \verb+timing+ & timing type & \verb+0+ \\
+Integer variable & \verb+parameter1+ & first parameter & \verb+0+ \\
+Integer variable & \verb+parameter2+ & second parameter & \verb+0+ \\
+Integer variable & \verb+power+ & power & \verb+0+ \\
+Integer variable & \verb+resist_dispel+ & magic resistance/dispel type & \verb+0+ \\
+Integer variable & \verb+duration+ & duration & \verb+0+ \\
+Integer variable & \verb+probability1+ & probability 1 (default 100) & \verb+100+ \\
+Integer variable & \verb+probability2+ & probability 2 & \verb+0+ \\
+String variable & \verb+resource+ & resource (8 chars max) & Empty string \\
+Integer variable & \verb+dicenumber+ & number of dices to be thrown & \verb+0+ \\
+Integer variable & \verb+dicesize+ & size of dices to be thrown & \verb+0+ \\
+Integer variable & \verb+savingthrow+ & type of savingthrow to be allowed against the effect & \verb+0+ \\
+Integer variable & \verb+savebonus+ & saving throw bonus & \verb+0+ \\
+Integer variable & \verb+special+ & the special parameter (only valid for functions; not macros) & \verb+0+ \\
+Integer variable & \verb+header+ & number of extended header (starting from 1) the effect should be added to (by default the effect is added to every header). & \verb+0+ \\
+Integer variable & \verb+insert_point+ & the position of the effect. If this variable is 0 the effect will be inserted as the first effect of the extended header. If this variable is negative or greater than the number of effects, the effect will be inserted as the last effect. The effect is added as the last effect by default. & \verb+-1+ \\
+\end{weiduarguments}
+
 
 \verb+ADD_ITEM_EFFECT+: adds an extended effect to an item. All variables except \verb+probability1+, \verb+type+ and \verb+insert_point+ are 0 by default.
 This is a PATCH macro and function.
-\begin{itemize}
-\item SET \verb+opcode+ to opcode
-\item SET \verb+target+ to target type
-\item SET \verb+timing+ to timing type
-\item SET \verb+parameter1+ to first parameter
-\item SET \verb+parameter2+ to second parameter
-\item SET \verb+power+ to power
-\item SET \verb+resist_dispel+ to magic resistance/dispel type
-\item SET \verb+duration+ to duration
-\item SET \verb+probability1+ to probability 1 (default 100)
-\item SET \verb+probability2+ to probability 2
-\item SPRINT \verb+resource+ to resource (8 chars max)
-\item SET \verb+dicenumber+ to number of dices to be thrown
-\item SET \verb+dicesize+ to size of dices to be thrown
-\item SET \verb+savingthrow+ to type of savingthrow to be allowed against the effect
-\item SET \verb+savebonus+ to saving throw bonus
-\item SET \verb+special+ to the special parameter (only valid for functions; not macros)
-\item SET \verb+header+ to number of extended header (starting from 1) the effect should be added to (by default the effect is added to every header).
-\item SET \verb+type+ to the type of header to which the effect should be added or 99 for all types. Defaults to 3 (magic).
-\item SET \verb+insert_point+ to the position of the effect. If this variable is 0 the effect will be inserted as the first effect of the extended header. If this variable is negative or greater than the number of effects, the effect will be inserted as the last effect. The effect is added as the last effect by default.
-\end{itemize}
+\begin{weiduarguments}
+Integer variable & \verb+opcode+ & opcode & \verb+0+ \\
+Integer variable & \verb+target+ & target type & \verb+0+ \\
+Integer variable & \verb+timing+ & timing type & \verb+0+ \\
+Integer variable & \verb+parameter1+ & first parameter & \verb+0+ \\
+Integer variable & \verb+parameter2+ & second parameter & \verb+0+ \\
+Integer variable & \verb+power+ & power & \verb+0+ \\
+Integer variable & \verb+resist_dispel+ & magic resistance/dispel type & \verb+0+ \\
+Integer variable & \verb+duration+ & duration & \verb+0+ \\
+Integer variable & \verb+probability1+ & probability 1 (default 100) & \verb+100+ \\
+Integer variable & \verb+probability2+ & probability 2 & \verb+0+ \\
+String variable & \verb+resource+ & resource (8 chars max) & Empty string \\
+Integer variable & \verb+dicenumber+ & number of dices to be thrown & \verb+0+ \\
+Integer variable & \verb+dicesize+ & size of dices to be thrown & \verb+0+ \\
+Integer variable & \verb+savingthrow+ & type of savingthrow to be allowed against the effect & \verb+0+ \\
+Integer variable & \verb+savebonus+ & saving throw bonus & \verb+0+ \\
+Integer variable & \verb+special+ & the special parameter (only valid for functions; not macros) & \verb+0+ \\
+Integer variable & \verb+header+ & number of extended header (starting from 1) the effect should be added to (by default the effect is added to every header). & \verb+0+ \\
+Integer variable & \verb+type+ & the type of header to which the effect should be added or 99 for all types. Defaults to 3 (magic). & \verb+3+ \\
+Integer variable & \verb+insert_point+ & the position of the effect. If this variable is 0 the effect will be inserted as the first effect of the extended header. If this variable is negative or greater than the number of effects, the effect will be inserted as the last effect. The effect is added as the last effect by default. & \verb+-1+ \\
+\end{weiduarguments}
+
 
 \verb+ADD_ITEM_EQEFFECT+: adds an equipping effect to an item. All variables except \verb+probability1+ are 0 by default.
 This is a PATCH macro and function.
-\begin{itemize}
-\item SET \verb+opcode+ to opcode
-\item SET \verb+target+ to target type
-\item SET \verb+timing+ to timing type
-\item SET \verb+parameter1+ to first parameter
-\item SET \verb+parameter2+ to second parameter
-\item SET \verb+power+ to power
-\item SET \verb+resist_dispel+ to magic resistance/dispel type
-\item SET \verb+duration+ to duration
-\item SET \verb+probability1+ to probability 1 (default 100)
-\item SET \verb+probability2+ to probability 2
-\item SPRINT \verb+resource+ to resource (8 chars max)
-\item SET \verb+dicenumber+ to number of dices to be thrown
-\item SET \verb+dicesize+ to size of dices to be thrown
-\item SET \verb+savingthrow+ to type of savingthrow to be allowed against the effect
-\item SET \verb+savebonus+ to saving throw bonus
-\item SET \verb+special+ to the special parameter (only valid for functions; not macros)
-\item SET \verb+insert_point+ to the position of the effect. If this variable is 0 the effect will be inserted as the first effect of the extended header. If this variable is negative or greater than the number of effects, the effect will be inserted as the last effect. The effect is added as the first effect by default.
-\end{itemize}
+\begin{weiduarguments}
+Integer variable & \verb+opcode+ & opcode & \verb+0+ \\
+Integer variable & \verb+target+ & target type & \verb+0+ \\
+Integer variable & \verb+timing+ & timing type & \verb+0+ \\
+Integer variable & \verb+parameter1+ & first parameter & \verb+0+ \\
+Integer variable & \verb+parameter2+ & second parameter & \verb+0+ \\
+Integer variable & \verb+power+ & power & \verb+0+ \\
+Integer variable & \verb+resist_dispel+ & magic resistance/dispel type & \verb+0+ \\
+Integer variable & \verb+duration+ & duration & \verb+0+ \\
+Integer variable & \verb+probability1+ & probability 1 (default 100) & \verb+100+ \\
+Integer variable & \verb+probability2+ & probability 2 & \verb+0+ \\
+String variable & \verb+resource+ & resource (8 chars max) & Empty string \\
+Integer variable & \verb+dicenumber+ & number of dices to be thrown & \verb+0+ \\
+Integer variable & \verb+dicesize+ & size of dices to be thrown & \verb+0+ \\
+Integer variable & \verb+savingthrow+ & type of savingthrow to be allowed against the effect & \verb+0+ \\
+Integer variable & \verb+savebonus+ & saving throw bonus & \verb+0+ \\
+Integer variable & \verb+special+ & the special parameter (only valid for functions; not macros) & \verb+0+ \\
+Integer variable & \verb+insert_point+ & the position of the effect. If this variable is 0 the effect will be inserted as the first effect of the extended header. If this variable is negative or greater than the number of effects, the effect will be inserted as the last effect. The effect is added as the first effect by default. & \verb+0+ \\
+\end{weiduarguments}
+
 
 \verb+ADD_SPELL_CFEFFECT+: adds a casting-feature effect to a spell. All variables except \verb+probability1+ are 0 by default.
 This is a PATCH macro and function.
-\begin{itemize}
-\item SET \verb+opcode+ to opcode
-\item SET \verb+target+ to target type
-\item SET \verb+timing+ to timing type
-\item SET \verb+parameter1+ to first parameter
-\item SET \verb+parameter2+ to second parameter
-\item SET \verb+power+ to power
-\item SET \verb+resist_dispel+ to magic resistance/dispel type
-\item SET \verb+duration+ to duration
-\item SET \verb+probability1+ to probability 1 (default 100)
-\item SET \verb+probability2+ to probability 2
-\item SPRINT \verb+resource+ to resource (8 chars max)
-\item SET \verb+dicenumber+ to number of dices to be thrown
-\item SET \verb+dicesize+ to size of dices to be thrown
-\item SET \verb+savingthrow+ to type of savingthrow to be allowed against the effect
-\item SET \verb+savebonus+ to saving throw bonus
-\item SET \verb+special+ to the special parameter (only valid for functions; not macros)
-\item SET \verb+insert_point+ to the position of the effect. If this variable is 0 the effect will be inserted as the first effect of the extended header. If this variable is negative or greater than the number of effects, the effect will be inserted as the last effect. The effect is added as the first effect by default.
-\end{itemize}
+\begin{weiduarguments}
+Integer variable & \verb+opcode+ & opcode & \verb+0+ \\
+Integer variable & \verb+target+ & target type & \verb+0+ \\
+Integer variable & \verb+timing+ & timing type & \verb+0+ \\
+Integer variable & \verb+parameter1+ & first parameter & \verb+0+ \\
+Integer variable & \verb+parameter2+ & second parameter & \verb+0+ \\
+Integer variable & \verb+power+ & power & \verb+0+ \\
+Integer variable & \verb+resist_dispel+ & magic resistance/dispel type & \verb+0+ \\
+Integer variable & \verb+duration+ & duration & \verb+0+ \\
+Integer variable & \verb+probability1+ & probability 1 (default 100) & \verb+100+ \\
+Integer variable & \verb+probability2+ & probability 2 & \verb+0+ \\
+String variable & \verb+resource+ & resource (8 chars max) & Empty string \\
+Integer variable & \verb+dicenumber+ & number of dices to be thrown & \verb+0+ \\
+Integer variable & \verb+dicesize+ & size of dices to be thrown & \verb+0+ \\
+Integer variable & \verb+savingthrow+ & type of savingthrow to be allowed against the effect & \verb+0+ \\
+Integer variable & \verb+savebonus+ & saving throw bonus & \verb+0+ \\
+Integer variable & \verb+special+ & the special parameter (only valid for functions; not macros) & \verb+0+ \\
+Integer variable & \verb+insert_point+ & the position of the effect. If this variable is 0 the effect will be inserted as the first effect of the extended header. If this variable is negative or greater than the number of effects, the effect will be inserted as the last effect. The effect is added as the first effect by default. & \verb+0+ \\
+\end{weiduarguments}
+
 
 \verb+ADD_CRE_EFFECT+: adds an effect to a creature. All variables except probability1 are 0 by default.
 This is a PATCH macro and function.
-\begin{itemize}
-\item SET \verb+opcode+ to opcode
-\item SET \verb+timing+ to timing type
-\item SET \verb+target+ to target type
-\item SET \verb+parameter1+ to first parameter
-\item SET \verb+parameter2+ to second parameter
-\item SET \verb+parameter3+ to third parameter
-\item SET \verb+parameter4+ to forth parameter
-\item SET \verb+power+ to power
-\item SET \verb+resist_dispel+ to magic resistance/dispel type
-\item SET \verb+duration+ to duration
-\item SET \verb+probability1+ to probability 1 (default 100)
-\item SET \verb+probability2+ to probability 2
-\item SPRINT \verb+resource+ to resource (8 chars max)
-\item SPRINT \verb+resource2+ to second resource (8 chars max)
-\item SPRINT \verb+vvcresource+ to VVC resource (8 chars max)
-\item SPRINT \verb+effsource+ to effect source
-\item SPRINT \verb+effvar+ to effect variable
-\item SET \verb+dicenumber+ to number of dices to be thrown
-\item SET \verb+dicesize+ to size of dices to be thrown
-\item SET \verb+savingthrow+ to type of savingthrow to be allowed against the effect
-\item SET \verb+savebonus+ to saving throw bonus
-\item SET \verb+school+ to magical school
-\item SET \verb+special+ to the special parameter (only valid for functions; not macros)
-\item SET \verb+lowestafflvl+ to lowest affected level
-\item SET \verb+highestafflvl+ to highest affected level
-\item SET \verb+casterx+ to caster X position
-\item SET \verb+castery+ to caster Y position
-\item SET \verb+targetx+ to target X position
-\item SET \verb+targety+ to target Y position
-\item SET \verb+restype+ to source resource type
-\item SET \verb+sourceslot+ to source resource slot
-\item SET \verb+casterlvl+ to caster level
-\item SET \verb+sectype+ to secondary type
-\item SET \verb+insert_point+ to the index at which the new effect
-  is to be inserted. 0 is first and negative values or values
-  equal to or exceeding the existing number of effects are last.
-\end{itemize}
+\begin{weiduarguments}
+Integer variable & \verb+opcode+ & opcode & \verb+0+ \\
+Integer variable & \verb+timing+ & timing type & \verb+0+ \\
+Integer variable & \verb+target+ & target type & \verb+0+ \\
+Integer variable & \verb+parameter1+ & first parameter & \verb+0+ \\
+Integer variable & \verb+parameter2+ & second parameter & \verb+0+ \\
+Integer variable & \verb+parameter3+ & third parameter & \verb+0+ \\
+Integer variable & \verb+parameter4+ & forth parameter & \verb+0+ \\
+Integer variable & \verb+power+ & power & \verb+0+ \\
+Integer variable & \verb+resist_dispel+ & magic resistance/dispel type & \verb+0+ \\
+Integer variable & \verb+duration+ & duration & \verb+0+ \\
+Integer variable & \verb+probability1+ & probability 1 (default 100) & \verb+100+ \\
+Integer variable & \verb+probability2+ & probability 2 & \verb+0+ \\
+String variable & \verb+resource+ & resource (8 chars max) & Empty string \\
+String variable & \verb+resource2+ & second resource (8 chars max) & Empty string \\
+String variable & \verb+vvcresource+ & VVC resource (8 chars max) & Empty string \\
+String variable & \verb+effsource+ & effect source & Empty string \\
+String variable & \verb+effvar+ & effect variable & Empty string \\
+Integer variable & \verb+dicenumber+ & number of dices to be thrown & \verb+0+ \\
+Integer variable & \verb+dicesize+ & size of dices to be thrown & \verb+0+ \\
+Integer variable & \verb+savingthrow+ & type of savingthrow to be allowed against the effect & \verb+0+ \\
+Integer variable & \verb+savebonus+ & saving throw bonus & \verb+0+ \\
+Integer variable & \verb+school+ & magical school & \verb+0+ \\
+Integer variable & \verb+special+ & the special parameter (only valid for functions; not macros) & \verb+0+ \\
+Integer variable & \verb+lowestafflvl+ & lowest affected level & \verb+0+ \\
+Integer variable & \verb+highestafflvl+ & highest affected level & \verb+0+ \\
+Integer variable & \verb+casterx+ & caster X position & \verb+-1+ \\
+Integer variable & \verb+castery+ & caster Y position & \verb+-1+ \\
+Integer variable & \verb+targetx+ & target X position & \verb+-1+ \\
+Integer variable & \verb+targety+ & target Y position & \verb+-1+ \\
+Integer variable & \verb+restype+ & source resource type & \verb+0+ \\
+Integer variable & \verb+sourceslot+ & source resource slot & \verb+-1+ \\
+Integer variable & \verb+casterlvl+ & caster level & \verb+0+ \\
+Integer variable & \verb+sectype+ & secondary type & \verb+0+ \\
+Integer variable & \verb+insert_point+ & the index at which the new effect is to be inserted. 0 is first and negative values or values equal to or exceeding the existing number of effects are last. & \verb+0+ \\
+\end{weiduarguments}
+
 
 \verb+DELETE_CRE_ITEM+: deletes all matching items from a creature. Regexp allowed.
 This is a PATCH macro and function.
-\begin{itemize}
-\item SPRINT \verb+item_to_delete+ to the item you want to delete.
-\end{itemize}
+\begin{weiduarguments}
+String variable & \verb+item_to_delete+ & the item you want to delete. & Empty string \\
+\end{weiduarguments}
+
 
 \verb+DELETE_STORE_ITEM+: deletes all matching items from a store. Regexp allowed.
 This is a PATCH macro and function.
-\begin{itemize}
-\item SPRINT \verb+item_to_delete+ to the item you want to delete.
-\end{itemize}
+\begin{weiduarguments}
+String variable & \verb+item_to_delete+ & the item you want to delete. & Empty string \\
+\end{weiduarguments}
+
 
 \verb+DELETE_AREA_ITEM+: deletes all matching items from an area. Regexp allowed.
 This is a PATCH macro and function.
-\begin{itemize}
-\item SPRINT \verb+item_to_delete+ to the item you want to delete.
-\end{itemize}
+\begin{weiduarguments}
+String variable & \verb+item_to_delete+ & the item you want to delete. & Empty string \\
+\end{weiduarguments}
+
 
 \verb+REPLACE_STORE_ITEM+: replaces all matching items in a store with another item. Regexp allowed.
 This is a PATCH macro and function.
-\begin{itemize}
-\item SPRINT \verb+old_item+ to the item you want to be replaced
-\item SPRINT \verb+new_item+ to the new item
-\item SET \verb+number_in_stock+ to number of new items in stock (default 0)
-\item SPRINT \verb+flags+ to flags new item should have (usual weidu syntax: STOLEN, IDENTIFIED&STOLEN, etc). Default - no flags.
-\item SET \verb+charges1+ to number of charges of first magical ability (default 0)
-\item SET \verb+charges2+ to number of charges of second magical ability (default 0)
-\item SET \verb+charges3+ to number of charges of third magical ability (default 0)
-\end{itemize}
+\begin{weiduarguments}
+String variable & \verb+old_item+ & the item you want to be replaced & Empty string \\
+String variable & \verb+new_item+ & the new item & Empty string \\
+Integer variable & \verb+number_in_stock+ & number of new items in stock (default 0) & \verb+0+ \\
+String variable & \verb+flags+ & flags new item should have (usual weidu syntax: STOLEN, IDENTIFIED\&STOLEN, etc). Default - no flags. & Empty string \\
+Integer variable & \verb+charges1+ & number of charges of first magical ability (default 0) & \verb+0+ \\
+Integer variable & \verb+charges2+ & number of charges of second magical ability (default 0) & \verb+0+ \\
+Integer variable & \verb+charges3+ & number of charges of third magical ability (default 0) & \verb+0+ \\
+\end{weiduarguments}
+
 
 \verb+REPLACE_AREA_ITEM+: replaces all matching items in an area with another item. Regexp allowed.
 This is a PATCH macro and function.
-\begin{itemize}
-\item SPRINT \verb+old_item+ to the item you want to be replaced
-\item SPRINT \verb+new_item+ to the new item
-\item SPRINT \verb+flags+ to flags the new item should have (usual weidu syntax: STOLEN, IDENTIFIED&STOLEN, etc). Default - no flags.
-\item SET \verb+charges1+ to amount in stock/number of charges of first magical ability (default 0)
-\item SET \verb+charges2+ to number of charges of second magical ability (default 0)
-\item SET \verb+charges3+ to number of charges of third magical ability (default 0)
-\end{itemize}
+\begin{weiduarguments}
+String variable & \verb+old_item+ & the item you want to be replaced & Empty string \\
+String variable & \verb+new_item+ & the new item & Empty string \\
+String variable & \verb+flags+ & flags the new item should have (usual weidu syntax: STOLEN, IDENTIFIED\&STOLEN, etc). Default - no flags. & Empty string \\
+Integer variable & \verb+charges1+ & amount in stock/number of charges of first magical ability (default 0) & \verb+0+ \\
+Integer variable & \verb+charges2+ & number of charges of second magical ability (default 0) & \verb+0+ \\
+Integer variable & \verb+charges3+ & number of charges of third magical ability (default 0) & \verb+0+ \\
+\end{weiduarguments}
+
 
 \verb+ADD_AREA_ITEM+: adds an item to a container of an area.
 This is a PATCH macro and function.
-\begin{itemize}
-\item SPRINT \verb+item_to_add+ to the item you want to add
-\item SET \verb+container_to_add_to+ to the number of the container the item should be added to. The count starts at 1.
-\item SPRINT \verb+flags+ to flags the item should have (usual weidu syntax: STOLEN, IDENTIFIED&STOLEN, etc). Default - no flags.
-\item SET \verb+charges1+ to amount in stock/number of charges of first magical ability (default 0)
-\item SET \verb+charges2+ to number of charges of second magical ability (default 0)
-\item SET \verb+charges3+ to number of charges of third magical ability (default 0)
-\end{itemize}
+\begin{weiduarguments}
+String variable & \verb+item_to_add+ & the item you want to add & Empty string \\
+Integer variable & \verb+container_to_add_to+ & the number of the container the item should be added to. The count starts at 1. & \verb+1+ \\
+String variable & \verb+flags+ & flags the item should have (usual weidu syntax: STOLEN, IDENTIFIED\&STOLEN, etc). Default - no flags. & Empty string \\
+Integer variable & \verb+charges1+ & amount in stock/number of charges of first magical ability (default 0) & \verb+0+ \\
+Integer variable & \verb+charges2+ & number of charges of second magical ability (default 0) & \verb+0+ \\
+Integer variable & \verb+charges3+ & number of charges of third magical ability (default 0) & \verb+0+ \\
+\end{weiduarguments}
+
 
 \verb+ADD_CRE_ITEM_FLAGS+: adds flags to all matching items possessed by a creature. Regexp allowed.
 This is a PATCH macro and function.
-\begin{itemize}
-\item SPRINT \verb+item_to_change+ to the item the flags should be added to
-\item SPRINT \verb+flags+ to flags you need to add (usual weidu syntax: STOLEN, IDENTIFIED&STOLEN, etc).
-\end{itemize}
+\begin{weiduarguments}
+String variable & \verb+item_to_change+ & the item the flags should be added to & Empty string \\
+String variable & \verb+flags+ & flags you need to add (usual weidu syntax: STOLEN, IDENTIFIED\&STOLEN, etc). & Empty string \\
+\end{weiduarguments}
+
 
 \verb+REMOVE_CRE_ITEM_FLAGS+: removes flags from all matching items possessed by a creature. Regexp allowed.
 This is a PATCH macro and function.
-\begin{itemize}
-\item SPRINT \verb+item_to_change+ to the item the flags should be removed from
-\item SPRINT \verb+flags+ to flags you need to remove (usual weidu syntax: STOLEN, IDENTIFIED&STOLEN, etc).
-\end{itemize}
+\begin{weiduarguments}
+String variable & \verb+item_to_change+ & the item the flags should be removed from & Empty string \\
+String variable & \verb+flags+ & flags you need to remove (usual weidu syntax: STOLEN, IDENTIFIED\&STOLEN, etc). & Empty string \\
+\end{weiduarguments}
+
 
 \verb+SET_CRE_ITEM_FLAGS+: set flags to all matching items possessed by a creature. Regexp allowed.
 This is a PATCH macro and function.
-\begin{itemize}
-\item SPRINT \verb+item_to_change+ to the item which flags should be set
-\item SPRINT \verb+flags+ to flags you need to set (usual weidu syntax: STOLEN, IDENTIFIED&STOLEN, etc).
-\end{itemize}
+\begin{weiduarguments}
+String variable & \verb+item_to_change+ & the item which flags should be set & Empty string \\
+String variable & \verb+flags+ & flags you need to set (usual weidu syntax: STOLEN, IDENTIFIED\&STOLEN, etc). & Empty string \\
+\end{weiduarguments}
+
 
 \verb+READ_SOUNDSET+: reads soundset of a creature and stores it as an array of string references %soundset%_%i% (i=0-99)
 This is an ACTION macro.
-\begin{itemize}
-\item SPRINT \verb+npc+ to the target creature (with .cre extension)
-\item SPRINT \verb+soundset+ to the name of soundset you want.
-\end{itemize}
+\begin{weiduarguments}
+String variable & \verb+npc+ & the target creature (with .cre extension) & \emph{Not specified} \\
+String variable & \verb+soundset+ & the name of soundset you want. & \emph{Not specified} \\
+\end{weiduarguments}
+
 
 \verb+WRITE_SOUNDSET+: writes soundset to all matching creatures. Regexp allowed.
 This is an ACTION macro.
-\begin{itemize}
-\item SPRINT \verb+npc+ to a creature in question (with .cre extension)
-\item SPRINT \verb+soundset+ to name of soundset you have.
-\item SET \verb+overwrite+ to 2 if you want new soundset to overwrite the old one completely. Set it to 1 if you want to overwrite old string references only with non-empty new references (may keep some old). Set it to 0 it you want to overwrite only empty old references with new ones.
-\end{itemize}
+\begin{weiduarguments}
+String variable & \verb+npc+ & a creature in question (with .cre extension) & \emph{Not specified} \\
+String variable & \verb+soundset+ & name of soundset you have. & \emph{Not specified} \\
+Integer variable & \verb+overwrite+ & 2 if you want new soundset to overwrite the old one completely. Set it to 1 if you want to overwrite old string references only with non-empty new references (may keep some old). Set it to 0 it you want to overwrite only empty old references with new ones. & \emph{Not specified} \\
+\end{weiduarguments}
 
-\verb+FL#FJ_CRE_VALIDITY+: This function is a wrapper around
-\verb+FJ_CRE_VALIDITY+ and allows you to use the conventional function
-interface together with \ttref{MODDER} \verb+fun_args+.
 
-\verb+FJ_CRE_VALIDITY+: Checks whether a CRE file is well-formed or not, fixes some common bugs, and reports whether the CRE file is still broken or not. In particular:
+\verb+FL#FJ_CRE_VALIDITY+: This function is the conventional function
+interface for \verb+FJ_CRE_VALIDITY+ and is compatible with \ttref{MODDER}
+\verb+fun_args+. This is a PATCH function.
+\begin{weiduarguments}
+Integer variable & \verb+do_message+ & 1 to print an explicit message when the CRE is invalid. & \verb+0+ \\
+Integer variable & \verb+do_reindex+ & 0 to leave the creature's structure offsets in their existing order. & \verb+1+ \\
+Integer variable & \verb+do_eff+ & 0 to skip EFF V1/V2 conversion. & \verb+1+ \\
+Return value & \verb+valid+ & 1 if the CRE is well-formed, 0 otherwise. & Not applicable \\
+\end{weiduarguments}
+
+\verb+FJ_CRE_VALIDITY+: Checks whether a CRE file is well-formed or not,
+fixes some common bugs, and reports whether the CRE file is still broken or
+not. This legacy compatibility interface declares no formal arguments. It
+reads \verb+do_message+, \verb+do_reindex+ and \verb+do_eff+ from caller
+scope; use \verb+FL#FJ_CRE_VALIDITY+ when passing these values in an
+\verb+INT_VAR+ block. In particular:
 \begin{itemize}
 \item reports invalidity if it is charbase.cre, shorter than the minimum size, the signature mismatches, or a sub-structure has members and its offset is in the header.
-\item if a empty sub-structure's offset is in the header, point them to the end of the header.
-\item if the cre is valid, force it to use proper order (known spells, spell memorization info, memorized spells, effects, items, item slot).
+\item if an empty sub-structure's offset is in the header, points it to the end of the header.
+\item if the CRE is valid, forces it to use proper order (known spells, spell memorization info, memorized spells, effects, items, item slot).
 \item forces the CRE file to use EFF V2 effects internally (or EFF V1 if on BG1).
 \end{itemize}
 This is a PATCH function.
-\begin{itemize}
-\item INT_VAR \verb+do_message+ to 1 if you want explicit an explicit message regarding the cre invalidity. Defaults to 0.
-\item INT_VAR \verb+do_reindex+ to 0 if you don't want the creature file to be reindexed. Defaults to 1.
-\item INT_VAR \verb+do_eff+ to 0 if you don't want EFFv1 <-> EFFv2 conversion to be applied. Defaults to 1.
-\item RET \verb+valid+ returns 1 if the CRE is well-formed, 0 otherwise.
-\end{itemize}
 
-\verb+FL#FJ_CRE_REINDEX+: This function is a wrapper around
-\verb+FJ_CRE_REINDEX+ and allows you to use the conventional function
-interface together with \ttref{MODDER} \verb+fun_args+.
+
+\verb+FL#FJ_CRE_REINDEX+: This function is the conventional function
+interface for \verb+FJ_CRE_REINDEX+ and is compatible with \ttref{MODDER}
+\verb+fun_args+. This is a PATCH function.
+\begin{weiduarguments}
+Integer variable & \verb+do_reindex+ & 0 to leave the creature's structure offsets in their existing order. & \verb+1+ \\
+Integer variable & \verb+do_eff+ & 0 to skip EFF V1/V2 conversion. & \verb+1+ \\
+\end{weiduarguments}
 
 \verb+FJ_CRE_REINDEX+: reorders creatures with nonstandard offset
-orders. Called by FJ_CRE_VALIDITY automatically if relevant.\\\\
-This is a PATCH function.
-\begin{itemize}
-\item INT_VAR \verb+do_reindex+ to 0 if you don't want the creature file to be reindexed. Defaults to 1.
-\item INT_VAR \verb+do_eff+ to 0 if you don't want EFFv1 <-> EFFv2 conversion to be applied. Defaults to 1.
-\end{itemize}
+orders. Called by FJ_CRE_VALIDITY automatically if relevant. This legacy
+compatibility interface declares no formal arguments. It reads
+\verb+do_reindex+ and \verb+do_eff+ from caller scope; use
+\verb+FL#FJ_CRE_REINDEX+ when passing these values in an \verb+INT_VAR+
+block. This is a PATCH function.
+
 
 \verb+FJ_CRE_EFF_V2+: Converts creatures using version 1 effects to
 version 2. Called by FJ_CRE_VALIDITY or FJ_CRE_REINDEX automatically
@@ -9252,42 +9305,49 @@ if relevant.\\
 This is a PATCH function.
 
 \verb+ADD_AREA_REGION_TRIGGER+: adds an area region to the current are file.
-This is a PATCH macro and function. Unlike other macros you do not need to set every variable. You are only required to set those values that you need to write.
-\begin{itemize}
-\item SPRINT \verb+ab_RT_Name+ -- Name to assign to new region
-\item SET \verb+ab_RT_Type+ -- Type of trigger -- 0=proximity;1=info;2=travel
-\item SET \verb+ab_RT_BbLX+ -- Bounding Box - low x value  - LEFT
-\item SET \verb+ab_RT_BbLY+ -- Bounding Box - low y value  - TOP
-\item SET \verb+ab_RT_BbHX+ -- Bounding Box - High x value - RIGHT
-\item SET \verb+ab_RT_BbHY+ -- Bounding Box - High y value - BOTTOM
-\item SET \verb+ab_RT_VxPr+ -- Number of Vertex Pairs for current region
-\item SET \verb+ab_RT_CuId+ -- Cursor Index - points to a graphic in cursors.bam
-\item SPRINT \verb+ab_RT_Dest+ -- Destination Area
-\item SPRINT \verb+ab_RT_EntN+ -- Entrance Name
-\item SET \verb+ab_RT_Fbit+ -- Flag bits set in bit format which are read right to left - 0=off; 1=on
-\item SET \verb+ab_RT_Itxt+ -- Info text
-\item SET \verb+ab_RT_TDtD+ -- Trap Detection Difficulty
-\item SET \verb+ab_RT_TRmD+ -- Trap Removal Difficulty
-\item SET \verb+ab_RT_TSet+ -- Trap is set - 0=no; 1=yes
-\item SET \verb+ab_RT_TDet+ -- Trap is detected - 0=no; 1=yes
-\item SET \verb+ab_RT_LPoX+ -- Launch Point X
-\item SET \verb+ab_RT_LPoY+ -- Launch Point Y
-\item SPRINT \verb+ab_RT_KeyI+ -- Key Item
-\item SET \verb+ab_RT_Rbcs+ -- Region Script file
-\item SET \verb+ab_RT_ALPX+ -- Alternate Launch Point X
-\item SET \verb+ab_RT_ALPY+ -- Alternate Launch Point Y
-\item SET \verb+ab_RT_Dial+ -- Dialog file (used only in PST)
-\end{itemize}
+This is a PATCH macro. Unlike other macros you do not need to set every
+variable. You are only required to set those values that you need to write.
+The same-named PATCH function declares an \verb+AREA_RT_*+ interface, but its
+implementation launches the current \verb+ab_RT_*+ macro without forwarding
+those formal arguments. The table below therefore documents the working macro
+interface only.
+\begin{weiduarguments}
+String variable & \verb+ab_RT_Name+ & Name to assign to the new region. & Empty string \\
+Integer variable & \verb+ab_RT_Type+ & Type of trigger: 0=proximity; 1=info; 2=travel. & \verb+0+ \\
+Integer variable & \verb+ab_RT_BbLX+ & Bounding-box low X value (left). & \verb+0+ \\
+Integer variable & \verb+ab_RT_BbLY+ & Bounding-box low Y value (top). & \verb+0+ \\
+Integer variable & \verb+ab_RT_BbHX+ & Bounding-box high X value (right). & \verb+0+ \\
+Integer variable & \verb+ab_RT_BbHY+ & Bounding-box high Y value (bottom). & \verb+0+ \\
+Integer variable & \verb+ab_RT_VxPr+ & Number of vertex pairs for the region. & \emph{Not specified} \\
+Integer variable & \verb+ab_RT_CuId+ & Cursor index, pointing to a graphic in \t{CURSORS.BAM}. & \verb+0+ \\
+String variable & \verb+ab_RT_Dest+ & Destination area. & Empty string \\
+String variable & \verb+ab_RT_EntN+ & Entrance name. & Empty string \\
+Integer variable & \verb+ab_RT_Fbit+ & Flag bits, read from right to left (0=off; 1=on). & \verb+0+ \\
+Integer variable & \verb+ab_RT_Itxt+ & Information text. & \verb+-1+ \\
+Integer variable & \verb+ab_RT_TDtD+ & Trap-detection difficulty. & \verb+0+ \\
+Integer variable & \verb+ab_RT_TRmD+ & Trap-removal difficulty. & \verb+0+ \\
+Integer variable & \verb+ab_RT_TSet+ & Whether the trap is set (0=no; 1=yes). & \verb+0+ \\
+Integer variable & \verb+ab_RT_TDet+ & Whether the trap is detected (0=no; 1=yes). & \verb+0+ \\
+Integer variable & \verb+ab_RT_LPoX+ & Launch-point X coordinate. & \verb+0+ \\
+Integer variable & \verb+ab_RT_LPoY+ & Launch-point Y coordinate. & \verb+0+ \\
+String variable & \verb+ab_RT_KeyI+ & Key item. & Empty string \\
+String variable & \verb+ab_RT_Rbcs+ & Region script. & Empty string \\
+Integer variable & \verb+ab_RT_ALPX+ & Alternate launch-point X coordinate. & \verb+0+ \\
+Integer variable & \verb+ab_RT_ALPY+ & Alternate launch-point Y coordinate. & \verb+0+ \\
+String variable & \verb+ab_RT_Dial+ & Dialog file (PST only). & Empty string \\
+\end{weiduarguments}
+
 
 \\
 The vertex points are separated by their X & Y values
 You may have as many pairs as you need. Just copy this set and increment the #.
 Example: For the X values: \verb+ab_RT_Vx_X_0+, \verb+ab_RT_Vx_X_1+, \verb+ab_RT_Vx_X_2+\\
          For the Y values: \verb+ab_RT_Vx_Y_0+, \verb+ab_RT_Vx_Y_1+, \verb+ab_RT_Vx_Y_2+
-\begin{itemize}
-\item SET \verb+ab_RT_Vx_X_0+ -- Point #0 X value
-\item SET \verb+ab_RT_Vx_Y_0+ -- Point #0 Y value
-\end{itemize}
+\begin{weiduarguments}
+Caller-scope integer series & \verb+ab_RT_Vx_X_0+ & Point \#0 X value. Define one value for every index from 0 through \verb+ab_RT_VxPr - 1+ before launching the macro. & Required \\
+Caller-scope integer series & \verb+ab_RT_Vx_Y_0+ & Point \#0 Y value. Define one value for every index from 0 through \verb+ab_RT_VxPr - 1+ before launching the macro. & Required \\
+\end{weiduarguments}
+
 
 \\
 NOTE: The original code released in WeiDU v211 has been overhauled and re-released in v212. Therefore, the user defined variable names have been changed. If you used the 211 version you will need to update your mod to use the variables in this version. Sorry for the inconvenience...
@@ -9296,29 +9356,32 @@ NOTE: The original code released in WeiDU v211 has been overhauled and re-releas
 \\
 \verb+RES_NUM_OF_SPELL_NAME+: converts a spell.ids reference to resource name.
 This is an ACTION and PATCH macro and function.
-\begin{itemize}
-\item SPRINT \verb+spell_name+ to the IDS symbolic reference of a spell.
-\item RET \verb+spell_num+ to the IDS numerical reference of that spell.
-\item RET \verb+spell_res to+ the resource name for the referenced spell.
-\end{itemize}
+\begin{weiduarguments}
+String variable & \verb+spell_name+ & the IDS symbolic reference of a spell. & Empty string \\
+Return value & \verb+spell_num+ & the IDS numerical reference of that spell. & Not applicable \\
+Return value & \verb+spell_res+ & the resource name for the referenced spell. & Not applicable \\
+\end{weiduarguments}
+
 \\
 
 \verb+RES_NAME_OF_SPELL_NUM+: converts a spell.ids reference to resource name.
 This is an ACTION and PATCH macro and function.
-\begin{itemize}
-\item SET \verb+spell_num+ to the IDS numerical reference of that spell.
-\item RET \verb+spell_name+ to the IDS symbolic reference of a spell.
-\item RET \verb+spell_res+ to the resource name for the referenced spell.
-\end{itemize}
+\begin{weiduarguments}
+Integer variable & \verb+spell_num+ & the IDS numerical reference of that spell. & \verb+0+ \\
+Return value & \verb+spell_name+ & the IDS symbolic reference of a spell. & Not applicable \\
+Return value & \verb+spell_res+ & the resource name for the referenced spell. & Not applicable \\
+\end{weiduarguments}
+
 \\
 
 \verb+NAME_NUM_OF_SPELL_RES+: converts a spell resource name to a spell.ids reference.
 This is an ACTION and PATCH macro and function.
-\begin{itemize}
-\item SPRINT \verb+spell_res+ to the resource name for the referenced spell.
-\item RET \verb+spell_num+ to the IDS numerical reference of that spell.
-\item RET \verb+spell_name+ to the IDS symbolic reference of a spell.
-\end{itemize}
+\begin{weiduarguments}
+String variable & \verb+spell_res+ & the resource name for the referenced spell. & Empty string \\
+Return value & \verb+spell_num+ & the IDS numerical reference of that spell. & Not applicable \\
+Return value & \verb+spell_name+ & the IDS symbolic reference of a spell. & Not applicable \\
+\end{weiduarguments}
+
 \\
 
 \verb+GET_UNIQUE_FILE_NAME+: Creates a file name that is currently unallocated.
@@ -9338,353 +9401,367 @@ file on reinstalls. For instance, if you're iterating through Mages to give each
 them a spellbook, base should contain your modder prefix, an identifier for the purpose
 of the call, and the file name you're working on, for instance:
 \verb+~tb#spellbooks_%SOURCE_RES%~+
-\begin{itemize}
-\item STR_VAR \verb+extension+ to the desired extension (required).
-\item STR_VAR \verb+base+ to a string unique to your mod and current file (optional).
-\item RET \verb+filename+ the currently unallocated file name (sans the extension).
-\end{itemize}
+\begin{weiduarguments}
+String variable & \verb+extension+ & the desired extension (required). & Empty string \\
+String variable & \verb+base+ & a string unique to your mod and current file (optional). & Empty string \\
+Return value & \verb+filename+ & the currently unallocated file name (sans the extension). & Not applicable \\
+\end{weiduarguments}
+
 \\
 
 \verb+ALTER_AREA_ENTRANCE+: patch coordinates and orientation of \ahref{\url{http://gibberlings3.net/iesdp/file_formats/ie_formats/are_v1.htm#formAREAV1_0_Entrance}}{area party entrance points}.
 This is a PATCH function. For all integer variables, a negative value results in no change to that field and the default value is -1. The variable \verb+entrance_name+ is required.
-\begin{itemize}
-\item INT_VAR \verb+x_coord+ to the new X coordinate.
-\item INT_VAR \verb+y_coord+ to the new Y coordinate.
-\item INT_VAR \verb+orient+ to the new orientation.
-\item STR_VAR \verb+entrance_name+ to the name of the entrance point to be altered. This variable is required.
-\end{itemize}
+\begin{weiduarguments}
+Integer variable & \verb+x_coord+ & the new X coordinate. & \verb+-1+ \\
+Integer variable & \verb+y_coord+ & the new Y coordinate. & \verb+-1+ \\
+Integer variable & \verb+orient+ & the new orientation. & \verb+-1+ \\
+String variable & \verb+entrance_name+ & the name of the entrance point to be altered. This variable is required. & Empty string \\
+\end{weiduarguments}
+
 \\
 
 \verb+ALTER_AREA_REGION+: patch \ahref{\url{http://gibberlings3.net/iesdp/file_formats/ie_formats/are_v1.htm#formAREAV1_0_Info}}{area regions}, also known as area triggers.
 This is a PATCH function. For all integer variables except \verb+info_point+, a negative value results in no change and the default value is -1. The variable \verb+info_point+ results in no change if it has the default value 99999999. In the case of flags, a value of 1 will set the flag and a value of 0 will unset it. For all string variables except \verb+region_name+, the default value is the string "same", which results in no change to that field. The variable \verb+region_name+ is required.
-\begin{itemize}
-\item INT_VAR \verb+type+ to the new type of the region.
-\item INT_VAR \verb+cursor+ to the new cursor index to be used.
-\item INT_VAR \verb+trap_detect+ to the new difficulty of trap detection.
-\item INT_VAR \verb+trap_remove+ to the new difficulty of trap removal.
-\item INT_VAR \verb+trapped+ to whether the region should be trapped.
-\item INT_VAR \verb+detected+ to whether the trap should be detected.
-\item INT_VAR \verb+flag_locked+ to the new value of the flag known as \t{locked} or \t{invisible trap} (bit 0).
-\item INT_VAR \verb+flag_resets+ to the new value of the flag known as \t{trap resets} (bit 1).
-\item INT_VAR \verb+flag_party_required+ to the new value of the flag known as \t{party is required} (bit 2).
-\item INT_VAR \verb+flag_trap_detectable+ to the new value of the flag known as \t{trap is detectable} (bit 3).
-\item INT_VAR \verb+flag_trap_enemies+ to the new value of the flag known as \t{trap can be set off by enemies} (bit 4).
-\item INT_VAR \verb+flag_tutorial+ to the new value of the flag known as \t{tutorial trigger} (bit 5).
-\item INT_VAR \verb+flag_trap_npcs+ to the new value of the flag known as \t{trap can be set off by NPCs} (bit 6).
-\item INT_VAR \verb+flag_silent+ to the new value of the flag known as \t{silent trigger} (bit 7).
-\item INT_VAR \verb+flag_deactivated+ to the new value of the flag known as \t{deactivated} (bit 8).
-\item INT_VAR \verb+flag_impassable_npc+ to the new value of the flag known as \t{cannot be passed by NPCs} (bit 9).
-\item INT_VAR \verb+flag_activation_point+ to the new value of the flag known as \t{use activation point} (bit 10).
-\item INT_VAR \verb+flag_connect_to_door+ to the new value of the flag known as \t{connected to door} (bit 11).
-\item INT_VAR \verb+bounding_left+ to the new value of the left edge of the bounding box. The vertices remain unchanged.
-\item INT_VAR \verb+bounding_top+ to the new value of the top edge of the bounding box. The vertices remain unchanged.
-\item INT_VAR \verb+bounding_right+ to the new value of the right edge of the bounding box. The vertices remain unchanged.
-\item INT_VAR \verb+bounding_bottom+ to the new value of the bottom edge of the bounding box. The vertices remain unchanged.
-\item INT_VAR \verb+info_point+ to the new string reference of the info point.
-\item INT_VAR \verb+launch_x+ to the new x coordinate of the launch point.
-\item INT_VAR \verb+launch_y+ to the new y coordinate of the launch point.
-\item INT_VAR \verb+activate_x+ to the new x coordinate of the activation point.
-\item INT_VAR \verb+activate_y+ to the new y coordinate of the activation point.
-\item STR_VAR \verb+region_name+ to the name of the region to be patched. This variable is required.
-\item STR_VAR \verb+destination_area+ to the resref of the new destination area.
-\item STR_VAR \verb+entrance_name+ to the new entrance name of the destination area.
-\item STR_VAR \verb+region_key+ to the resref of the key item.
-\item STR_VAR \verb+region_script+ to the resref of the region script.
-\end{itemize}
+\begin{weiduarguments}
+Integer variable & \verb+type+ & the new type of the region. & \verb+-1+ \\
+Integer variable & \verb+cursor+ & the new cursor index to be used. & \verb+-1+ \\
+Integer variable & \verb+trap_detect+ & the new difficulty of trap detection. & \verb+-1+ \\
+Integer variable & \verb+trap_remove+ & the new difficulty of trap removal. & \verb+-1+ \\
+Integer variable & \verb+trapped+ & whether the region should be trapped. & \verb+-1+ \\
+Integer variable & \verb+detected+ & whether the trap should be detected. & \verb+-1+ \\
+Integer variable & \verb+flag_locked+ & the new value of the flag known as \t{locked} or \t{invisible trap} (bit 0). & \verb+-1+ \\
+Integer variable & \verb+flag_resets+ & the new value of the flag known as \t{trap resets} (bit 1). & \verb+-1+ \\
+Integer variable & \verb+flag_party_required+ & the new value of the flag known as \t{party is required} (bit 2). & \verb+-1+ \\
+Integer variable & \verb+flag_trap_detectable+ & the new value of the flag known as \t{trap is detectable} (bit 3). & \verb+-1+ \\
+Integer variable & \verb+flag_trap_enemies+ & the new value of the flag known as \t{trap can be set off by enemies} (bit 4). & \verb+-1+ \\
+Integer variable & \verb+flag_tutorial+ & the new value of the flag known as \t{tutorial trigger} (bit 5). & \verb+-1+ \\
+Integer variable & \verb+flag_trap_npcs+ & the new value of the flag known as \t{trap can be set off by NPCs} (bit 6). & \verb+-1+ \\
+Integer variable & \verb+flag_silent+ & the new value of the flag known as \t{silent trigger} (bit 7). & \verb+-1+ \\
+Integer variable & \verb+flag_deactivated+ & the new value of the flag known as \t{deactivated} (bit 8). & \verb+-1+ \\
+Integer variable & \verb+flag_impassable_npc+ & the new value of the flag known as \t{cannot be passed by NPCs} (bit 9). & \verb+-1+ \\
+Integer variable & \verb+flag_activation_point+ & the new value of the flag known as \t{use activation point} (bit 10). & \verb+-1+ \\
+Integer variable & \verb+flag_connect_to_door+ & the new value of the flag known as \t{connected to door} (bit 11). & \verb+-1+ \\
+Integer variable & \verb+bounding_left+ & the new value of the left edge of the bounding box. The vertices remain unchanged. & \verb+-1+ \\
+Integer variable & \verb+bounding_top+ & the new value of the top edge of the bounding box. The vertices remain unchanged. & \verb+-1+ \\
+Integer variable & \verb+bounding_right+ & the new value of the right edge of the bounding box. The vertices remain unchanged. & \verb+-1+ \\
+Integer variable & \verb+bounding_bottom+ & the new value of the bottom edge of the bounding box. The vertices remain unchanged. & \verb+-1+ \\
+Integer variable & \verb+info_point+ & the new string reference of the info point. & \verb+99999999+ \\
+Integer variable & \verb+launch_x+ & the new x coordinate of the launch point. & \verb+-1+ \\
+Integer variable & \verb+launch_y+ & the new y coordinate of the launch point. & \verb+-1+ \\
+Integer variable & \verb+activate_x+ & the new x coordinate of the activation point. & \verb+-1+ \\
+Integer variable & \verb+activate_y+ & the new y coordinate of the activation point. & \verb+-1+ \\
+String variable & \verb+region_name+ & the name of the region to be patched. This variable is required. & Empty string \\
+String variable & \verb+destination_area+ & the resref of the new destination area. & \verb+same+ \\
+String variable & \verb+entrance_name+ & the new entrance name of the destination area. & \verb+same+ \\
+String variable & \verb+region_key+ & the resref of the key item. & \verb+EVAL "%door_key%"+ \\
+String variable & \verb+region_script+ & the resref of the region script. & \verb+EVAL"%door_script%"+ \\
+\end{weiduarguments}
+
 \\
 
 \verb+ALTER_AREA_ACTOR+: patch \ahref{\url{http://gibberlings3.net/iesdp/file_formats/ie_formats/are_v1.htm#formAREAV1_0_Actor}}{area actors}.
 This is a PATCH function. All integer variables, except \verb+expiry+, default to the value -1 and a negative value results in no change to the corresponding field. The variable \verb+expiry+ instead has a default value of -2. In the case of flags, a value of 1 will set the flag and a value of 0 will unset it. All string variables except \verb+actor_name+ default to the string "same", which results in no change to the corresponding field. The variable \verb+actor_name+ is required.
-\begin{itemize}
-\item INT_VAR \verb+x_coord+ to the new x coordinate. Unless \verb+dest_x+ is defined, \verb+x_coord+ is used as the x-value of the destination, as well.
-\item INT_VAR \verb+y_coord+ to the new y coordinate. Unless \verb+dest_y+ is defined, \verb+y_coord+ is used as the y-value of the destination, as well.
-\item INT_VAR \verb+dest_x+ to the new x destination.
-\item INT_VAR \verb+dest_y+ to the new y destination.
-\item INT_VAR \verb+spawned+ to the new spawned value.
-\item INT_VAR \verb+animation+ to the new animation value.
-\item INT_VAR \verb+orient+ to the new facing direction.
-\item INT_VAR \verb+expiry+ to the new expiration time.
-\item INT_VAR \verb+wander+ to the new wander-distance value.
-\item INT_VAR \verb+follow+ to the new follow-distance value.
-\item INT_VAR \verb+times_talked+ to the new number of times the actor has been talked to.
-\item INT_VAR \verb+flag_cre_unattached+ to the new value of the flag known as \t{CRE attached} (bit 0).
-\item INT_VAR \verb+flag_seen_party+ to the new value of the flag known as \t{has seen party} (bit 1).
-\item INT_VAR \verb+flag_invulnerable+ to the new value of the flag known as \t{invulnerable} (bit 2).
-\item INT_VAR \verb+flag_override_script_name+ to the new value of the flag known as {override script name} (bit 3).
-\item INT_VAR \verb+flag_time_0+ through \verb+flag_time_23+ to the new values of the actor's appearance schedule.
-\item STR_VAR \verb+actor_name+ to the name of the actor to be patched. This variable is required.
-\item STR_VAR \verb+dlg_file+ to the resref of the new dialogue file.
-\item STR_VAR \verb+script_override+ to the resref of the new override script.
-\item STR_VAR \verb+script_general+ to the resref of the new general script.
-\item STR_VAR \verb+script_class+ to the resref of the new class script.
-\item STR_VAR \verb+script_race+ to the resref of the new race script.
-\item STR_VAR \verb+script_default+ to the resref of the new default script.
-\item STR_VAR \verb+script_specifics+ to the resref of the new specifics script.
-\item STR_VAR \verb+cre_file+ to the resref of the new creature file.
-\end{itemize}
+\begin{weiduarguments}
+Integer variable & \verb+x_coord+ & the new x coordinate. Unless \verb+dest_x+ is defined, \verb+x_coord+ is used as the x-value of the destination, as well. & \verb+-1+ \\
+Integer variable & \verb+y_coord+ & the new y coordinate. Unless \verb+dest_y+ is defined, \verb+y_coord+ is used as the y-value of the destination, as well. & \verb+-1+ \\
+Integer variable & \verb+dest_x+ & the new x destination. & \verb+-1+ \\
+Integer variable & \verb+dest_y+ & the new y destination. & \verb+-1+ \\
+Integer variable & \verb+spawned+ & the new spawned value. & \verb+-1+ \\
+Integer variable & \verb+animation+ & the new animation value. & \verb+-1+ \\
+Integer variable & \verb+orient+ & the new facing direction. & \verb+-1+ \\
+Integer variable & \verb+expiry+ & the new expiration time. & \verb+-2+ \\
+Integer variable & \verb+wander+ & the new wander-distance value. & \verb+-1+ \\
+Integer variable & \verb+follow+ & the new follow-distance value. & \verb+-1+ \\
+Integer variable & \verb+times_talked+ & the new number of times the actor has been talked to. & \verb+-1+ \\
+Integer variable & \verb+flag_cre_unattached+ & the new value of the flag known as \t{CRE attached} (bit 0). & \verb+-1+ \\
+Integer variable & \verb+flag_seen_party+ & the new value of the flag known as \t{has seen party} (bit 1). & \verb+-1+ \\
+Integer variable & \verb+flag_invulnerable+ & the new value of the flag known as \t{invulnerable} (bit 2). & \verb+-1+ \\
+Integer variable & \verb+flag_override_script_name+ & the new value of the flag known as {override script name} (bit 3). & \verb+-1+ \\
+Integer variable & \verb+flag_time_0+ & through \verb+flag_time_23+ to the new values of the actor's appearance schedule. & \verb+-1+ \\
+String variable & \verb+actor_name+ & the name of the actor to be patched. This variable is required. & Empty string \\
+String variable & \verb+dlg_file+ & the resref of the new dialogue file. & \verb+same+ \\
+String variable & \verb+script_override+ & the resref of the new override script. & \verb+same+ \\
+String variable & \verb+script_general+ & the resref of the new general script. & \verb+same+ \\
+String variable & \verb+script_class+ & the resref of the new class script. & \verb+same+ \\
+String variable & \verb+script_race+ & the resref of the new race script. & \verb+same+ \\
+String variable & \verb+script_default+ & the resref of the new default script. & \verb+same+ \\
+String variable & \verb+script_specifics+ & the resref of the new specifics script. & \verb+same+ \\
+String variable & \verb+cre_file+ & the resref of the new creature file. & \verb+same+ \\
+\end{weiduarguments}
+
 \\
 
 \verb+ALTER_AREA_CONTAINER+: patch \ahref{\url{http://gibberlings3.net/iesdp/file_formats/ie_formats/are_v1.htm#formAREAV1_0_Container}}{area containers}, but not their contents. This is a PATCH function. All integer variables default to -1 and negative values result in no change to the corresponding field. In the case of flags, a value of 1 will set the flag and a value of 0 will unset it. All string variables except \verb+container_name+ default to the string "same", which results in no change to the corresponding field. The variable \verb+container_name+ is required.
-\begin{itemize}
-\item INT_VAR \verb+coord_x+ to the new x coordinate.
-\item INT_VAR \verb+coord_y+ to the new y coordinate.
-\item INT_VAR \verb+container_type+ to the new type of the container.
-\item INT_VAR \verb+trapped+ to whether the container should be trapped.
-\item INT_VAR \verb+detected+ to whether the container trap should be detected.
-\item INT_VAR \verb+launch_x+ to the new x coordinate of the launch point.
-\item INT_VAR \verb+launch_y+ to the new y coordinate of the launch point.
-\item INT_VAR \verb+bounding_left+ to the new value of the left edge of the bounding box. The vertices remain unchanged.
-\item INT_VAR \verb+bounding_top+ to the new value of the top edge of the bounding box. The vertices remain unchanged.
-\item INT_VAR \verb+bounding_right+ to the new value of the right edge of the bounding box. The vertices remain unchanged.
-\item INT_VAR \verb+bounding_bottom+ to the new value of the bottom edge of the bounding box. The vertices remain unchanged.
-\item INT_VAR \verb+range+ to the new trigger-range value.
-\item INT_VAR \verb+lockpick_strref+ to the new strref of the lockpick string.
-\item INT_VAR \verb+lock_difficulty+ to the new difficulty of the lock.
-\item INT_VAR \verb+trap_detect+ to the new difficulty of trap detection.
-\item INT_VAR \verb+trap_remove+ to the new difficulty of trap removal.
-\item INT_VAR \verb+flag_locked+ to the new value of the flag known as \t{locked} (bit 0).
-\item INT_VAR \verb+flag_mlocked+ to the new value of the flag known as \t{magical lock} (bit 2).
-\item INT_VAR \verb+flag_resets+ to the new value of the flag known as \t{trap resets} (bit 3).
-\item INT_VAR \verb+flag_disabled+ to the new value of the flag known as \t{disabled} (bit 5).
-\item STR_VAR \verb+container_name+ to the name of the container to be patched. This variable is required.
-\item STR_VAR \verb+container_script+ to the resref of the new container script.
-\item STR_VAR \verb+container_key+ to the resref of the new container key.
-\end{itemize}
+\begin{weiduarguments}
+Integer variable & \verb+coord_x+ & the new x coordinate. & \verb+-1+ \\
+Integer variable & \verb+coord_y+ & the new y coordinate. & \verb+-1+ \\
+Integer variable & \verb+container_type+ & the new type of the container. & \verb+-1+ \\
+Integer variable & \verb+trapped+ & whether the container should be trapped. & \verb+-1+ \\
+Integer variable & \verb+detected+ & whether the container trap should be detected. & \verb+-1+ \\
+Integer variable & \verb+launch_x+ & the new x coordinate of the launch point. & \verb+-1+ \\
+Integer variable & \verb+launch_y+ & the new y coordinate of the launch point. & \verb+-1+ \\
+Integer variable & \verb+bounding_left+ & the new value of the left edge of the bounding box. The vertices remain unchanged. & \verb+-1+ \\
+Integer variable & \verb+bounding_top+ & the new value of the top edge of the bounding box. The vertices remain unchanged. & \verb+-1+ \\
+Integer variable & \verb+bounding_right+ & the new value of the right edge of the bounding box. The vertices remain unchanged. & \verb+-1+ \\
+Integer variable & \verb+bounding_bottom+ & the new value of the bottom edge of the bounding box. The vertices remain unchanged. & \verb+-1+ \\
+Integer variable & \verb+range+ & the new trigger-range value. & \verb+-1+ \\
+Integer variable & \verb+lockpick_strref+ & the new strref of the lockpick string. & \verb+-1+ \\
+Integer variable & \verb+lock_difficulty+ & the new difficulty of the lock. & \verb+-1+ \\
+Integer variable & \verb+trap_detect+ & the new difficulty of trap detection. & \verb+-1+ \\
+Integer variable & \verb+trap_remove+ & the new difficulty of trap removal. & \verb+-1+ \\
+Integer variable & \verb+flag_locked+ & the new value of the flag known as \t{locked} (bit 0). & \verb+-1+ \\
+Integer variable & \verb+flag_mlocked+ & the new value of the flag known as \t{magical lock} (bit 2). & \verb+-1+ \\
+Integer variable & \verb+flag_resets+ & the new value of the flag known as \t{trap resets} (bit 3). & \verb+-1+ \\
+Integer variable & \verb+flag_disabled+ & the new value of the flag known as \t{disabled} (bit 5). & \verb+-1+ \\
+String variable & \verb+container_name+ & the name of the container to be patched. This variable is required. & Empty string \\
+String variable & \verb+container_script+ & the resref of the new container script. & \verb+same+ \\
+String variable & \verb+container_key+ & the resref of the new container key. & \verb+same+ \\
+\end{weiduarguments}
+
 \\
 
 \verb+ALTER_AREA_DOOR+: patch \ahref{\url{http://gibberlings3.net/iesdp/file_formats/ie_formats/are_v1.htm#formAREAV1_0_Door}}{area doors.} This is a PATCH function. All integer variables, except \verb+string_unlock+ and \verb+string_speaker+, default to -1 and negative values result in no change to the corresponding field. The variables \verb+string_unlock+ and \verb+string_speaker+ instead default to 99999999. In the case of flags, a value of 1 will set the flag and a value of 0 will unset it. All string variables except \verb+door_name+ default to the string "same", which results in no change to the corresponding field. The variable \verb+door_name+ is required.
-\begin{itemize}
-\item INT_VAR \verb+bounding_open_left+ to the new value of the left edge of the open-state bounding box. The vertices remain unchanged.
-\item INT_VAR \verb+bounding_open_top+ to the new value of the top edge of the open-state bounding box. The vertices remain unchanged.
-\item INT_VAR \verb+bounding_open_right+ to the new value of the right edge of the open-state bounding box. The vertices remain unchanged.
-\item INT_VAR \verb+bounding_open_bottom+ to the new value of the bottom edge of the open-state bounding box. The vertices remain unchanged.
-\item INT_VAR \verb+bounding_closed_left+ to the new value of the left edge of the closed-state bounding box. The vertices remain unchanged.
-\item INT_VAR \verb+bounding_closed_top+ to the new value of the top edge of the closed-state bounding box. The vertices remain unchanged.
-\item INT_VAR \verb+bounding_closed_right+ to the new value of the right edge of the closed-state bounding box. The vertices remain unchanged.
-\item INT_VAR \verb+bounding_closed_bottom+ to the new value of the bottom edge of the closed-state bounding box. The vertices remain unchanged.
-\item INT_VAR \verb+door_hp+ to the new hit-point value.
-\item INT_VAR \verb+door_ac+ to the new armor-class value.
-\item INT_VAR \verb+cursor+ to the new cursor index.
-\item INT_VAR \verb+trap_detect+ to the new difficulty of trap detection.
-\item INT_VAR \verb+trap_remove+ to the new difficulty of trap removal.
-\item INT_VAR \verb+trapped+ to whether the door should be trapped.
-\item INT_VAR \verb+detected+ to whether the door trap should be detected.
-\item INT_VAR \verb+launch_x+ to the new x coordinate of the launch point.
-\item INT_VAR \verb+launch_y+ to the new y coordinate of the launch point.
-\item INT_VAR \verb+door_detect+ to the new difficulty of door detection.
-\item INT_VAR \verb+lock_difficulty+ to the new difficulty of the lock.
-\item INT_VAR \verb+open_x+ to the new x coordinate of the opening point.
-\item INT_VAR \verb+open_y+ to the new y coordinate of the opening point.
-\item INT_VAR \verb+close_x+ to the new x coordinate of the closing point.
-\item INT_VAR \verb+close_y+ to the new y coordinate of the closing point.
-\item INT_VAR \verb+string_unlock+ to the new string reference of the unlock message.
-\item INT_VAR \verb+string_speaker+ to the new string reference of the dialogue-speaker name.
-\item INT_VAR \verb+flag_open+ to the new value of the flag known as \t{door open} (bit 0).
-\item INT_VAR \verb+flag_locked+ to the new value of the flag known as \t{door locked} (bit 1).
-\item INT_VAR \verb+flag_resets+ to the new value of the flag known as \t{reset trap} (bit 2).
-\item INT_VAR \verb+flag_detectable+ to the new value of the flag known as \t{trap detectable} (bit 3).
-\item INT_VAR \verb+flag_forced+ to the new value of the flag known as \t{broken} (bit 4).
-\item INT_VAR \verb+flag_no_close+ to the new value of the flag known as \t{can't close} (bit 5).
-\item INT_VAR \verb+flag_located+ to the new value of the flag known as \t{linked} (bit 6).
-\item INT_VAR \verb+flag_secret+ to the new value of the flag known as \t{door hidden} (bit 7).
-\item INT_VAR \verb+flag_detected+ to the new value of the flag known as \t{door found} (bit 8).
-\item INT_VAR \verb+flag_no_look+ to the new value of the flag known as \t{don't block line of sight} (bit 9).
-\item INT_VAR \verb+flag_uses_key+ to the new value of the flag known as \t{remove key} (bit 10).
-\item INT_VAR \verb+flag_sliding+ to the new value of the flag known as \t{ignore obstacles when closing} (bit 11).
-\item STR_VAR \verb+door_name+ to the name of the door to be patched. This variable is required.
-\item STR_VAR \verb+door_open_sound+ to the resource reference of the opening sound.
-\item STR_VAR \verb+door_close_sound+ to the resource reference of the closing sound.
-\item STR_VAR \verb+door_key+ to the resref of the new door key.
-\item STR_VAR \verb+door_script+ to the resref of the new door script.
-\item STR_VAR \verb+travel_trigger+ to the new travel-trigger name. This field is 24 bytes in length.
-\item STR_VAR \verb+dialogue+ to the new resource reference of the dialogue file.
-\end{itemize}
+\begin{weiduarguments}
+Integer variable & \verb+bounding_open_left+ & the new value of the left edge of the open-state bounding box. The vertices remain unchanged. & \verb+-1+ \\
+Integer variable & \verb+bounding_open_top+ & the new value of the top edge of the open-state bounding box. The vertices remain unchanged. & \verb+-1+ \\
+Integer variable & \verb+bounding_open_right+ & the new value of the right edge of the open-state bounding box. The vertices remain unchanged. & \verb+-1+ \\
+Integer variable & \verb+bounding_open_bottom+ & the new value of the bottom edge of the open-state bounding box. The vertices remain unchanged. & \verb+-1+ \\
+Integer variable & \verb+bounding_closed_left+ & the new value of the left edge of the closed-state bounding box. The vertices remain unchanged. & \verb+-1+ \\
+Integer variable & \verb+bounding_closed_top+ & the new value of the top edge of the closed-state bounding box. The vertices remain unchanged. & \verb+-1+ \\
+Integer variable & \verb+bounding_closed_right+ & the new value of the right edge of the closed-state bounding box. The vertices remain unchanged. & \verb+-1+ \\
+Integer variable & \verb+bounding_closed_bottom+ & the new value of the bottom edge of the closed-state bounding box. The vertices remain unchanged. & \verb+-1+ \\
+Integer variable & \verb+door_hp+ & the new hit-point value. & \verb+-1+ \\
+Integer variable & \verb+door_ac+ & the new armor-class value. & \verb+-1+ \\
+Integer variable & \verb+cursor+ & the new cursor index. & \verb+-1+ \\
+Integer variable & \verb+trap_detect+ & the new difficulty of trap detection. & \verb+-1+ \\
+Integer variable & \verb+trap_remove+ & the new difficulty of trap removal. & \verb+-1+ \\
+Integer variable & \verb+trapped+ & whether the door should be trapped. & \verb+-1+ \\
+Integer variable & \verb+detected+ & whether the door trap should be detected. & \verb+-1+ \\
+Integer variable & \verb+launch_x+ & the new x coordinate of the launch point. & \verb+-1+ \\
+Integer variable & \verb+launch_y+ & the new y coordinate of the launch point. & \verb+-1+ \\
+Integer variable & \verb+door_detect+ & the new difficulty of door detection. & \verb+-1+ \\
+Integer variable & \verb+lock_difficulty+ & the new difficulty of the lock. & \verb+-1+ \\
+Integer variable & \verb+open_x+ & the new x coordinate of the opening point. & \verb+-1+ \\
+Integer variable & \verb+open_y+ & the new y coordinate of the opening point. & \verb+-1+ \\
+Integer variable & \verb+close_x+ & the new x coordinate of the closing point. & \verb+-1+ \\
+Integer variable & \verb+close_y+ & the new y coordinate of the closing point. & \verb+-1+ \\
+Integer variable & \verb+string_unlock+ & the new string reference of the unlock message. & \verb+99999999+ \\
+Integer variable & \verb+string_speaker+ & the new string reference of the dialogue-speaker name. & \verb+99999999+ \\
+Integer variable & \verb+flag_open+ & the new value of the flag known as \t{door open} (bit 0). & \verb+-1+ \\
+Integer variable & \verb+flag_locked+ & the new value of the flag known as \t{door locked} (bit 1). & \verb+-1+ \\
+Integer variable & \verb+flag_resets+ & the new value of the flag known as \t{reset trap} (bit 2). & \verb+-1+ \\
+Integer variable & \verb+flag_detectable+ & the new value of the flag known as \t{trap detectable} (bit 3). & \verb+-1+ \\
+Integer variable & \verb+flag_forced+ & the new value of the flag known as \t{broken} (bit 4). & \verb+-1+ \\
+Integer variable & \verb+flag_no_close+ & the new value of the flag known as \t{can't close} (bit 5). & \verb+-1+ \\
+Integer variable & \verb+flag_located+ & the new value of the flag known as \t{linked} (bit 6). & \verb+-1+ \\
+Integer variable & \verb+flag_secret+ & the new value of the flag known as \t{door hidden} (bit 7). & \verb+-1+ \\
+Integer variable & \verb+flag_detected+ & the new value of the flag known as \t{door found} (bit 8). & \verb+-1+ \\
+Integer variable & \verb+flag_no_look+ & the new value of the flag known as \t{don't block line of sight} (bit 9). & \verb+-1+ \\
+Integer variable & \verb+flag_uses_key+ & the new value of the flag known as \t{remove key} (bit 10). & \verb+-1+ \\
+Integer variable & \verb+flag_sliding+ & the new value of the flag known as \t{ignore obstacles when closing} (bit 11). & \verb+-1+ \\
+String variable & \verb+door_name+ & the name of the door to be patched. This variable is required. & Empty string \\
+String variable & \verb+door_open_sound+ & the resource reference of the opening sound. & \verb+same+ \\
+String variable & \verb+door_close_sound+ & the resource reference of the closing sound. & \verb+same+ \\
+String variable & \verb+door_key+ & the resref of the new door key. & \verb+same+ \\
+String variable & \verb+door_script+ & the resref of the new door script. & \verb+same+ \\
+String variable & \verb+travel_trigger+ & the new travel-trigger name. This field is 24 bytes in length. & \verb+same+ \\
+String variable & \verb+dialogue+ & the new resource reference of the dialogue file. & \verb+same+ \\
+\end{weiduarguments}
+
 \\
 
 \verb+ALTER_ITEM_EFFECT+: patch \ahref{\url{http://gibberlings3.net/iesdp/file_formats/ie_formats/itm_v1.htm#itmv1_Feature_Block}}{global (equipping) effects} and/or \ahref{\url{http://gibberlings3.net/iesdp/file_formats/ie_formats/itm_v1.htm#itmv1_Extended_Header}}{effects on extended headers}. This is a PATCH function. All integer variables except \verb+check_globals+, \verb+check_headers+, \verb+header+ and \verb+savebonus+ default to -1 and negative values result in no change to the corresponding field. The integer variables \verb+check_globals+, \verb+check_headers+ and \verb+header+ default to 0. The integer variable \verb+savebonus+ defaults to -11 and values lower than -10 result in no change to the corresponding field. The string variable \verb+resource+ defaults to the string "same", which results in no change to the corresponding field.
 
 Note that both \verb+check_globals+ and \verb+check_headers+ are 0 by default, so you need to change one or both of these to 1 to perform any patching at all. If you patch headers, you can further target by using type to target melee, ranged, or magical headers. \verb+match_opcode+ can be left at -1 to match all effects on your targeted range or targeted to a specific opcode. If the opcode itself needs to be changed, you can use \verb+match_opcode+ to target the existing effect and \verb+new_opcode+ as the new opcode to use. \verb+duration_high+ is an alternative to \verb+duration+, mainly for changing the overall duration of an item's effects. The idea is to allow you to mass patch effects to new durations while leaving the one-time only cosmetics and visuals--which are usual instant or only run for a few seconds--unchanged.
-\begin{itemize}
-\item INT_VAR \verb+check_globals+ to whether to check global (on-equip) effects (0 for no, 1 for yes). (default 0)
-\item INT_VAR \verb+check_headers+ to whether to check effects on extended headers (0 for no, 1 for yes). (default 0)
-\item INT_VAR \verb+header+ to the number of the ability header that should be altered. A value of 0 matches all headers. (default 0)
-\item INT_VAR \verb+header_type+ to which type of header that should be checked. If this variable is -1, all header types will be checked.
-\item INT_VAR \verb+match_opcode+ to which type of opcode to match. If this variable is -1, all opcodes are a match.
-\item INT_VAR \verb+new_opcode+ to the value the matched opcode should be changed into.
-\item INT_VAR \verb+target+ to the new target.
-\item INT_VAR \verb+power+ to the new power.
-\item INT_VAR \verb+parameter1+ to the new parameter1.
-\item INT_VAR \verb+parameter2+ to the new parameter2.
-\item INT_VAR \verb+timing+ to the new timing mode.
-\item INT_VAR \verb+resist_dispel+ to the new resist/dispel.
-\item INT_VAR \verb+duration+ to the new duration.
-\item INT_VAR \verb+duration_high+ to the new duration, but is only written if the existing duration is greater than 5.
-\item INT_VAR \verb+probability1+ to the new probability1 (the upper bound).
-\item INT_VAR \verb+probability2+ to the new probability2 (the lower bound).
-\item INT_VAR \verb+dicenumber+ to the new number of dice. This field is instead used for maximum hit-dice (HD) by some opcodes.
-\item INT_VAR \verb+dicesize+ to the new size of dice. This field is also instead for minimum hit-dice (HD) by some opcodes.
-\item INT_VAR \verb+savingthrow+ to the new saving-throw type.
-\item INT_VAR \verb+savebonus+ to the new saving-throw bonus/penalty. This variable can take negative values down to -10 while still writing to the corresponding field. (default -11)
-\item INT_VAR \verb+special+ to the new special parameter.
-\item STR_VAR \verb+resource+ to the new resource reference.
-\end{itemize}
+\begin{weiduarguments}
+Integer variable & \verb+check_globals+ & whether to check global (on-equip) effects (0 for no, 1 for yes). (default 0) & \verb+0+ \\
+Integer variable & \verb+check_headers+ & whether to check effects on extended headers (0 for no, 1 for yes). (default 0) & \verb+0+ \\
+Integer variable & \verb+header+ & the number of the ability header that should be altered. A value of 0 matches all headers. (default 0) & \verb+0+ \\
+Integer variable & \verb+header_type+ & which type of header that should be checked. If this variable is -1, all header types will be checked. & \verb+-1+ \\
+Integer variable & \verb+match_opcode+ & which type of opcode to match. If this variable is -1, all opcodes are a match. & \verb+-1+ \\
+Integer variable & \verb+new_opcode+ & the value the matched opcode should be changed into. & \verb+-1+ \\
+Integer variable & \verb+target+ & the new target. & \verb+-1+ \\
+Integer variable & \verb+power+ & the new power. & \verb+-1+ \\
+Integer variable & \verb+parameter1+ & the new parameter1. & \verb+-1+ \\
+Integer variable & \verb+parameter2+ & the new parameter2. & \verb+-1+ \\
+Integer variable & \verb+timing+ & the new timing mode. & \verb+-1+ \\
+Integer variable & \verb+resist_dispel+ & the new resist/dispel. & \verb+-1+ \\
+Integer variable & \verb+duration+ & the new duration. & \verb+-1+ \\
+Integer variable & \verb+duration_high+ & the new duration, but is only written if the existing duration is greater than 5. & \verb+-1+ \\
+Integer variable & \verb+probability1+ & the new probability1 (the upper bound). & \verb+-1+ \\
+Integer variable & \verb+probability2+ & the new probability2 (the lower bound). & \verb+-1+ \\
+Integer variable & \verb+dicenumber+ & the new number of dice. This field is instead used for maximum hit-dice (HD) by some opcodes. & \verb+-1+ \\
+Integer variable & \verb+dicesize+ & the new size of dice. This field is also instead for minimum hit-dice (HD) by some opcodes. & \verb+-1+ \\
+Integer variable & \verb+savingthrow+ & the new saving-throw type. & \verb+-1+ \\
+Integer variable & \verb+savebonus+ & the new saving-throw bonus/penalty. This variable can take negative values down to -10 while still writing to the corresponding field. (default -11) & \verb+-11+ \\
+Integer variable & \verb+special+ & the new special parameter. & \verb+-1+ \\
+String variable & \verb+resource+ & the new resource reference. & \verb+same+ \\
+\end{weiduarguments}
+
 \\
 
 \verb+ALTER_ITEM_HEADER+: patch \ahref{\url{http://gibberlings3.net/iesdp/file_formats/ie_formats/itm_v1.htm#itmv1_Extended_Header}}{ability headers} on items. This is a PATCH function. All integer variables except \verb+match_icon+ and \verb+header+ default to -1 and negative values result in no change to the corresponding field. The integer variables \verb+match_icon+ and \verb+header+ default to 0. In the case of flags, a value of 1 will set the flag and a value of 0 will unset it. The string variable \verb+icon+ defaults to the string "same", which results in no change to the corresponding field.
 
 \verb+header_type+ is used to limit the scope of matching. The default value of -1 will match all types of headers while values of 0-4 will match headers with those values. If \verb+match_icon+ is 1, the icon resource reference will be match with the \verb+icon+ variable as an additional qualifier. This is useful for items which have multiple magic abilities. \verb+header+ can also be used to limit patching to the Nth header, counting from 1 as the first header. The default is 0, which will match all headers.
 
-\begin{itemize}
-\item INT_VAR \verb+header_type+ to the type of header to be matched. If this variable is -1, all headers will be a match. (default -1)
-\item INT_VAR \verb+match_icon+ to whether to match the ability icon (0 for no, 1 for yes). (default 0)
-\item INT_VAR \verb+header+ to the number of the ability header (starting from 1) that should be altered. A value of 0 matches all header. (default 0)
-\item INT_VAR \verb+new_header_type+ to the value the matched header should be changed into.
-\item INT_VAR \verb+identify+ to the new identification requirement.
-\item INT_VAR \verb+location+ to the new new ability location.
-\item INT_VAR \verb+target+ to the new target.
-\item INT_VAR \verb+target_count+ to the new target count.
-\item INT_VAR \verb+range+ to the new range.
-\item INT_VAR \verb+launcher+ to the new required launcher.
-\item INT_VAR \verb+speed+ to the new speed factor.
-\item INT_VAR \verb+thac0_bonus+ to the new THAC0 bonus.
-\item INT_VAR \verb+dicesize+ to the new dice size.
-\item INT_VAR \verb+primary_type+ to the new primary type (school).
-\item INT_VAR \verb+dicenumber+ to the new number of dice.
-\item INT_VAR \verb+secondary_type+ to the new secondary type.
-\item INT_VAR \verb+damage_bonus+ to the new damage bonus.
-\item INT_VAR \verb+damage_type+ to the new damage type.
-\item INT_VAR \verb+charges+ to the new number of charges.
-\item INT_VAR \verb+drained+ to the new charge-depletion behaviour.
-\item INT_VAR \verb+projectile+ to the new projectile.
-\item INT_VAR \verb+animation_overhand+ to the new overhand animation percentage.
-\item INT_VAR \verb+animation_backhand+ to the new backhand animation percentage.
-\item INT_VAR \verb+animation_thrust+ to the new thrust animation percentage.
-\item INT_VAR \verb+arrow+ to the new arrow qualifier.
-\item INT_VAR \verb+bolt+ to the new bolt qualifier.
-\item INT_VAR \verb+bullet+ to the new bullet qualifier.
-\item INT_VAR \verb+flag_strength+ to the new value of the flag known as \t{add strength bonus} (bit 0).
-\item INT_VAR \verb+flag_break+ to the new value of the flag known as \t{breakable} (bit 1).
-\item INT_VAR \verb+flag_strength_damage+ to the new value of the flag known as \t{add strength bonus to damage only} (bit 2). This flag is not available in all games.
-\item INT_VAR \verb+flag_strength_thac0+ to the new value of the flag known as \t{add strength bonus to THAC0 only} (bit 3). This flag is not available in all games.
-\item INT_VAR \verb+flag_hostile+ to the new value of the flag known as \t{hostile} (bit 10).
-\item INT_VAR \verb+flag_recharge+ to the new value of the flag known as \t{recharges} (bit 11).
-\item INT_VAR \verb+flag_bypass+ to the new value of the flag known as \t{bypass armor} (bit 16). This flag is not available in all games.
-\item INT_VAR \verb+flag_keenedge+ to the new value of the flag known as \t{keen edge} (bit 17). This flag is not available in all games.
-\item INT_VAR \verb+flag_backstab+ to the new value of the flag known as \t{toggle backstab} (bit 25). This flag is not available in all games.
-\item INT_VAR \verb+flag_noinvisible+ to the new value of the flag known as \t{cannot target invisible} (bit 26). This flag is not available in all games.
-\item STR_VAR \verb+icon+ to the resource reference to be used for matching if \verb+match_icon+ is 1, or the new ability icon if \verb+match_icon+ is 0.
-\end{itemize}
+\begin{weiduarguments}
+Integer variable & \verb+header_type+ & the type of header to be matched. If this variable is -1, all headers will be a match. (default -1) & \verb+-1+ \\
+Integer variable & \verb+match_icon+ & whether to match the ability icon (0 for no, 1 for yes). (default 0) & \verb+0+ \\
+Integer variable & \verb+header+ & the number of the ability header (starting from 1) that should be altered. A value of 0 matches all header. (default 0) & \verb+0+ \\
+Integer variable & \verb+new_header_type+ & the value the matched header should be changed into. & \verb+-1+ \\
+Integer variable & \verb+identify+ & the new identification requirement. & \verb+-1+ \\
+Integer variable & \verb+location+ & the new new ability location. & \verb+-1+ \\
+Integer variable & \verb+target+ & the new target. & \verb+-1+ \\
+Integer variable & \verb+target_count+ & the new target count. & \verb+-1+ \\
+Integer variable & \verb+range+ & the new range. & \verb+-1+ \\
+Integer variable & \verb+launcher+ & the new required launcher. & \verb+-1+ \\
+Integer variable & \verb+speed+ & the new speed factor. & \verb+-1+ \\
+Integer variable & \verb+thac0_bonus+ & the new THAC0 bonus. & \verb+-1+ \\
+Integer variable & \verb+dicesize+ & the new dice size. & \verb+-1+ \\
+Integer variable & \verb+primary_type+ & the new primary type (school). & \verb+-1+ \\
+Integer variable & \verb+dicenumber+ & the new number of dice. & \verb+-1+ \\
+Integer variable & \verb+secondary_type+ & the new secondary type. & \verb+-1+ \\
+Integer variable & \verb+damage_bonus+ & the new damage bonus. & \verb+-1+ \\
+Integer variable & \verb+damage_type+ & the new damage type. & \verb+-1+ \\
+Integer variable & \verb+charges+ & the new number of charges. & \verb+-1+ \\
+Integer variable & \verb+drained+ & the new charge-depletion behaviour. & \verb+-1+ \\
+Integer variable & \verb+projectile+ & the new projectile. & \verb+-1+ \\
+Integer variable & \verb+animation_overhand+ & the new overhand animation percentage. & \verb+-1+ \\
+Integer variable & \verb+animation_backhand+ & the new backhand animation percentage. & \verb+-1+ \\
+Integer variable & \verb+animation_thrust+ & the new thrust animation percentage. & \verb+-1+ \\
+Integer variable & \verb+arrow+ & the new arrow qualifier. & \verb+-1+ \\
+Integer variable & \verb+bolt+ & the new bolt qualifier. & \verb+-1+ \\
+Integer variable & \verb+bullet+ & the new bullet qualifier. & \verb+-1+ \\
+Integer variable & \verb+flag_strength+ & the new value of the flag known as \t{add strength bonus} (bit 0). & \verb+-1+ \\
+Integer variable & \verb+flag_break+ & the new value of the flag known as \t{breakable} (bit 1). & \verb+-1+ \\
+Integer variable & \verb+flag_strength_damage+ & the new value of the flag known as \t{add strength bonus to damage only} (bit 2). This flag is not available in all games. & \verb+-1+ \\
+Integer variable & \verb+flag_strength_thac0+ & the new value of the flag known as \t{add strength bonus to THAC0 only} (bit 3). This flag is not available in all games. & \verb+-1+ \\
+Integer variable & \verb+flag_hostile+ & the new value of the flag known as \t{hostile} (bit 10). & \verb+-1+ \\
+Integer variable & \verb+flag_recharge+ & the new value of the flag known as \t{recharges} (bit 11). & \verb+-1+ \\
+Integer variable & \verb+flag_bypass+ & the new value of the flag known as \t{bypass armor} (bit 16). This flag is not available in all games. & \verb+-1+ \\
+Integer variable & \verb+flag_keenedge+ & the new value of the flag known as \t{keen edge} (bit 17). This flag is not available in all games. & \verb+-1+ \\
+Integer variable & \verb+flag_backstab+ & the new value of the flag known as \t{toggle backstab} (bit 25). This flag is not available in all games. & \verb+-1+ \\
+Integer variable & \verb+flag_noinvisible+ & the new value of the flag known as \t{cannot target invisible} (bit 26). This flag is not available in all games. & \verb+-1+ \\
+String variable & \verb+icon+ & the resource reference to be used for matching if \verb+match_icon+ is 1, or the new ability icon if \verb+match_icon+ is 0. & \verb+same+ \\
+\end{weiduarguments}
+
 \\
 
 \verb+DELETE_ITEM_HEADER+: delete ability headers, also known as \ahref{\url{http://gibberlings3.net/iesdp/file_formats/ie_formats/itm_v1.htm#itmv1_Extended_Header}}{extended headers}, from items. This is a PATCH function. All integer variables default to 0.
 
 This function will delete one or more ability headers, along with all of their associated effects, and properly re-index the file.
 
-\begin{itemize}
-\item INT_VAR \verb+header_type+ to the header type to delete. If this variable is -1, all header types will be a match. (default 0)
-\end{itemize}
+\begin{weiduarguments}
+Integer variable & \verb+header_type+ & the header type to delete. If this variable is -1, all header types will be a match. (default 0) & \verb+0+ \\
+\end{weiduarguments}
+
 \\
 
 \verb+ALTER_SPELL_EFFECT+: patch \ahref{\url{http://gibberlings3.net/iesdp/file_formats/ie_formats/spl_v1.htm#splv1_Feature_Block}}{effects} on spells. This is a PATCH function. All integer variables except \verb+check_globals+, \verb+check_headers+, \verb+header+ and \verb+savebonus+ default to -1 and negative values result in no change to the corresponding field. The integer variables \verb+check_globals+ and \verb+header+ default to 0. The integer variable \verb+check_headers+ defaults to 1. The integer variable \verb+savebonus+ defaults to -11 and values lower than -10 result in no change to the corresponding field. The string variable \verb+resource+ defaults to the string "same", which results in no change to the corresponding field.
 
 The function will by default only check effects on headers. You can change this by changing the values of the variables \verb+check_globals+ and \verb+check_headers+. If you patch headers, you can further target by using type to target melee, ranged, or magical headers. \verb+match_opcode+ can be left at -1 to match all effects on your targeted range or targeted to a specific opcode. If the opcode itself needs to be changed, you can use \verb+match_opcode+ to target the existing effect and \verb+new_opcode+ as the new opcode to use. \verb+duration_high+ is an alternative to \verb+duration+, mainly for changing the overall duration of an item's effects. The idea is to allow you to mass patch effects to new durations while leaving the one-time only cosmetics and visuals--which are usual instant or only run for a few seconds--unchanged.
-\begin{itemize}
-\item INT_VAR \verb+check_globals+ to whether to check global effects (0 for no, 1 for yes). (default 0)
-\item INT_VAR \verb+check_headers+ to whether to check effects on extended headers (0 for no, 1 for yes). (default 1)
-\item INT_VAR \verb+header+ to the number of the ability header that should be altered. A value of 0 matches all headers. (default 0)
-\item INT_VAR \verb+header_type+ to which type of header that should be checked. If this variable is -1, all header types will be checked.
-\item INT_VAR \verb+match_opcode+ to which type of opcode to match. If this variable is -1, all opcodes are a match.
-\item INT_VAR \verb+new_opcode+ to the value the matched opcode should be changed into.
-\item INT_VAR \verb+target+ to the new target.
-\item INT_VAR \verb+power+ to the new power.
-\item INT_VAR \verb+parameter1+ to the new parameter1.
-\item INT_VAR \verb+parameter2+ to the new parameter2.
-\item INT_VAR \verb+timing+ to the new timing mode.
-\item INT_VAR \verb+resist_dispel+ to the new resist/dispel.
-\item INT_VAR \verb+duration+ to the new duration.
-\item INT_VAR \verb+duration_high+ to the new duration, but is only written if the existing duration is greater than 5.
-\item INT_VAR \verb+probability1+ to the new probability1 (the upper bound).
-\item INT_VAR \verb+probability2+ to the new probability2 (the lower bound).
-\item INT_VAR \verb+dicenumber+ to the new number of dice. This field is instead used for maximum hit-dice (HD) by some opcodes.
-\item INT_VAR \verb+dicesize+ to the new size of dice. This field is also instead for minimum hit-dice (HD) by some opcodes.
-\item INT_VAR \verb+savingthrow+ to the new saving-throw type.
-\item INT_VAR \verb+savebonus+ to the new saving-throw bonus/penalty. This variable can take negative values down to -10 while still writing to the corresponding field. (default -11)
-\item INT_VAR \verb+special+ to the new special parameter.
-\item STR_VAR \verb+resource+ to the new resource reference.
-\end{itemize}
+\begin{weiduarguments}
+Integer variable & \verb+check_globals+ & whether to check global effects (0 for no, 1 for yes). (default 0) & \verb+0+ \\
+Integer variable & \verb+check_headers+ & whether to check effects on extended headers (0 for no, 1 for yes). (default 1) & \verb+1+ \\
+Integer variable & \verb+header+ & the number of the ability header that should be altered. A value of 0 matches all headers. (default 0) & \verb+0+ \\
+Integer variable & \verb+header_type+ & which type of header that should be checked. If this variable is -1, all header types will be checked. & \verb+-1+ \\
+Integer variable & \verb+match_opcode+ & which type of opcode to match. If this variable is -1, all opcodes are a match. & \verb+-1+ \\
+Integer variable & \verb+new_opcode+ & the value the matched opcode should be changed into. & \verb+-1+ \\
+Integer variable & \verb+target+ & the new target. & \verb+-1+ \\
+Integer variable & \verb+power+ & the new power. & \verb+-1+ \\
+Integer variable & \verb+parameter1+ & the new parameter1. & \verb+-1+ \\
+Integer variable & \verb+parameter2+ & the new parameter2. & \verb+-1+ \\
+Integer variable & \verb+timing+ & the new timing mode. & \verb+-1+ \\
+Integer variable & \verb+resist_dispel+ & the new resist/dispel. & \verb+-1+ \\
+Integer variable & \verb+duration+ & the new duration. & \verb+-1+ \\
+Integer variable & \verb+duration_high+ & the new duration, but is only written if the existing duration is greater than 5. & \verb+-1+ \\
+Integer variable & \verb+probability1+ & the new probability1 (the upper bound). & \verb+-1+ \\
+Integer variable & \verb+probability2+ & the new probability2 (the lower bound). & \verb+-1+ \\
+Integer variable & \verb+dicenumber+ & the new number of dice. This field is instead used for maximum hit-dice (HD) by some opcodes. & \verb+-1+ \\
+Integer variable & \verb+dicesize+ & the new size of dice. This field is also instead for minimum hit-dice (HD) by some opcodes. & \verb+-1+ \\
+Integer variable & \verb+savingthrow+ & the new saving-throw type. & \verb+-1+ \\
+Integer variable & \verb+savebonus+ & the new saving-throw bonus/penalty. This variable can take negative values down to -10 while still writing to the corresponding field. (default -11) & \verb+-11+ \\
+Integer variable & \verb+special+ & the new special parameter. & \verb+-1+ \\
+String variable & \verb+resource+ & the new resource reference. & \verb+same+ \\
+\end{weiduarguments}
+
 \\
 
 \verb+ALTER_SPELL_HEADER+: patch \ahref{\url{http://gibberlings3.net/iesdp/file_formats/ie_formats/spl_v1.htm#splv1_Extended_Header}}{ability headers} on spells. This is a PATCH function.All integer variables except \verb+match_icon+ and \verb+header+ default to -1 and negative values result in no change to the corresponding field. The integer variables \verb+match_icon+ and \verb+header+ default to 0. The string variable \verb+icon+ defaults to the string "same", which results in no change to the corresponding field.
 
 \verb+header_type+ is used to limit the scope of matching. The default value of -1 will match all types of headers while values of 0-4 will match headers with those values. If \verb+match_icon+ is 1, the icon resource reference will be match with the \verb+icon+ variable as an additional qualifier. This is useful for items which have multiple magic abilities. \verb+header+ can also be used to limit patching to the Nth header, counting from 1 as the first header. The default is 0, which will match all headers.
 
-\begin{itemize}
-\item INT_VAR \verb+header_type+ to the type of header to be matched. If this variable is -1, all headers will be a match. (default -1)
-\item INT_VAR \verb+match_icon+ to whether to match the ability icon (0 for no, 1 for yes). (default 0)
-\item INT_VAR \verb+header+ to the number of the ability header (starting from 1) that should be altered. A value of 0 matches all header. (default 0)
-\item INT_VAR \verb+new_header_type+ to the value the matched header should be changed into.
-\item INT_VAR \verb+location+ to the new new ability location.
-\item INT_VAR \verb+target+ to the new target.
-\item INT_VAR \verb+target_count+ to the new target count.
-\item INT_VAR \verb+range+ to the new range.
-\item INT_VAR \verb+min_level+ to the new required minimum level.
-\item INT_VAR \verb+speed+ to the new speed factor.
-\item INT_VAR \verb+thac0_bonus+ to the new THAC0 bonus.
-\item INT_VAR \verb+dicesize+ to the new dice size.
-\item INT_VAR \verb+dicenumber+ to the new number of dice.
-\item INT_VAR \verb+damage_bonus+ to the new damage bonus.
-\item INT_VAR \verb+damage_type+ to the new damage type.
-\item INT_VAR \verb+charges+ to the new number of charges.
-\item INT_VAR \verb+projectile+ to the new projectile.
-\item STR_VAR \verb+icon+ to the resource reference to be used for matching if \verb+match_icon+ is 1, or the new ability icon if \verb+match_icon+ is 0.
-\end{itemize}
+\begin{weiduarguments}
+Integer variable & \verb+header_type+ & the type of header to be matched. If this variable is -1, all headers will be a match. (default -1) & \verb+-1+ \\
+Integer variable & \verb+match_icon+ & whether to match the ability icon (0 for no, 1 for yes). (default 0) & \verb+0+ \\
+Integer variable & \verb+header+ & the number of the ability header (starting from 1) that should be altered. A value of 0 matches all header. (default 0) & \verb+0+ \\
+Integer variable & \verb+new_header_type+ & the value the matched header should be changed into. & \verb+-1+ \\
+Integer variable & \verb+location+ & the new new ability location. & \verb+-1+ \\
+Integer variable & \verb+target+ & the new target. & \verb+-1+ \\
+Integer variable & \verb+target_count+ & the new target count. & \verb+-1+ \\
+Integer variable & \verb+range+ & the new range. & \verb+-1+ \\
+Integer variable & \verb+min_level+ & the new required minimum level. & \verb+-1+ \\
+Integer variable & \verb+speed+ & the new speed factor. & \verb+-1+ \\
+Integer variable & \verb+thac0_bonus+ & the new THAC0 bonus. & \verb+-1+ \\
+Integer variable & \verb+dicesize+ & the new dice size. & \verb+-1+ \\
+Integer variable & \verb+dicenumber+ & the new number of dice. & \verb+-1+ \\
+Integer variable & \verb+damage_bonus+ & the new damage bonus. & \verb+-1+ \\
+Integer variable & \verb+damage_type+ & the new damage type. & \verb+-1+ \\
+Integer variable & \verb+charges+ & the new number of charges. & \verb+-1+ \\
+Integer variable & \verb+projectile+ & the new projectile. & \verb+-1+ \\
+String variable & \verb+icon+ & the resource reference to be used for matching if \verb+match_icon+ is 1, or the new ability icon if \verb+match_icon+ is 0. & \verb+same+ \\
+\end{weiduarguments}
+
 \\
 
 \verb+DELETE_SPELL_HEADER+: delete ability headers, also known as \ahref{\url{http://gibberlings3.net/iesdp/file_formats/ie_formats/itm_v1.htm#itmv1_Extended_Header}}{extended headers}, from spells. This is a PATCH function. The integer variable \verb+header_type+ defaults to 0. The integer variable \verb+min_level+ defaults to -1 and if this variable is 0 or greater, only headers with a matching minimum level will be deleted.
 
 This function will delete one or more ability headers, along with all of their associated effects, and properly re-index the file.
 
-\begin{itemize}
-\item INT_VAR \verb+header_type+ to the header type to delete. If this variable is -1, all header types will be a match. (default 0)
-\item INT_VAR \verb+min_level+ to the minimum level to be matched. If this variable is negative, it will not be used for matching. (default -1)
-\end{itemize}
+\begin{weiduarguments}
+Integer variable & \verb+header_type+ & the header type to delete. If this variable is -1, all header types will be a match. (default 0) & \verb+0+ \\
+Integer variable & \verb+min_level+ & the minimum level to be matched. If this variable is negative, it will not be used for matching. (default -1) & \verb+-1+ \\
+\end{weiduarguments}
+
 \\
 
 \verb+CLONE_EFFECT+: This is a patch function for creature, item, or spell files that will match an existing effect and create a new one based on the matched effect. Numerous variables are available for matching the specified effect and for specifying new values in the new effect based on the matched effect.
 
 The first batch of variables are meta-variables which will help determine the scope of the function:
 
-\begin{itemize}
-\item INT_VAR \verb+check_globals+ to whether the function should loop through global effects on items (also known as equipping effects) and spells (default is 1). Creature effects are all global effects, so this variable will always be considered to be one when this function is run on a creature.
-\item INT_VAR \verb+check_headers+ to whether the function should loop through effects on extended headers on items and spells if set to 1 (default is 1). Creatures have no extended headers, so this variable is ignored when used on creatures.
-\item INT_VAR \verb+header+ to whether the function should target effects on one specific header, counting the first header as zero. A negative value will match all headers (default is -1). Creatures have no extended headers, so this variable is ignored when used on creatures.
-\item INT_VAR \verb+header_type+ to whether the function should only clone effects on extended headers of the specified type (1 - melee, 2 - ranged, etc.). Negative values will look at effects on all headers (default is -1). Creatures have no extended headers, so this variable is ignored when used on creatures.
-\item INT_VAR \verb+multi_match+ to the number of effects to clone in the active stack. If you just want to match the first effect and have the function stop, use 1. Otherwise the function will continue matching until the number of cloned effects matches this value. The function will always make at least one change (e.g. 0 or negative values are treated as 1). (default is 999).
-\item INT_VAR \verb+verbose+ to whether the function should provide some rudimentary information on how many effects were added (default is 0).
-\item INT_VAR \verb+silent+ to whether the function should suppress warnings when no effects were added. This option also suppresses the \t{verbose} option (default is 0).
-\item STR_VAR \verb+insert+ to the relative position the cloned effect should be inserted at. A value of 'below' puts the new, cloned effect immediately below the matched effect. Values of 'first' or last' will put the new effect at the top or bottom of the effect stack, respectively. All other values will default to 'above', where the effect is added immediately before the matched effect (default is 'above').
-\end{itemize}
+\begin{weiduarguments}
+Integer variable & \verb+check_globals+ & whether the function should loop through global effects on items (also known as equipping effects) and spells (default is 1). Creature effects are all global effects, so this variable will always be considered to be one when this function is run on a creature. & \verb+1+ \\
+Integer variable & \verb+check_headers+ & whether the function should loop through effects on extended headers on items and spells if set to 1 (default is 1). Creatures have no extended headers, so this variable is ignored when used on creatures. & \verb+1+ \\
+Integer variable & \verb+header+ & whether the function should target effects on one specific header, counting the first header as zero. A negative value will match all headers (default is -1). Creatures have no extended headers, so this variable is ignored when used on creatures. & \verb+-1+ \\
+Integer variable & \verb+header_type+ & whether the function should only clone effects on extended headers of the specified type (1 - melee, 2 - ranged, etc.). Negative values will look at effects on all headers (default is -1). Creatures have no extended headers, so this variable is ignored when used on creatures. & \verb+-1+ \\
+Integer variable & \verb+multi_match+ & the number of effects to clone in the active stack. If you just want to match the first effect and have the function stop, use 1. Otherwise the function will continue matching until the number of cloned effects matches this value. The function will always make at least one change (e.g. 0 or negative values are treated as 1). (default is 999). & \verb+999+ \\
+Integer variable & \verb+verbose+ & whether the function should provide some rudimentary information on how many effects were added (default is 0). & \verb+0+ \\
+Integer variable & \verb+silent+ & whether the function should suppress warnings when no effects were added. This option also suppresses the \t{verbose} option (default is 0). & \verb+0+ \\
+String variable & \verb+insert+ & the relative position the cloned effect should be inserted at. A value of 'below' puts the new, cloned effect immediately below the matched effect. Values of 'first' or last' will put the new effect at the top or bottom of the effect stack, respectively. All other values will default to 'above', where the effect is added immediately before the matched effect (default is 'above'). & \verb+above+ \\
+\end{weiduarguments}
+
 
 The next batch of variables sets the function boundaries on matching an effect to clone. Any variables not specified will not be used to determine a match. The function will only determine an effect is a match only if ALL of the variables specified are matched.
 
-\begin{itemize}
-\item INT_VAR \verb+match_opcode+ to the opcode of effects to be matched (default -1).
-\item INT_VAR \verb+match_target+ to the target of effects to be matched (default -1).
-\item INT_VAR \verb+match_power+ to the power of effects to be matched (default -1).
-\item INT_VAR \verb+match_parameter1+ to parameter1 of effects to be matched (default -1).
-\item INT_VAR \verb+match_parameter2+ to parameter2 of effects to be matched (default -1).
-\item INT_VAR \verb+match_timing+ to the timing of effects to be matched (default -1).
-\item INT_VAR \verb+match_resist_dispel+ to the resist/dispel setting of effects to be matched (default -1).
-\item INT_VAR \verb+match_duration+ to the duration of effects to be matched (default -1).
-\item INT_VAR \verb+match_probability1+ to probability1 (the upper bound) of effects to be matched (default -1).
-\item INT_VAR \verb+match_probability2+ to probability2 (the lower bound) of effects to be matched (default -1).
-\item INT_VAR \verb+match_dicenumber+ to the number of dice of effects to be matched (default -1). This field is instead used for maximum hit-dice (HD) by some opcodes.
-\item INT_VAR \verb+match_dicesize+ to the size of dice of effects to be matched (default -1). This field is used instead for minimum hit-dice (HD) by some opcodes.
-\item INT_VAR \verb+match_savingthrow+ to the saving throw type of effects to be matched (default -1).
-\item INT_VAR \verb+match_savebonus+ to the saving throw bonus of effects to be matched (default -11). Since saving throws can range into negative values, this variable can match all the way down to -10.
-\item INT_VAR \verb+match_special+  to the special field of effects to be matched (default -1). The special field is used by some EE effects.
-\item STR_VAR \verb+match_resource+ to the resource of effects to be matched (default "SAME").
-\end{itemize}
+\begin{weiduarguments}
+Integer variable & \verb+match_opcode+ & the opcode of effects to be matched (default -1). & \verb+-1+ \\
+Integer variable & \verb+match_target+ & the target of effects to be matched (default -1). & \verb+-1+ \\
+Integer variable & \verb+match_power+ & the power of effects to be matched (default -1). & \verb+-1+ \\
+Integer variable & \verb+match_parameter1+ & parameter1 of effects to be matched (default -1). & \verb+-1+ \\
+Integer variable & \verb+match_parameter2+ & parameter2 of effects to be matched (default -1). & \verb+-1+ \\
+Integer variable & \verb+match_timing+ & the timing of effects to be matched (default -1). & \verb+-1+ \\
+Integer variable & \verb+match_resist_dispel+ & the resist/dispel setting of effects to be matched (default -1). & \verb+-1+ \\
+Integer variable & \verb+match_duration+ & the duration of effects to be matched (default -1). & \verb+-1+ \\
+Integer variable & \verb+match_probability1+ & probability1 (the upper bound) of effects to be matched (default -1). & \verb+-1+ \\
+Integer variable & \verb+match_probability2+ & probability2 (the lower bound) of effects to be matched (default -1). & \verb+-1+ \\
+Integer variable & \verb+match_dicenumber+ & the number of dice of effects to be matched (default -1). This field is instead used for maximum hit-dice (HD) by some opcodes. & \verb+-1+ \\
+Integer variable & \verb+match_dicesize+ & the size of dice of effects to be matched (default -1). This field is used instead for minimum hit-dice (HD) by some opcodes. & \verb+-1+ \\
+Integer variable & \verb+match_savingthrow+ & the saving throw type of effects to be matched (default -1). & \verb+-1+ \\
+Integer variable & \verb+match_savebonus+ & the saving throw bonus of effects to be matched (default -11). Since saving throws can range into negative values, this variable can match all the way down to -10. & \verb+-11+ \\
+Integer variable & \verb+match_special+ & the special field of effects to be matched (default -1). The special field is used by some EE effects. & \verb+-1+ \\
+String variable & \verb+match_resource+ & the resource of effects to be matched (default "SAME"). & \verb+SAME+ \\
+\end{weiduarguments}
+
 
 Once a matching effect is found, a new effect is created (STR_VAR
 \verb+insert+ determines its placement) with all of the same
@@ -9695,59 +9772,62 @@ except savebonus which defaults to -11. If the value of a variable is
 less than or equal to the default value, the new effect inherits the
 corresponding value of the matched effect.
 
-\begin{itemize}
-\item INT_VAR \verb+opcode+ to the value the of the new effect's opcode.
-\item INT_VAR \verb+target+ to the new effect's target.
-\item INT_VAR \verb+power+ to the new effect's power.
-\item INT_VAR \verb+parameter1+ to the new effect's parameter1.
-\item INT_VAR \verb+parameter2+ to the new effect's parameter2.
-\item INT_VAR \verb+timing+ to the new effect's timing mode.
-\item INT_VAR \verb+resist_dispel+ to the new effect's resist/dispel setting.
-\item INT_VAR \verb+duration+ to the new effect's duration.
-\item INT_VAR \verb+probability1+ to the new effect's probability1 (the upper bound).
-\item INT_VAR \verb+probability2+ to the new effect's probability2 (the lower bound).
-\item INT_VAR \verb+dicenumber+ to the new effect's number of dice. This field is instead used for maximum hit-dice (HD) by some opcodes.
-\item INT_VAR \verb+dicesize+ to the new effect's size of dice. This field is also instead for minimum hit-dice (HD) by some opcodes.
-\item INT_VAR \verb+savingthrow+ to the new effect's saving-throw type.
-\item INT_VAR \verb+savebonus+ to the new effect's saving-throw bonus/penalty. This variable can take negative values down to -10 while still writing to the corresponding field.
-\item INT_VAR \verb+special+ to the new effect's special field. The special field is used by many EE effects.
-\item STR_VAR \verb+resource+ to the new effect's resource reference.
-\end{itemize}
+\begin{weiduarguments}
+Integer variable & \verb+opcode+ & the value the of the new effect's opcode. & \verb+-1+ \\
+Integer variable & \verb+target+ & the new effect's target. & \verb+-1+ \\
+Integer variable & \verb+power+ & the new effect's power. & \verb+-1+ \\
+Integer variable & \verb+parameter1+ & the new effect's parameter1. & \verb+-1+ \\
+Integer variable & \verb+parameter2+ & the new effect's parameter2. & \verb+-1+ \\
+Integer variable & \verb+timing+ & the new effect's timing mode. & \verb+-1+ \\
+Integer variable & \verb+resist_dispel+ & the new effect's resist/dispel setting. & \verb+-1+ \\
+Integer variable & \verb+duration+ & the new effect's duration. & \verb+-1+ \\
+Integer variable & \verb+probability1+ & the new effect's probability1 (the upper bound). & \verb+-1+ \\
+Integer variable & \verb+probability2+ & the new effect's probability2 (the lower bound). & \verb+-1+ \\
+Integer variable & \verb+dicenumber+ & the new effect's number of dice. This field is instead used for maximum hit-dice (HD) by some opcodes. & \verb+-1+ \\
+Integer variable & \verb+dicesize+ & the new effect's size of dice. This field is also instead for minimum hit-dice (HD) by some opcodes. & \verb+-1+ \\
+Integer variable & \verb+savingthrow+ & the new effect's saving-throw type. & \verb+-1+ \\
+Integer variable & \verb+savebonus+ & the new effect's saving-throw bonus/penalty. This variable can take negative values down to -10 while still writing to the corresponding field. & \verb+-11+ \\
+Integer variable & \verb+special+ & the new effect's special field. The special field is used by many EE effects. & \verb+-1+ \\
+String variable & \verb+resource+ & the new effect's resource reference. & \verb+SAME+ \\
+\end{weiduarguments}
+
 \\
 
 \verb+DELETE_EFFECT+: This is a patch function for creature, item, or spell files that will match an existing effect and then delete it. Numerous variables are available for matching the specified effect.
 
 The first batch of variables are meta-variables which will help determine the scope of the function:
 
-\begin{itemize}
-\item INT_VAR \verb+check_globals+ to whether the function should loop through global effects on items (also known as equipping effects) and spells (default is 1). Creature effects are all global effects, so this variable will always be considered to be one when this function is run on a creature.
-\item INT_VAR \verb+check_headers+ to whether the function should loop through effects on extended headers on items and spells (default is 1). Creatures have no extended headers, so this variable is ignored when used on creatures.
-\item INT_VAR \verb+header+ to whether the function should target effects on one specific header, counting the first header as zero. A negative value will match all headers (default is -1). Creatures have no extended headers, so this variable is ignored when used on creatures.
-\item INT_VAR \verb+header_type+ to whether the function should only delete effects on extended headers of the specified type (1 - melee, 2 - ranged, etc.). Negative values will look at effects on all headers (default is -1). Creatures have no extended headers, so this variable is ignored when used on creatures.
-\item INT_VAR \verb+multi_match+ to the number of effects to delete in the active stack. If you just want to match the first effect and have the function stop, use 1. Otherwise the function will continue matching until the number of deleted effects matches this value. The function will always make at least one change (e.g. 0 or negative values are treated as 1). (default is 999).
-\item INT_VAR \verb+verbose+ to whether the function should provide some rudimentary information on how many effects were deleted (default is 0).
-\end{itemize}
+\begin{weiduarguments}
+Integer variable & \verb+check_globals+ & whether the function should loop through global effects on items (also known as equipping effects) and spells (default is 1). Creature effects are all global effects, so this variable will always be considered to be one when this function is run on a creature. & \verb+1+ \\
+Integer variable & \verb+check_headers+ & whether the function should loop through effects on extended headers on items and spells (default is 1). Creatures have no extended headers, so this variable is ignored when used on creatures. & \verb+1+ \\
+Integer variable & \verb+header+ & whether the function should target effects on one specific header, counting the first header as zero. A negative value will match all headers (default is -1). Creatures have no extended headers, so this variable is ignored when used on creatures. & \verb+-1+ \\
+Integer variable & \verb+header_type+ & whether the function should only delete effects on extended headers of the specified type (1 - melee, 2 - ranged, etc.). Negative values will look at effects on all headers (default is -1). Creatures have no extended headers, so this variable is ignored when used on creatures. & \verb+-1+ \\
+Integer variable & \verb+multi_match+ & the number of effects to delete in the active stack. If you just want to match the first effect and have the function stop, use 1. Otherwise the function will continue matching until the number of deleted effects matches this value. The function will always make at least one change (e.g. 0 or negative values are treated as 1). (default is 999). & \verb+999+ \\
+Integer variable & \verb+verbose+ & whether the function should provide some rudimentary information on how many effects were deleted (default is 0). & \verb+0+ \\
+\end{weiduarguments}
+
 
 The next batch of variables sets the function boundaries on matching an effect to delete. Any variables not specified will not be used to determine a match. The function will only determine an effect is a match only if ALL of the variables specified are matched.
 
-\begin{itemize}
-\item INT_VAR \verb+match_opcode+ to the opcode of effects to be matched (default -1).
-\item INT_VAR \verb+match_target+ to the target of effects to be matched (default -1).
-\item INT_VAR \verb+match_power+ to the power of effects to be matched (default -1).
-\item INT_VAR \verb+match_parameter1+ to parameter1 of effects to be matched (default -1).
-\item INT_VAR \verb+match_parameter2+ to parameter2 of effects to be matched (default -1).
-\item INT_VAR \verb+match_timing+ to the timing of effects to be matched (default -1).
-\item INT_VAR \verb+match_resist_dispel+ to the resist/dispel setting of effects to be matched (default -1).
-\item INT_VAR \verb+match_duration+ to the duration of effects to be matched (default -1).
-\item INT_VAR \verb+match_probability1+ to probability1 (the upper bound) of effects to be matched (default -1).
-\item INT_VAR \verb+match_probability2+ to probability2 (the lower bound) of effects to be matched (default -1).
-\item INT_VAR \verb+match_dicenumber+ to the number of dice of effects to be matched (default -1). This field is instead used for maximum hit-dice (HD) by some opcodes.
-\item INT_VAR \verb+match_dicesize+ to the size of dice of effects to be matched (default -1). This field is used instead for minimum hit-dice (HD) by some opcodes.
-\item INT_VAR \verb+match_savingthrow+ to the saving throw type of effects to be matched (default -1).
-\item INT_VAR \verb+match_savebonus+ to the saving throw bonus effects to be matched (default -11). Since saving throws can range into negative values, this variable can match all the way down to -10.
-\item INT_VAR \verb+match_special+  to the special field of effects to be matched (default -1). The special field is used by some EE effects.
-\item STR_VAR \verb+match_resource+ to the resource of effects to be matched (default "SAME").
-\end{itemize}
+\begin{weiduarguments}
+Integer variable & \verb+match_opcode+ & the opcode of effects to be matched (default -1). & \verb+-1+ \\
+Integer variable & \verb+match_target+ & the target of effects to be matched (default -1). & \verb+-1+ \\
+Integer variable & \verb+match_power+ & the power of effects to be matched (default -1). & \verb+-1+ \\
+Integer variable & \verb+match_parameter1+ & parameter1 of effects to be matched (default -1). & \verb+-1+ \\
+Integer variable & \verb+match_parameter2+ & parameter2 of effects to be matched (default -1). & \verb+-1+ \\
+Integer variable & \verb+match_timing+ & the timing of effects to be matched (default -1). & \verb+-1+ \\
+Integer variable & \verb+match_resist_dispel+ & the resist/dispel setting of effects to be matched (default -1). & \verb+-1+ \\
+Integer variable & \verb+match_duration+ & the duration of effects to be matched (default -1). & \verb+-1+ \\
+Integer variable & \verb+match_probability1+ & probability1 (the upper bound) of effects to be matched (default -1). & \verb+-1+ \\
+Integer variable & \verb+match_probability2+ & probability2 (the lower bound) of effects to be matched (default -1). & \verb+-1+ \\
+Integer variable & \verb+match_dicenumber+ & the number of dice of effects to be matched (default -1). This field is instead used for maximum hit-dice (HD) by some opcodes. & \verb+-1+ \\
+Integer variable & \verb+match_dicesize+ & the size of dice of effects to be matched (default -1). This field is used instead for minimum hit-dice (HD) by some opcodes. & \verb+-1+ \\
+Integer variable & \verb+match_savingthrow+ & the saving throw type of effects to be matched (default -1). & \verb+-1+ \\
+Integer variable & \verb+match_savebonus+ & the saving throw bonus effects to be matched (default -11). Since saving throws can range into negative values, this variable can match all the way down to -10. & \verb+-11+ \\
+Integer variable & \verb+match_special+ & the special field of effects to be matched (default -1). The special field is used by some EE effects. & \verb+-1+ \\
+String variable & \verb+match_resource+ & the resource of effects to be matched (default "SAME"). & \verb+SAME+ \\
+\end{weiduarguments}
+
 
 Once a matching effect is found it is deleted. The function will continue to delete effects from the stack until the number of effects deleted matches the \verb+multi_match+ variable.\\
 \\
@@ -9756,36 +9836,38 @@ Once a matching effect is found it is deleted. The function will continue to del
 
 The first batch of variables are meta-variables which will help determine the scope of the function:
 
-\begin{itemize}
-\item INT_VAR \verb+check_globals+ to whether the function should loop through global effects on items (also known as equipping effects) and spells (default is 1). Creature effects are all global effects, so this variable will always be considered to be one when this function is run on a creature.
-\item INT_VAR \verb+check_headers+ to whether the function should loop through effects on extended headers on items and spells (default is 1). Creatures have no extended headers, so this variable is ignored when used on creatures.
-\item INT_VAR \verb+header+ to whether the function should target effects on one specific header, counting the first header as zero. A negative value will match all headers (default is -1). Creatures have no extended headers, so this variable is ignored when used on creatures.
-\item INT_VAR \verb+header_type+ to whether the function should only alter effects on extended headers of the specified type (1 - melee, 2 - ranged, etc.). Negative values will look at effects on all headers (default is -1). Creatures have no extended headers, so this variable is ignored when used on creatures.
-\item INT_VAR \verb+multi_match+ to the number of effects to alter in the active stack. If you just want to match the first effect and have the function stop, use 1. Otherwise the function will continue matching until the number of altered effects matches this value. The function will always make at least one change (e.g. 0 or negative values are treated as 1). (default is 999).
-\item INT_VAR \verb+verbose+ to whether the function should provide some rudimentary information on how many effects were added (default is 0).
-\item INT_VAR \verb+silent+ to whether the function should suppress warnings when no effects were altered. This option also suppresses the \t{verbose} option (default is 0).
-\end{itemize}
+\begin{weiduarguments}
+Integer variable & \verb+check_globals+ & whether the function should loop through global effects on items (also known as equipping effects) and spells (default is 1). Creature effects are all global effects, so this variable will always be considered to be one when this function is run on a creature. & \verb+1+ \\
+Integer variable & \verb+check_headers+ & whether the function should loop through effects on extended headers on items and spells (default is 1). Creatures have no extended headers, so this variable is ignored when used on creatures. & \verb+1+ \\
+Integer variable & \verb+header+ & whether the function should target effects on one specific header, counting the first header as zero. A negative value will match all headers (default is -1). Creatures have no extended headers, so this variable is ignored when used on creatures. & \verb+-1+ \\
+Integer variable & \verb+header_type+ & whether the function should only alter effects on extended headers of the specified type (1 - melee, 2 - ranged, etc.). Negative values will look at effects on all headers (default is -1). Creatures have no extended headers, so this variable is ignored when used on creatures. & \verb+-1+ \\
+Integer variable & \verb+multi_match+ & the number of effects to alter in the active stack. If you just want to match the first effect and have the function stop, use 1. Otherwise the function will continue matching until the number of altered effects matches this value. The function will always make at least one change (e.g. 0 or negative values are treated as 1). (default is 999). & \verb+999+ \\
+Integer variable & \verb+verbose+ & whether the function should provide some rudimentary information on how many effects were added (default is 0). & \verb+0+ \\
+Integer variable & \verb+silent+ & whether the function should suppress warnings when no effects were altered. This option also suppresses the \t{verbose} option (default is 0). & \verb+0+ \\
+\end{weiduarguments}
+
 
 The next batch of variables sets the function boundaries on matching an effect to alter. Any variables not specified will not be used to determine a match. The function will only determine an effect is a match only if ALL of the variables specified are matched.
 
-\begin{itemize}
-\item INT_VAR \verb+match_opcode+ to the opcode of effects to be matched (default is -1).
-\item INT_VAR \verb+match_target+ to the target of effects to be matched (default is -1).
-\item INT_VAR \verb+match_power+ to the power of effects to be matched (default is -1).
-\item INT_VAR \verb+match_parameter1+ to parameter1 of effects to be matched (default is -1).
-\item INT_VAR \verb+match_parameter2+ to parameter2 of effects to be matched (default is -1).
-\item INT_VAR \verb+match_timing+ to the timing of effects to be matched (default is -1).
-\item INT_VAR \verb+match_resist_dispel+ to the resist/dispel setting of effects to be matched (default is -1).
-\item INT_VAR \verb+match_duration+ to the duration of effects to be matched (default is -1).
-\item INT_VAR \verb+match_probability1+ to probability1 (the upper bound) of effects to be matched (default is -1).
-\item INT_VAR \verb+match_probability2+ to probability2 (the lower bound) of effects to be matched (default is -1).
-\item INT_VAR \verb+match_dicenumber+ to the number of dice of effects to be matched (default is -1). This field is instead used for maximum hit-dice (HD) by some opcodes.
-\item INT_VAR \verb+match_dicesize+ to the size of dice of effects to be matched (default is -1). This field is used instead for minimum hit-dice (HD) by some opcodes.
-\item INT_VAR \verb+match_savingthrow+ to the saving throw type of effects to be matched (default is -1).
-\item INT_VAR \verb+match_savebonus+ to the saving trow bonus effects to be matched (default is -11). Since saving throws can range into negative values, this variable can match all the way down to -10.
-\item INT_VAR \verb+match_special+ to the special field of effects to be matched (default is -1). The special field is used by some EE effects.
-\item STR_VAR \verb+match_resource+ to the resource of effects to be matched (default is "SAME").
-\end{itemize}
+\begin{weiduarguments}
+Integer variable & \verb+match_opcode+ & the opcode of effects to be matched (default is -1). & \verb+-1+ \\
+Integer variable & \verb+match_target+ & the target of effects to be matched (default is -1). & \verb+-1+ \\
+Integer variable & \verb+match_power+ & the power of effects to be matched (default is -1). & \verb+-1+ \\
+Integer variable & \verb+match_parameter1+ & parameter1 of effects to be matched (default is -1). & \verb+-1+ \\
+Integer variable & \verb+match_parameter2+ & parameter2 of effects to be matched (default is -1). & \verb+-1+ \\
+Integer variable & \verb+match_timing+ & the timing of effects to be matched (default is -1). & \verb+-1+ \\
+Integer variable & \verb+match_resist_dispel+ & the resist/dispel setting of effects to be matched (default is -1). & \verb+-1+ \\
+Integer variable & \verb+match_duration+ & the duration of effects to be matched (default is -1). & \verb+-1+ \\
+Integer variable & \verb+match_probability1+ & probability1 (the upper bound) of effects to be matched (default is -1). & \verb+-1+ \\
+Integer variable & \verb+match_probability2+ & probability2 (the lower bound) of effects to be matched (default is -1). & \verb+-1+ \\
+Integer variable & \verb+match_dicenumber+ & the number of dice of effects to be matched (default is -1). This field is instead used for maximum hit-dice (HD) by some opcodes. & \verb+-1+ \\
+Integer variable & \verb+match_dicesize+ & the size of dice of effects to be matched (default is -1). This field is used instead for minimum hit-dice (HD) by some opcodes. & \verb+-1+ \\
+Integer variable & \verb+match_savingthrow+ & the saving throw type of effects to be matched (default is -1). & \verb+-1+ \\
+Integer variable & \verb+match_savebonus+ & the saving trow bonus effects to be matched (default is -11). Since saving throws can range into negative values, this variable can match all the way down to -10. & \verb+-11+ \\
+Integer variable & \verb+match_special+ & the special field of effects to be matched (default is -1). The special field is used by some EE effects. & \verb+-1+ \\
+String variable & \verb+match_resource+ & the resource of effects to be matched (default is "SAME"). & \verb+SAME+ \\
+\end{weiduarguments}
+
 
 Once a matching effect is found, the next series of variables allows
 the function to change the fields to these new values in the matched
@@ -9794,46 +9876,49 @@ savebonus which defaults to -11. The function does not change the
 fields if the value of the corresponding value is less than or equal
 to the default value.
 
-\begin{itemize}
-\item INT_VAR \verb+opcode+ to the value the of the altered effect's opcode.
-\item INT_VAR \verb+target+ to the altered effect's target.
-\item INT_VAR \verb+power+ to the altered effect's power.
-\item INT_VAR \verb+parameter1+ to the altered effect's parameter1.
-\item INT_VAR \verb+parameter2+ to the altered effect's parameter2.
-\item INT_VAR \verb+timing+ to the altered effect's timing mode.
-\item INT_VAR \verb+resist_dispel+ to the altered effect's resist/dispel setting.
-\item INT_VAR \verb+duration+ to the altered effect's duration.
-\item INT_VAR \verb+probability1+ to the altered effect's probability1 (the upper bound).
-\item INT_VAR \verb+probability2+ to the altered effect's probability2 (the lower bound).
-\item INT_VAR \verb+dicenumber+ to the altered effect's number of dice. This field is instead used for maximum hit-dice (HD) by some opcodes.
-\item INT_VAR \verb+dicesize+ to the altered effect's size of dice. This field is also instead for minimum hit-dice (HD) by some opcodes.
-\item INT_VAR \verb+savingthrow+ to the altered effect's saving-throw type.
-\item INT_VAR \verb+savebonus+ to the altered effect's saving-throw bonus/penalty. This variable can take negative values down to -10 while still writing to the corresponding field.
-\item INT_VAR \verb+special+ to the new effect's special field. The special field is used by many EE effects.
-\item STR_VAR \verb+resource+ to the altered effect's resource reference.
-\end{itemize}
+\begin{weiduarguments}
+Integer variable & \verb+opcode+ & the value the of the altered effect's opcode. & \verb+-1+ \\
+Integer variable & \verb+target+ & the altered effect's target. & \verb+-1+ \\
+Integer variable & \verb+power+ & the altered effect's power. & \verb+-1+ \\
+Integer variable & \verb+parameter1+ & the altered effect's parameter1. & \verb+-1+ \\
+Integer variable & \verb+parameter2+ & the altered effect's parameter2. & \verb+-1+ \\
+Integer variable & \verb+timing+ & the altered effect's timing mode. & \verb+-1+ \\
+Integer variable & \verb+resist_dispel+ & the altered effect's resist/dispel setting. & \verb+-1+ \\
+Integer variable & \verb+duration+ & the altered effect's duration. & \verb+-1+ \\
+Integer variable & \verb+probability1+ & the altered effect's probability1 (the upper bound). & \verb+-1+ \\
+Integer variable & \verb+probability2+ & the altered effect's probability2 (the lower bound). & \verb+-1+ \\
+Integer variable & \verb+dicenumber+ & the altered effect's number of dice. This field is instead used for maximum hit-dice (HD) by some opcodes. & \verb+-1+ \\
+Integer variable & \verb+dicesize+ & the altered effect's size of dice. This field is also instead for minimum hit-dice (HD) by some opcodes. & \verb+-1+ \\
+Integer variable & \verb+savingthrow+ & the altered effect's saving-throw type. & \verb+-1+ \\
+Integer variable & \verb+savebonus+ & the altered effect's saving-throw bonus/penalty. This variable can take negative values down to -10 while still writing to the corresponding field. & \verb+-11+ \\
+Integer variable & \verb+special+ & the new effect's special field. The special field is used by many EE effects. & \verb+-1+ \\
+String variable & \verb+resource+ & the altered effect's resource reference. & \verb+SAME+ \\
+\end{weiduarguments}
+
 \\
 
 \verb+SUBSTRING+: returns a substring of the provided string. This is an ACTION and PATCH function. All integer variables default to 0.
 
 The function will fail with an error if either \verb+start+ or \verb+length+ are negative or if any of \verb+start+, \verb+length+ or the sum of the two is greater than the length of \verb+string+.
-\begin{itemize}
-\item INT_VAR \verb+start+ to the string index (0 based) from which the start of the substring should be read.
-\item INT_VAR \verb+length+ to the length of the substring to be read.
-\item STR_VAR \verb+string+ to the string the substring should be read from.
-\item RET \verb+substring+ the substring read from the provided string.
-\end{itemize}
+\begin{weiduarguments}
+Integer variable & \verb+start+ & the string index (0 based) from which the start of the substring should be read. & \verb+0+ \\
+Integer variable & \verb+length+ & the length of the substring to be read. & \verb+0+ \\
+String variable & \verb+string+ & the string the substring should be read from. & Empty string \\
+Return value & \verb+substring+ & the substring read from the provided string. & Not applicable \\
+\end{weiduarguments}
+
 \\
 
 \verb+ADD_CRE_SCRIPT+: assigns a script to a creature in the first available slot. This is a PATCH function. By default, the function will try all 5 script slots from \verb+SCRIPT_OVERRIDE+ to \verb+SCRIPT_DEFAULT+.
 
 The function will fail with an error if the file being patched does not have a signature (first 3 bytes) that case-sensitively equals \t{CRE}, if either \verb+offset_start+ or \verb+offset_end+ are negative, if \verb+offset_end+ is less than \verb+offset_start+ or if \verb+offset_end+ is greater than the size of the file being patched.
-\begin{itemize}
-\item INT_VAR \verb+offset_start+ to the offset from which the search for an empty slot should start. (default \verb+SCRIPT_OVERRIDE+)
-\item INT_VAR \verb+offset_end+ to the offset at which the search should end. (default \verb+SCRIPT_DEFAULT+)
-\item STR_VAR \verb+script+ to the resource reference of the script to be assigned.
-\item RET \verb+success+ a return value indicating whether the script was successfully assigned. 1 signifies success and 0 signifies that no empty slot was found. A harmless warning will be printed if the function was unsuccessful.
-\end{itemize}
+\begin{weiduarguments}
+Integer variable & \verb+offset_start+ & the offset from which the search for an empty slot should start. (default \verb+SCRIPT_OVERRIDE+) & \verb+SCRIPT_OVERRIDE+ \\
+Integer variable & \verb+offset_end+ & the offset at which the search should end. (default \verb+SCRIPT_DEFAULT+) & \verb+SCRIPT_DEFAULT+ \\
+String variable & \verb+script+ & the resource reference of the script to be assigned. & Empty string \\
+Return value & \verb+success+ & a return value indicating whether the script was successfully assigned. 1 signifies success and 0 signifies that no empty slot was found. A harmless warning will be printed if the function was unsuccessful. & Not applicable \\
+\end{weiduarguments}
+
 \\
 
 \DEFINE{\verb+HANDLE_AUDIO+}: install Ogg--Vorbis compressed audio files in a safe and easy manner. This is an ACTION function.
@@ -9846,14 +9931,15 @@ If the audio files need to be decompressed, this function will use oggdec.exe on
 
 If the decompression utility cannot be found, the user is warned that the audio files were not installed.
 
-\begin{itemize}
-\item INT_VAR \verb+music+ if this variable is not 0 and the game is BG:EE, the audio files are given the extension .acm instead of .wav. This variable has no effect if the game is not BG:EE. By default its value is 0.
-\item INT_VAR \verb+quiet+ if this variable is 1, the function will suppress output from oggdec and sox. By default this is 0.
-\item STR_VAR \verb+audio_path+ to the path your .ogg files are stored in. By default this variable is \verb+~%MOD_FOLDER%/audio~+.
-\item STR_VAR \verb+oggdec_path+ to the path oggdec is located in. By default this variable is \verb+~%audio_path%~+.
-\item STR_VAR \verb+sox_path+ to the path SoX is located in. By default this variable is \verb+~%audio_path%~+.
-\item STR_VAR \verb+output_path+ to the path the audio should be installed into. By default this variable is \t{override}.
-\end{itemize}
+\begin{weiduarguments}
+Integer variable & \verb+music+ & if this variable is not 0 and the game is BG:EE, the audio files are given the extension .acm instead of .wav. This variable has no effect if the game is not BG:EE. By default its value is 0. & \verb+0+ \\
+Integer variable & \verb+quiet+ & if this variable is 1, the function will suppress output from oggdec and sox. By default this is 0. & \verb+0+ \\
+String variable & \verb+audio_path+ & the path your .ogg files are stored in. By default this variable is \verb+~%MOD_FOLDER%/audio~+. & \verb+EVAL "%MOD_FOLDER%/audio"+ \\
+String variable & \verb+oggdec_path+ & the path oggdec is located in. By default this variable is \verb+~%audio_path%~+. & \verb+EVAL "%audio_path%"+ \\
+String variable & \verb+sox_path+ & the path SoX is located in. By default this variable is \verb+~%audio_path%~+. & \verb+EVAL "%audio_path%"+ \\
+String variable & \verb+output_path+ & the path the audio should be installed into. By default this variable is \t{override}. & \verb+override+ \\
+\end{weiduarguments}
+
 \\
 
 \DEFINE{\verb+HANDLE_TILESETS+}: install TISpack-compressed tilesets in a safe and easy manner. This is an ACTION function.
@@ -9864,11 +9950,12 @@ This function expects to find tisunpack for one or more of Windows, OS\begin{raw
 
 If tisunpack for the user's platform could not be found, the installation fails.
 
-\begin{itemize}
-\item STR_VAR \verb+tiz_path+ to the path your .tiz files are stored in. By default this variable is \verb+~%MOD_FOLDER%/tiz~+.
-\item STR_VAR \verb+tisunpack_path+ to the common directory where the subdirectories \t{win32}, \t{osx} and \t{unix} are located. By default this variable is \verb+~%tiz_path%~+.
-\item STR_VAR \verb+output_path+ to the path the tilesets should be installed into. By default this variable is \t{override}.
-\end{itemize}
+\begin{weiduarguments}
+String variable & \verb+tiz_path+ & the path your .tiz files are stored in. By default this variable is \verb+~%MOD_FOLDER%/tiz~+. & \verb+EVAL "%MOD_FOLDER%/tiz"+ \\
+String variable & \verb+tisunpack_path+ & the common directory where the subdirectories \t{win32}, \t{osx} and \t{unix} are located. By default this variable is \verb+~%tiz_path%~+. & \verb+EVAL "%tiz_path%"+ \\
+String variable & \verb+output_path+ & the path the tilesets should be installed into. By default this variable is \t{override}. & \verb+override+ \\
+\end{weiduarguments}
+
 \\
 
 \DEFINE{\verb+HANDLE_CHARSETS+}: runtime-convert \t{TRA} files to/from \t{UTF-8} in a safe and easy manner. This is an ACTION function.
@@ -9881,22 +9968,23 @@ In order to function, \verb+HANDLE_CHARSETS+ needs to know a few things. First, 
 
 Unless \verb+convert_array+ is specified, \verb+HANDLE_CHARSETS+ will recursively convert all \t{TRA} files in \verb+tra_path+ except those listed in \verb+noconvert_array+. If \verb+convert_array+ is specified, only those \t{TRA} files listed in the array will be converted. \verb+convert_array+ may contain references to \t{TRA} files in subdirectories of \verb+tra_path+.
 
-\begin{itemize}
-\item INT_VAR \verb+infer_charsets+ to whether \verb+HANDLE_CHARSETS+ should try to infer which language-dependent character set is used by the language in which the mod is being installed. It uses the contents of the \t{\%language\%} variable (\textit{vide infra}). If the contents of the variable can be recognised, \verb+HANDLE_CHARSETS+ will use the character set used by the localised version of BG2 for this language. If the contents of the variable cannot be recognised, or if the \t{TRA} files use a different character set than the expected one, \verb+HANDLE_CHARSETS+ will fail. Refer to the compatibility matrix below for additional information. \verb+infer_charsets+ overrides \verb+charset_table+. Defaults to 0.
-\item INT_VAR \verb+from_utf8+ to whether the function should assume the source \t{TRA} files are in UTF-8 or not. The default value is 0, that is, the function assumes the \t{TRA} files use language-dependent charater sets and should be converted into UTF-8 when the mod is installed on EE-type games; the function produces no results on the original editions of the games. If set to 1, the source \t{TRA} files are assumed to be in UTF-8 and are to be converted into language-dependent character sets when the mod is installed on original editions of the games; the function produces no results when installed on EE-type games.
-\item INT_VAR \verb+verbose+ to whether the function should print debug information. Defaults to 0.
-\item STR_VAR \verb+language+ to the name of the language directory you wish to convert. The default value of this variable is \t{\%LANGUAGE\%}, in other words, the directory corresponding to the language the user selected at the start of the installation. You should never need to alter the value of this variable.
-\item STR_VAR \verb+default_language+ to the name of the directory used by the default language of your mod, if your mod has one. The default language is typically one for which the translation is always complete and up to date and which you use to guard against incomplete translations. \verb+HANDLE_CHARSETS+ will convert the \t{TRA} files of the default language in addition to those of the user-selected language. Should these two languages be the same, the \t{TRA} files will only be converted once. Additionally, any \t{TRA} files listed in the \verb+reload_array+ (\textit{vide infra}) will be reloaded for the default language before they are reloaded for the user-selected language. The default value of this variable is \verb+~~+ (the empty string).
-\item STR_VAR \verb+tra_path+ to the path where your mod's language directories are located. \verb+%tra_path%/%language%+ should be a valid directory containing \t{TRA} files.
-\item STR_VAR \verb+out_path+ to the path to which the converted files should be directed. The default value of this variable is \verb+%tra_path%+, that is, the converted files reversibly overwrite the originals and the conversion is transparent to the rest of your mod. Note that if \verb+%tra_path+ and \verb+out_path+ are the same directory, the conversion will naturally happen only once regardless of how many times \verb+HANDLE_CHARSETS+ are invoked, but if the directories are different, the conversion will happen for every invocation (notably, if \verb+HANDLE_CHARSETS+ is invoked among the \ttref{ALWAYS} actions).
-\item STR_VAR \verb+iconv_path+ to the path where iconv.exe is located. Defaults to \verb+%tra_path%/iconv+.
-\item STR_VAR \verb+charset_table+ to the name of an associative array where the keys are the names of your language directories and the corresponding values are the character sets used by the respective language. The keys must be entirely in lowercase. \verb+charset_table+ is not used if you also specify \verb+infer_charsets+.
-\item STR_VAR \verb+noconvert_array+ to the name of an array indexed by monotonically increasing integers starting from 0. The values should be the names of \t{TRA} files that should not be converted into \t{UTF-8}. All \t{TRA} files in the language directory and its subdirectories except the ones listed in \verb+noconvert_array+ will be converted. The .tra file extension is optional. This variable should not be provided if you also provide \verb+convert_array+.
-\item STR_VAR \verb+convert_array+ to the name of an array indexed by monotonically increasing integers starting from 0. The values should be the names of \t{TRA} files that should be converted into \t{UTF-8}. Only those \t{TRA} files in the language directory or its subdirectories which are listed in \verb+convert_array+ will be converted. The .tra file extension is optional. If this variable is provided, \verb+noconvert_array+ will not be used.
-\item STR_VAR \verb+reload_array+ to the name of an array indexed by monotonically increasing integers starting from 0. The values should be the names of \t{TRA} files which should be reloaded after they have been converted. The .tra file extension is optional. You should use this variable for reloading those \t{TRA} files loaded by \ttref{LANGUAGE} which should also be converted.
-\item STR_VAR \verb+exclude_directories+ to the name of an array indexed by monotonically increasing integers starting from 0. The values should be the names of directories whose contents should not be converted. The directories should be subdirectories within \verb+%tra_path%/%language%+ or its subdirectories. Only the directory name itself should be specified, not its path.
-\item STR_VAR \verb+file_regexp+ to a regexp expression with the file names that must be converted. Defaults to \verb+~+\t{.+\textbackslash.tra}\verb+~+.
-\end{itemize}
+\begin{weiduarguments}
+Integer variable & \verb+infer_charsets+ & whether \verb+HANDLE_CHARSETS+ should try to infer which language-dependent character set is used by the language in which the mod is being installed. It uses the contents of the \t{\%language\%} variable (\textit{vide infra}). If the contents of the variable can be recognised, \verb+HANDLE_CHARSETS+ will use the character set used by the localised version of BG2 for this language. If the contents of the variable cannot be recognised, or if the \t{TRA} files use a different character set than the expected one, \verb+HANDLE_CHARSETS+ will fail. Refer to the compatibility matrix below for additional information. \verb+infer_charsets+ overrides \verb+charset_table+. Defaults to 0. & \verb+0+ \\
+Integer variable & \verb+from_utf8+ & whether the function should assume the source \t{TRA} files are in UTF-8 or not. The default value is 0, that is, the function assumes the \t{TRA} files use language-dependent charater sets and should be converted into UTF-8 when the mod is installed on EE-type games; the function produces no results on the original editions of the games. If set to 1, the source \t{TRA} files are assumed to be in UTF-8 and are to be converted into language-dependent character sets when the mod is installed on original editions of the games; the function produces no results when installed on EE-type games. & \verb+0+ \\
+Integer variable & \verb+verbose+ & whether the function should print debug information. Defaults to 0. & \verb+0+ \\
+String variable & \verb+language+ & the name of the language directory you wish to convert. The default value of this variable is \t{\%LANGUAGE\%}, in other words, the directory corresponding to the language the user selected at the start of the installation. You should never need to alter the value of this variable. & \verb+EVAL ~%LANGUAGE%~+ \\
+String variable & \verb+default_language+ & the name of the directory used by the default language of your mod, if your mod has one. The default language is typically one for which the translation is always complete and up to date and which you use to guard against incomplete translations. \verb+HANDLE_CHARSETS+ will convert the \t{TRA} files of the default language in addition to those of the user-selected language. Should these two languages be the same, the \t{TRA} files will only be converted once. Additionally, any \t{TRA} files listed in the \verb+reload_array+ (\textit{vide infra}) will be reloaded for the default language before they are reloaded for the user-selected language. The default value of this variable is \verb+~~+ (the empty string). & Empty string \\
+String variable & \verb+tra_path+ & the path where your mod's language directories are located. \verb+%tra_path%/%language%+ should be a valid directory containing \t{TRA} files. & Empty string \\
+String variable & \verb+out_path+ & the path to which the converted files should be directed. The default value of this variable is \verb+%tra_path%+, that is, the converted files reversibly overwrite the originals and the conversion is transparent to the rest of your mod. Note that if \verb+%tra_path+ and \verb+out_path+ are the same directory, the conversion will naturally happen only once regardless of how many times \verb+HANDLE_CHARSETS+ are invoked, but if the directories are different, the conversion will happen for every invocation (notably, if \verb+HANDLE_CHARSETS+ is invoked among the \ttref{ALWAYS} actions). & \verb+EVAL ~%tra_path%~+ \\
+String variable & \verb+iconv_path+ & the path where iconv.exe is located. Defaults to \verb+%tra_path%/iconv+. & \verb+EVAL ~%tra_path%/iconv~+ \\
+String variable & \verb+charset_table+ & the name of an associative array where the keys are the names of your language directories and the corresponding values are the character sets used by the respective language. The keys must be entirely in lowercase. \verb+charset_table+ is not used if you also specify \verb+infer_charsets+. & Empty string \\
+String variable & \verb+noconvert_array+ & the name of an array indexed by monotonically increasing integers starting from 0. The values should be the names of \t{TRA} files that should not be converted into \t{UTF-8}. All \t{TRA} files in the language directory and its subdirectories except the ones listed in \verb+noconvert_array+ will be converted. The .tra file extension is optional. This variable should not be provided if you also provide \verb+convert_array+. & Empty string \\
+String variable & \verb+convert_array+ & the name of an array indexed by monotonically increasing integers starting from 0. The values should be the names of \t{TRA} files that should be converted into \t{UTF-8}. Only those \t{TRA} files in the language directory or its subdirectories which are listed in \verb+convert_array+ will be converted. The .tra file extension is optional. If this variable is provided, \verb+noconvert_array+ will not be used. & Empty string \\
+String variable & \verb+reload_array+ & the name of an array indexed by monotonically increasing integers starting from 0. The values should be the names of \t{TRA} files which should be reloaded after they have been converted. The .tra file extension is optional. You should use this variable for reloading those \t{TRA} files loaded by \ttref{LANGUAGE} which should also be converted. & Empty string \\
+String variable & \verb+exclude_directories+ & the name of an array indexed by monotonically increasing integers starting from 0. The values should be the names of directories whose contents should not be converted. The directories should be subdirectories within \verb+%tra_path%/%language%+ or its subdirectories. Only the directory name itself should be specified, not its path. & \emph{Not specified} \\
+String variable & \verb+file_regexp+ & a regexp expression with the file names that must be converted. Defaults to \verb+~+\t{.+\textbackslash.tra}\verb+~+. & \verb|.+\.tra$| \\
+\end{weiduarguments}
+
 
 Compatibility matrix for \verb+infer_charsets+.
 \begin{tabular} {l c r}
@@ -9923,43 +10011,46 @@ Spanish & spanish, castilian, espanol, castellano, es_ES & CP1252 \\
 
 This function will delete links from one specified area to another. Links can be deleted from all four directional nodes (north, east, south, west) or from a specific node. Links connecting the areas in the opposite direction will not be deleted.
 
-\begin{itemize}
-\item STR_VAR \verb+from_area+ to the area from which the links that are to be deleted originate.
-\item STR_VAR \verb+from_node+ to the directional node from which the links that are to be deleted originate. Legal values for this variable are ``north'', ``n'', ``east'', ``e'', ``south'', ``s'', ``west'', ``w''. Values are not case sensitive. Links are deleted from all four nodes by default.
-\item STR_VAR \verb+to_area+ to the area to which the links that are to be deleted lead.
-\end{itemize}
+\begin{weiduarguments}
+String variable & \verb+from_area+ & the area from which the links that are to be deleted originate. & Empty string \\
+String variable & \verb+from_node+ & the directional node from which the links that are to be deleted originate. Legal values for this variable are ``north'', ``n'', ``east'', ``e'', ``south'', ``s'', ``west'', ``w''. Values are not case sensitive. Links are deleted from all four nodes by default. & Empty string \\
+String variable & \verb+to_area+ & the area to which the links that are to be deleted lead. & Empty string \\
+\end{weiduarguments}
+
 \\
 
 \DEFINE{\verb+ADD_WORLDMAP_LINKS+}: add links from one worldmap area to another. This is a PATCH function.
 
 This function add links from one specified area to another. Links can be added from all four directional nodes (north, east, south, west) or from a specific node. If a link already exists, its metadata (distance scale, random encounters, etc.) will be overwritten. Links connecting the areas in the opposite direction will not be added. If either of the areas do not exist in the worldmap, a warning is printed and no links are added.
 
-\begin{itemize}
-\item INT_VAR \verb+distance_scale+ to the distance scale between the two areas. \verb+distance_scale+ * 4 equals the travel time between the areas (in hours).
-\item INT_VAR \verb+default_entry+ to the default entry location. Legal values for this variable are 1 (northern side), 2 (eastern), 4 (southern) and 8 (western). The default value is 1.
-\item INT_VAR \verb+encounter_probability+ to the probability of a random encounter occurring.
-\item STR_VAR \verb+from_area+ to the area from which the links should originate.
-\item STR_VAR \verb+from_node+ to the directional node from which the links should originate. Legal values for this variable are ``north'', ``n'', ``east'', ``e'', ``south'', ``s'', ``west'' and ``w''. Values are not case sensitive. Links are added to all four nodes by default.
-\item STR_VAR \verb+to_area+ to the area to which the links should lead.
-\item STR_VAR \verb+entry+ to the entry point in \verb+to_area+.
-\item STR_VAR \verb+random_area1+ to the first random-encounter area.
-\item STR_VAR \verb+random_area2+ to the second random-encounter area.
-\item STR_VAR \verb+random_area3+ to the third random-encounter area.
-\item STR_VAR \verb+random_area4+ to the fourth random-encounter area.
-\item STR_VAR \verb+random_area5+ to the fifth random-encounter area.
-\end{itemize}
+\begin{weiduarguments}
+Integer variable & \verb+distance_scale+ & the distance scale between the two areas. \verb+distance_scale+ * 4 equals the travel time between the areas (in hours). & \verb+0+ \\
+Integer variable & \verb+default_entry+ & the default entry location. Legal values for this variable are 1 (northern side), 2 (eastern), 4 (southern) and 8 (western). The default value is 1. & \verb+1+ \\
+Integer variable & \verb+encounter_probability+ & the probability of a random encounter occurring. & \verb+0+ \\
+String variable & \verb+from_area+ & the area from which the links should originate. & Empty string \\
+String variable & \verb+from_node+ & the directional node from which the links should originate. Legal values for this variable are ``north'', ``n'', ``east'', ``e'', ``south'', ``s'', ``west'' and ``w''. Values are not case sensitive. Links are added to all four nodes by default. & Empty string \\
+String variable & \verb+to_area+ & the area to which the links should lead. & Empty string \\
+String variable & \verb+entry+ & the entry point in \verb+to_area+. & Empty string \\
+String variable & \verb+random_area1+ & the first random-encounter area. & Empty string \\
+String variable & \verb+random_area2+ & the second random-encounter area. & Empty string \\
+String variable & \verb+random_area3+ & the third random-encounter area. & Empty string \\
+String variable & \verb+random_area4+ & the fourth random-encounter area. & Empty string \\
+String variable & \verb+random_area5+ & the fifth random-encounter area. & Empty string \\
+\end{weiduarguments}
+
 \\
 
 \DEFINE{\verb+UPDATE_PVRZ_INDICES+}: update the \t{PVRZ} references in a \t{BAM V2} or \t{MOS V2} resource. This is a PATCH function.
 
 This function will update the \t{PVRZ} references in a \t{BAM V2} or \t{MOS V2} resource with the next contiguous block of free \t{PVRZ} indices. This function is intended to be used in combination with the action function \ttref{INSTALL_PVRZ}.
 
-\begin{itemize}
-\item INT_VAR \verb+target_base_index+ is an optional parameter. When specified, the function attempts to use a block of free \t{PVRZ} indices starting at the specified value. The default value is 1000.
-\item RET \verb+original_base_index+ returns the lowest \t{PVRZ} index used by the source \t{BAM} or \t{MOS}. Returns -1 on error.
-\item RET \verb+new_base_index+ returns the lowest \t{PVRZ} index used by the target \t{BAM} or \t{MOS}. Returns -1 on error.
-\item RET \verb+index_range+ returns the range of reserved \t{PVRZ} indices, i.e., the difference between the smallest and biggest \t{PVRZ} index, inclusive. Returns 0 on error.
-\end{itemize}
+\begin{weiduarguments}
+Integer variable & \verb+target_base_index+ & an optional parameter. When specified, the function attempts to use a block of free \t{PVRZ} indices starting at the specified value. The default value is 1000. & \verb+1000+ \\
+Return value & \verb+original_base_index+ & the lowest \t{PVRZ} index used by the source \t{BAM} or \t{MOS}. Returns -1 on error. & Not applicable \\
+Return value & \verb+new_base_index+ & the lowest \t{PVRZ} index used by the target \t{BAM} or \t{MOS}. Returns -1 on error. & Not applicable \\
+Return value & \verb+index_range+ & the range of reserved \t{PVRZ} indices, i.e., the difference between the smallest and biggest \t{PVRZ} index, inclusive. Returns 0 on error. & Not applicable \\
+\end{weiduarguments}
+
 \\
 
 \DEFINE{\verb+INSTALL_PVRZ+}: install a \t{PVRZ} file and updates the \t{PVRZ} index. This is an ACTION function.
@@ -9980,454 +10071,427 @@ This function copies the specified \t{PVRZ} file into the target folder and upda
 
 This function attempts to find the first available free \t{PVRZ} index of a contiguous block which guarantees to fit at least \verb+num_to_reserve+ indices.
 
-\begin{itemize}
-\item INT_VAR \verb+num_to_reserve+ to the minimum required size of the contiguous block of free indices. This number should be no smaller than 1 nor no bigger than 999. The default value is 1.
-\item INT_VAR \verb+start_index+ to the index the search should begin at. The default value is 1000.
-\item RET \verb+free_index+ returns the first available index matching the specified parameters. Returns -1 on errors.
-\end{itemize}
+\begin{weiduarguments}
+Integer variable & \verb+num_to_reserve+ & the minimum required size of the contiguous block of free indices. This number should be no smaller than 1 nor no bigger than 999. The default value is 1. & \verb+1+ \\
+Integer variable & \verb+start_index+ & the index the search should begin at. The default value is 1000. & \verb+1000+ \\
+Return value & \verb+free_index+ & the first available index matching the specified parameters. Returns -1 on errors. & Not applicable \\
+\end{weiduarguments}
+
 \\
 
 \DEFINE{\verb+DIRECTORY_OF_FILESPEC+}: returns the directory of a file specification. Compare to \ttref{SOURCE_DIRECTORY}. This is an ACTION and PATCH function.
 
-\begin{itemize}
-\item STR_VAR \verb+filespec+ to the file specification, which must include an identifiable directory, or a warning will be raised.
-\item RET \verb+directory+ returns the directory of the file specification.
-\end{itemize}
+\begin{weiduarguments}
+String variable & \verb+filespec+ & the file specification, which must include an identifiable directory, or a warning will be raised. & Empty string \\
+Return value & \verb+directory+ & the directory of the file specification. & Not applicable \\
+\end{weiduarguments}
+
 
 \DEFINE{\verb+FILE_OF_FILESPEC+}: returns the file of a file specification. Compare to \ttref{SOURCE_FILE}. This is an ACTION and PATCH function.
 
-\begin{itemize}
-\item STR_VAR \verb+filespec+ to the file specification, which may or may not include a directory.
-\item RET \verb+file+ returns the file of the file specification.
-\end{itemize}
+\begin{weiduarguments}
+String variable & \verb+filespec+ & the file specification, which may or may not include a directory. & Empty string \\
+Return value & \verb+file+ & the file of the file specification. & Not applicable \\
+\end{weiduarguments}
+
 
 \DEFINE{\verb+RES_OF_FILESPEC+}: returns the resource name of a file specification. Compare to \ttref{SOURCE_RES}. This is an ACTION and PATCH function.
 
-\begin{itemize}
-\item STR_VAR \verb+filespec+ to the file specification, which must include an identifiable resource name, or a warning will be raised.
-\item RET \verb+res+ returns the resource name of the file specification.
-\end{itemize}
+\begin{weiduarguments}
+String variable & \verb+filespec+ & the file specification, which must include an identifiable resource name, or a warning will be raised. & Empty string \\
+Return value & \verb+res+ & the resource name of the file specification. & Not applicable \\
+\end{weiduarguments}
+
 
 \DEFINE{\verb+EXT_OF_FILESPEC+}: returns the resource extension of a file specification. Compare to \ttref{SOURCE_EXT}. This is an ACTION and PATCH function.
 
-\begin{itemize}
-\item STR_VAR \verb+filespec+ to the file specification, which must include an identifiable resource extension, or a warning will be raised.
-\item RET \verb+ext+ returns the resource extension of the file specification.
-\end{itemize}
+\begin{weiduarguments}
+String variable & \verb+filespec+ & the file specification, which must include an identifiable resource extension, or a warning will be raised. & Empty string \\
+Return value & \verb+ext+ & the resource extension of the file specification. & Not applicable \\
+\end{weiduarguments}
+
 \\
 
 \subsection{Store-related functions}
 
 \DEFINE{\verb+ADD_STORE_ITEM_EX+}: adds an item to the current STO file. This is a PATCH function.
 
-\begin{itemize}
-\item INT_VAR \verb+charge1+ to the number of charges of the 1st ability or quantity for stackables. (Default: 0)
-\item INT_VAR \verb+charge2+ to the number of charges of the 2nd ability. (Default: 0)
-\item INT_VAR \verb+charge3+ to the number of charges of the 3rd ability. (Default: 0)
-\item INT_VAR \verb+stack+ to the number of item instances the store carries in the stack. (Default: 1)
-\item INT_VAR \verb+unlimited+ to non-zero if the store should carry an inexhaustible stack of the new item. (Default: 0)
-\item INT_VAR \verb+overwrite+ to non-zero to overwrite any instances of an existing sale entry of matching item resref when found. (Default: 0)
-\item INT_VAR \verb+expiration+ to the item's expiration time, when it will be replaced with the drained item. (Default: 0)
-\item STR_VAR \verb+item_name+ to the resource name (resref) of the item to add.
-\item STR_VAR \verb+position+ to the desired position of the item in the list of sale entries. The following syntax is supported:
-\begin{verbatim}
-AFTER resref    Will place the new item directly behind the item given by "resref".
-                You can list more than one resref, separated by space. The new item will be
-                added after the entry of the first matching resref.
-BEFORE resref   Will place the new item directly before the item given by "resref".
-                You can list more than one resref, separated by space. The new item will be
-                added before the entry of the first matching resref.
-LAST            Will place the new item after all existing items.
-FIRST           Will place the new item before all existing items.
-AT value        Will place the new item at the position given by the number "value".
-                Use negative values to place the new item relative to the last item position
-                in reverse order.
-\end{verbatim}
-(Default: FIRST)
-\item STR_VAR \verb+flags+ to numeric values or the following constants: \verb+none+, \verb+identified+, \verb+unstealable+, \verb+stolen+. Constants can be combined by using ampersand (\&) or space as separators (e.g. \verb+identified&unstealable+). (Default: \verb+none+)
-\item STR_VAR \verb+sale_trigger+ Availability trigger (STO V1.1 only). The following syntax is supported:
-\begin{verbatim}
-Trigger string          Example: GlobalGT("MyCondition","GLOBAL",0)
-Strref value            Example: #1234
-Translation reference   Example: @1000
-\end{verbatim}
-(Default: #-1)
-\item RET \verb+index+ returns the index of the added item or the last matching index when overwriting items. Returns -1 if the item could not be added or updated.
-\item RET \verb+offset+ returns the offset of the added item or the last matching offset when overwriting items. Returns -1 if the item could not be added or updated.
-\end{itemize}
+\begin{weiduarguments}
+Integer variable & \verb+charge1+ & the number of charges of the 1st ability or quantity for stackables. (Default: 0) & \verb+0+ \\
+Integer variable & \verb+charge2+ & the number of charges of the 2nd ability. (Default: 0) & \verb+0+ \\
+Integer variable & \verb+charge3+ & the number of charges of the 3rd ability. (Default: 0) & \verb+0+ \\
+Integer variable & \verb+stack+ & the number of item instances the store carries in the stack. (Default: 1) & \verb+1+ \\
+Integer variable & \verb+unlimited+ & non-zero if the store should carry an inexhaustible stack of the new item. (Default: 0) & \verb+0+ \\
+Integer variable & \verb+overwrite+ & non-zero to overwrite any instances of an existing sale entry of matching item resref when found. (Default: 0) & \verb+0+ \\
+Integer variable & \verb+expiration+ & the item's expiration time, when it will be replaced with the drained item. (Default: 0) & \verb+0+ \\
+String variable & \verb+item_name+ & the resource name (resref) of the item to add. & Empty string \\
+String variable & \verb+position+ & the desired position of the item in the list of sale entries. The following syntax is supported: \begin{verbatim} AFTER resref    Will place the new item directly behind the item given by "resref". You can list more than one resref, separated by space. The new item will be added after the entry of the first matching resref. BEFORE resref   Will place the new item directly before the item given by "resref". You can list more than one resref, separated by space. The new item will be added before the entry of the first matching resref. LAST            Will place the new item after all existing items. FIRST           Will place the new item before all existing items. AT value        Will place the new item at the position given by the number "value". Use negative values to place the new item relative to the last item position in reverse order. \end{verbatim} (Default: FIRST) & \verb+FIRST+ \\
+String variable & \verb+flags+ & numeric values or the following constants: \verb+none+, \verb+identified+, \verb+unstealable+, \verb+stolen+. Constants can be combined by using ampersand (\&) or space as separators (e.g. \verb+identified&unstealable+). (Default: \verb+none+) & \verb+none+ \\
+String variable & \verb+sale_trigger+ & Availability trigger (STO V1.1 only). The following syntax is supported: \begin{verbatim} Trigger string          Example: GlobalGT("MyCondition","GLOBAL",0) Strref value            Example: #1234 Translation reference   Example: @1000 \end{verbatim} (Default: #-1) & \verb+#-1+ \\
+Return value & \verb+index+ & the index of the added item or the last matching index when overwriting items. Returns -1 if the item could not be added or updated. & Not applicable \\
+Return value & \verb+offset+ & the offset of the added item or the last matching offset when overwriting items. Returns -1 if the item could not be added or updated. & Not applicable \\
+\end{weiduarguments}
+
 
 \DEFINE{\verb+ADD_STORE_DRINK+}: adds a drink to the current STO file. This is a PATCH function.
 
-\begin{itemize}
-\item INT_VAR \verb+price+ to the price of the drink.
-\item INT_VAR \verb+rate+ to the rate (\%) of displaying a rumor.
-\item INT_VAR \verb+overwrite+ to non-zero to overwrite any instances of an existing drink of matching \verb+drink_name+ when found. (Default: 0)
-\item STR_VAR \verb+drink_name+ to the name of the drink.
-The following syntax is supported:
-\begin{verbatim}
-Literal string          Example: Elminster's Choice Beer
-Strref value            Example: #1234
-Translation reference   Example: @1000
-\end{verbatim}
-\item STR_VAR \verb+position+ to the desired position in the list of drinks. Refer to the table below for supported expressions. The following syntax is supported:
-\begin{verbatim}
-AFTER name      Will place the new drink directly behind the drink given by "name". Name can
-                either be a strref value (e.g. #1234) or a translation reference (e.g. @1000).
-                You can list more than one name, separated by space. The new drink will be
-                added after the entry of the first matching name.
-BEFORE name     Will place the new drink directly before the drink given by "name". Name can
-                either be a strref value (e.g. #1234) or a translation reference (e.g. @1000).
-                You can list more than one name, separated by space. The new drink will be
-                added before the entry of the first matching name.
-LAST            Will place the new drink after all existing drinks.
-FIRST           Will place the new drink before all existing drinks.
-AT value        Will place the new drink at the position given by the number "value".
-                Use negative values to place the new drink relative to the last drink position
-                in reverse order.
-\end{verbatim}
-(Default: FIRST)
-\item RET \verb+index+ returns the index of the added drink or the last matching index when overwriting drinks. Returns -1 if the drink could not be added or updated.
-\item RET \verb+offset+ returns the offset of the added drink or the last matching offset when overwriting drinks. Returns -1 if the drink could not be added or updated.
-\end{itemize}
+\begin{weiduarguments}
+Integer variable & \verb+price+ & the price of the drink. & \verb+0+ \\
+Integer variable & \verb+rate+ & the rate (\%) of displaying a rumor. & \verb+0+ \\
+Integer variable & \verb+overwrite+ & non-zero to overwrite any instances of an existing drink of matching \verb+drink_name+ when found. (Default: 0) & \verb+0+ \\
+String variable & \verb+drink_name+ & the name of the drink. The following syntax is supported: \begin{verbatim} Literal string          Example: Elminster's Choice Beer Strref value            Example: #1234 Translation reference   Example: @1000 \end{verbatim} & Empty string \\
+String variable & \verb+position+ & the desired position in the list of drinks. Refer to the table below for supported expressions. The following syntax is supported: \begin{verbatim} AFTER name      Will place the new drink directly behind the drink given by "name". Name can either be a strref value (e.g. #1234) or a translation reference (e.g. @1000). You can list more than one name, separated by space. The new drink will be added after the entry of the first matching name. BEFORE name     Will place the new drink directly before the drink given by "name". Name can either be a strref value (e.g. #1234) or a translation reference (e.g. @1000). You can list more than one name, separated by space. The new drink will be added before the entry of the first matching name. LAST            Will place the new drink after all existing drinks. FIRST           Will place the new drink before all existing drinks. AT value        Will place the new drink at the position given by the number "value". Use negative values to place the new drink relative to the last drink position in reverse order. \end{verbatim} (Default: FIRST) & \verb+FIRST+ \\
+Return value & \verb+index+ & the index of the added drink or the last matching index when overwriting drinks. Returns -1 if the drink could not be added or updated. & Not applicable \\
+Return value & \verb+offset+ & the offset of the added drink or the last matching offset when overwriting drinks. Returns -1 if the drink could not be added or updated. & Not applicable \\
+\end{weiduarguments}
+
 
 \DEFINE{\verb+ADD_STORE_CURE+}: adds a cure to the current STO file. This is a PATCH function.
 
-\begin{itemize}
-\item INT_VAR \verb+price+ to the spell price.
-\item INT_VAR \verb+overwrite+ to non-zero to overwrite any instances of an existing cure entry of matching spell resref when found. (Default: 0)
-\item STR_VAR \verb+spell_name+ to the resource name (resref) of the spell to add.
-\item STR_VAR \verb+position+ to the desired position in the list of cures. Refer to the table below for supported expressions. The following syntax is supported:
-\begin{verbatim}
-AFTER resref    Will place the new spell directly behind the spell given by "resref".
-                You can list more than one resref, separated by space. The new spell will be
-                added after the entry of the first matching resref.
-BEFORE resref   Will place the new spell directly before the spell given by "resref".
-                You can list more than one resref, separated by space. The new spell will be
-                added before the entry of the first matching resref.
-LAST            Will place the new spell after all existing cures.
-FIRST           Will place the new spell before all existing cures.
-AT value        Will place the new spell at the position given by the number "value".
-                Use negative values to place the new spell relative to the last spell position
-                in reverse order.
-\end{verbatim}
-(Default: FIRST)
-\item RET \verb+index+ returns the index of the added cure or the last matching index when overwriting cure entries. Returns -1 if the spell could not be added or updated.
-\item RET \verb+offset+ returns the offset of the added cure or the last matching offset when overwriting cures. Returns -1 if the spell could not be added or updated.
-\end{itemize}
+\begin{weiduarguments}
+Integer variable & \verb+price+ & the spell price. & \verb+0+ \\
+Integer variable & \verb+overwrite+ & non-zero to overwrite any instances of an existing cure entry of matching spell resref when found. (Default: 0) & \verb+0+ \\
+String variable & \verb+spell_name+ & the resource name (resref) of the spell to add. & Empty string \\
+String variable & \verb+position+ & the desired position in the list of cures. Refer to the table below for supported expressions. The following syntax is supported: \begin{verbatim} AFTER resref    Will place the new spell directly behind the spell given by "resref". You can list more than one resref, separated by space. The new spell will be added after the entry of the first matching resref. BEFORE resref   Will place the new spell directly before the spell given by "resref". You can list more than one resref, separated by space. The new spell will be added before the entry of the first matching resref. LAST            Will place the new spell after all existing cures. FIRST           Will place the new spell before all existing cures. AT value        Will place the new spell at the position given by the number "value". Use negative values to place the new spell relative to the last spell position in reverse order. \end{verbatim} (Default: FIRST) & \verb+FIRST+ \\
+Return value & \verb+index+ & the index of the added cure or the last matching index when overwriting cure entries. Returns -1 if the spell could not be added or updated. & Not applicable \\
+Return value & \verb+offset+ & the offset of the added cure or the last matching offset when overwriting cures. Returns -1 if the spell could not be added or updated. & Not applicable \\
+\end{weiduarguments}
+
 
 \DEFINE{\verb+ADD_STORE_PURCHASE+}: adds one or more item categories the store will buy to the current STO file. Existing categories will be skipped.
-\begin{itemize}
-\item INT_VAR \verb+category+ to the item category to add. A nearly complete list of supported item category codes can be found \ahref{\url{https://gibberlings3.github.io/iesdp/file_formats/ie_formats/sto_v1.htm#tableItemType}}{here}.
-\item RET \verb+index+ returns the index of the added purchase. Returns -1 if the purchase could not be added.
-\item RET \verb+offset+ returns the offset of the added purchase. Returns -1 if the purchase could not be added.
-\end{itemize}
+\begin{weiduarguments}
+Integer variable & \verb+category+ & the item category to add. A nearly complete list of supported item category codes can be found \ahref{\url{https://gibberlings3.github.io/iesdp/file_formats/ie_formats/sto_v1.htm#tableItemType}}{here}. & \verb+-1+ \\
+Return value & \verb+index+ & the index of the added purchase. Returns -1 if the purchase could not be added. & Not applicable \\
+Return value & \verb+offset+ & the offset of the added purchase. Returns -1 if the purchase could not be added. & Not applicable \\
+\end{weiduarguments}
+
 
 \DEFINE{\verb+REMOVE_STORE_ITEM_EX+}: removes all sale instances matching the specified item name from the current STO file. This is a patch function.
-\begin{itemize}
-\item STR_VAR \verb+item_name+ to the resource name (resref) of the item to remove. Regular expression syntax is supported.
-\item RET \verb+index+ returns the index of the first removed entry matching the item name, returns -1 otherwise.
-\item RET \verb+offset+ returns the offset of the first removed entry matching the item name, returns -1 otherwise.
-\end{itemize}
+\begin{weiduarguments}
+String variable & \verb+item_name+ & the resource name (resref) of the item to remove. Regular expression syntax is supported. & Empty string \\
+Return value & \verb+index+ & the index of the first removed entry matching the item name, returns -1 otherwise. & Not applicable \\
+Return value & \verb+offset+ & the offset of the first removed entry matching the item name, returns -1 otherwise. & Not applicable \\
+\end{weiduarguments}
+
 
 \DEFINE{\verb+REMOVE_STORE_DRINK+}: removes all drink instances matching the specified drink name from the current STO file. This is a patch function.
-\begin{itemize}
-\item STR_VAR \verb+drink_name+ to the name of the drink to remove. The following syntax is supported:
-\begin{verbatim}
-Literal string          Example: Elminster's Choice Beer
-Strref value            Example: #1234
-Translation reference   Example: @1000
-\end{verbatim}
-Note: Regular expression syntax is supported for literal strings.
-\item RET \verb+index+ returns the index of the first removed entry matching the drink name, returns -1 otherwise.
-\item RET \verb+offset+ returns the offset of the first removed entry matching the drink name, returns -1 otherwise.
-\end{itemize}
+\begin{weiduarguments}
+String variable & \verb+drink_name+ & the name of the drink to remove. The following syntax is supported: \begin{verbatim} Literal string          Example: Elminster's Choice Beer Strref value            Example: #1234 Translation reference   Example: @1000 \end{verbatim} Note: Regular expression syntax is supported for literal strings. & Empty string \\
+Return value & \verb+index+ & the index of the first removed entry matching the drink name, returns -1 otherwise. & Not applicable \\
+Return value & \verb+offset+ & the offset of the first removed entry matching the drink name, returns -1 otherwise. & Not applicable \\
+\end{weiduarguments}
+
 
 \DEFINE{\verb+REMOVE_STORE_CURE+}: removes all cure instances matching the specified spell name from the current STO file. This is a patch function.
-\begin{itemize}
-\item STR_VAR \verb+spell_name+ to the resource name (resref) of the spell to remove. Regular expression syntax is supported.
-\item RET \verb+index+ returns the index of the first removed entry matching the spell name, returns -1 otherwise.
-\item RET \verb+offset+ returns the offset of the first removed entry matching the spell name, returns -1 otherwise.
-\end{itemize}
+\begin{weiduarguments}
+String variable & \verb+spell_name+ & the resource name (resref) of the spell to remove. Regular expression syntax is supported. & Empty string \\
+Return value & \verb+index+ & the index of the first removed entry matching the spell name, returns -1 otherwise. & Not applicable \\
+Return value & \verb+offset+ & the offset of the first removed entry matching the spell name, returns -1 otherwise. & Not applicable \\
+\end{weiduarguments}
+
 
 \DEFINE{\verb+REMOVE_STORE_PURCHASE+}: removes the specified item category from the current STO file. This is a patch function.
-\begin{itemize}
-\item INT_VAR \verb+category+ to the item category to remove. A nearly complete list of supported item category codes can be found \ahref{\url{https://gibberlings3.github.io/iesdp/file_formats/ie_formats/sto_v1.htm#tableItemType}}{here}.
-\item RET \verb+index+ returns the index of the first removed entry matching the category, returns -1 otherwise.
-\item RET \verb+offset+ returns the offset of the first removed entry matching the category, returns -1 otherwise.
-\end{itemize}
+\begin{weiduarguments}
+Integer variable & \verb+category+ & the item category to remove. A nearly complete list of supported item category codes can be found \ahref{\url{https://gibberlings3.github.io/iesdp/file_formats/ie_formats/sto_v1.htm#tableItemType}}{here}. & \verb+-1+ \\
+Return value & \verb+index+ & the index of the first removed entry matching the category, returns -1 otherwise. & Not applicable \\
+Return value & \verb+offset+ & the offset of the first removed entry matching the category, returns -1 otherwise. & Not applicable \\
+\end{weiduarguments}
+
 
 \subsection{\DEFINE{fj_are_structure}}
-Adds a structure to an area file. All variables are zero or blank by default unless otherwise indicated. Fields designated by an asterisk are typically required; all others are optional.
+Adds a structure to an area file. All formal arguments are zero or blank by
+default unless otherwise indicated. Fields designated by an asterisk are
+typically required; all others are optional. The dynamically numbered
+\verb+fj_vertex_+, \verb+fj_door_open_vert_+,
+\verb+fj_door_closed_vert_+, \verb+fj_cell_open_vert_+,
+\verb+fj_cell_closed_vert_+ and \verb+fj_embedded_eff_+ series are not formal
+arguments. Define each required series contiguously from index 0 in caller
+scope before launching the function. \ttref{PATCH_WITH_SCOPE} can keep these
+temporary variables from leaking into subsequent patches.
 This is a PATCH function.
 
 Universal structure variables:
-\begin{itemize}
-\item STR_VAR \verb+fj_structure_type+ to the type of area structure to be added (actor, region, spawn, entrance, container, itm, ambient, variable, door, animation, bitmask, songs, interrupts, note or projectile)*;
-\item INT_VAR \verb+fj_delete_mode+ to the index of the structure to be deleted (if deleting rather than adding a new structure);
-\item INT_VAR \verb+fj_debug+ to 1 to enable feedback
-\item RET \verb+fj_return_offset+ returns the position of the structure in the area file;
-\end{itemize}
+\begin{weiduarguments}
+String variable & \verb+fj_structure_type+ & the type of area structure to be added (actor, region, spawn, entrance, container, itm, ambient, variable, door, animation, bitmask, songs, interrupts, note or projectile)*; & Empty string \\
+Integer variable & \verb+fj_delete_mode+ & the index of the structure to be deleted (if deleting rather than adding a new structure); & \verb+-1+ \\
+Integer variable & \verb+fj_debug+ & 1 to enable feedback & \verb+0+ \\
+Return value & \verb+fj_return_offset+ & the position of the structure in the area file; & Not applicable \\
+\end{weiduarguments}
+
 Actor structure variables:
-\begin{itemize}
-\item STR_VAR \verb+fj_name+ to the actor's name*;
-\item INT_VAR \verb+fj_loc_x+ to the starting X (horizontal) coordinate*;
-\item INT_VAR \verb+fj_loc_y+ to the starting Y (vertical) coordinate*;
-\item INT_VAR \verb+fj_dest_x+ to the destination X coordinate (by default the same as \verb+fj_loc_x+);
-\item INT_VAR \verb+fj_dest_y+ to the destination Y coordinate (by default the same as \verb+fj_loc_y+);
-\item INT_VAR \verb+fj_loading+ to whether the .cre file is loaded (0=attached, 1=loaded, default 1);
-\item INT_VAR \verb+fj_spawned+ to whether the creature has been spawned (0=no, 1=yes, default 0);
-\item INT_VAR \verb+fj_animation+ to the actor's animation number (from animate.ids, though the engine uses the animation set on the .cre file);
-\item INT_VAR \verb+fj_orientation+ to the facing direction (0-15 where 0=south, 4=west, 8=north, 12=east, default 0);
-\item INT_VAR \verb+fj_expiry+ to the actor removal timer in absolute ticks (default -1 to avoid removal);
-\item INT_VAR \verb+fj_wander_dist_actor+ to the actor's random walk distance limit;
-\item INT_VAR \verb+fj_mvmt_dist_actor+ to the actor's movement distance limit;
-\item INT_VAR \verb+fj_schedule+ to the hourly appearance schedule (bits 0-23, default -1 or always);
-\item INT_VAR \verb+fj_num_talked+ to the NumTimesTalkedTo (in .sav files);
-\item STR_VAR \verb+fj_dlg_resref+ to the actor's dialogue file (normally obtained from .cre files);
-\item STR_VAR \verb+fj_bcs_override+ to the actor's override script (normally obtained from .cre files);
-\item STR_VAR \verb+fj_bcs_general+ to the actor's general script (normally obtained from .cre files);
-\item STR_VAR \verb+fj_bcs_class+ to the actor's class script (normally obtained from .cre files);
-\item STR_VAR \verb+fj_bcs_race+ to the actor's race script (normally obtained from .cre files);
-\item STR_VAR \verb+fj_bcs_default+ to the actor's default script (normally obtained from .cre files);
-\item STR_VAR \verb+fj_bcs_specific+ to the actor's specific script (normally obtained from .cre files);
-\item STR_VAR \verb+fj_cre_resref+ to the actor's resource reference (creature filename)*;
-\item STR_VAR \verb+fj_cre_embedded+ to ~path/to/file.cre~ if embedding a new creature (defaults to \verb+fj_cre_resref+ if not set);
-\end{itemize}
+\begin{weiduarguments}
+String variable & \verb+fj_name+ & the actor's name*; & Empty string \\
+Integer variable & \verb+fj_loc_x+ & the starting X (horizontal) coordinate*; & \verb+0+ \\
+Integer variable & \verb+fj_loc_y+ & the starting Y (vertical) coordinate*; & \verb+0+ \\
+Integer variable & \verb+fj_dest_x+ & the destination X coordinate (by default the same as \verb+fj_loc_x+); & \verb+fj_loc_x+ \\
+Integer variable & \verb+fj_dest_y+ & the destination Y coordinate (by default the same as \verb+fj_loc_y+); & \verb+fj_loc_y+ \\
+Integer variable & \verb+fj_loading+ & whether the .cre file is loaded (0=attached, 1=loaded, default 1); & \verb+1+ \\
+Integer variable & \verb+fj_spawned+ & whether the creature has been spawned (0=no, 1=yes, default 0); & \verb+0+ \\
+Integer variable & \verb+fj_animation+ & the actor's animation number (from animate.ids, though the engine uses the animation set on the .cre file); & \verb+0+ \\
+Integer variable & \verb+fj_orientation+ & the facing direction (0-15 where 0=south, 4=west, 8=north, 12=east, default 0); & \verb+0+ \\
+Integer variable & \verb+fj_expiry+ & the actor removal timer in absolute ticks (default -1 to avoid removal); & \verb+-1+ \\
+Integer variable & \verb+fj_wander_dist_actor+ & the actor's random walk distance limit; & \verb+0+ \\
+Integer variable & \verb+fj_mvmt_dist_actor+ & the actor's movement distance limit; & \verb+0+ \\
+Integer variable & \verb+fj_schedule+ & the hourly appearance schedule (bits 0-23, default -1 or always); & \verb+-1+ \\
+Integer variable & \verb+fj_num_talked+ & the NumTimesTalkedTo (in .sav files); & \verb+0+ \\
+String variable & \verb+fj_dlg_resref+ & the actor's dialogue file (normally obtained from .cre files); & Empty string \\
+String variable & \verb+fj_bcs_override+ & the actor's override script (normally obtained from .cre files); & Empty string \\
+String variable & \verb+fj_bcs_general+ & the actor's general script (normally obtained from .cre files); & Empty string \\
+String variable & \verb+fj_bcs_class+ & the actor's class script (normally obtained from .cre files); & Empty string \\
+String variable & \verb+fj_bcs_race+ & the actor's race script (normally obtained from .cre files); & Empty string \\
+String variable & \verb+fj_bcs_default+ & the actor's default script (normally obtained from .cre files); & Empty string \\
+String variable & \verb+fj_bcs_specific+ & the actor's specific script (normally obtained from .cre files); & Empty string \\
+String variable & \verb+fj_cre_resref+ & the actor's resource reference (creature filename)*; & Empty string \\
+String variable & \verb+fj_cre_embedded+ & ~path/to/file.cre~ if embedding a new creature (defaults to \verb+fj_cre_resref+ if not set); & Empty string \\
+\end{weiduarguments}
+
 Region structure variables:
-\begin{itemize}
-\item STR_VAR \verb+fj_name+ to the region's name*;
-\item INT_VAR \verb+fj_type+ to the region type (0=trap, 1=info, 2=travel)*;
-\item INT_VAR \verb+fj_box_left+ to the leftmost X coordinate of the region's bounding box*;
-\item INT_VAR \verb+fj_box_top+ to the topmost Y coordinate of the region's bounding box*;
-\item INT_VAR \verb+fj_box_right+ to the rightmost X coordinate of the region's bounding box*;
-\item INT_VAR \verb+fj_box_bottom+ to the bottommost Y coordinate of the region's bounding box*;
-\item INT_VAR \verb+fj_cursor_idx+ to the region's mouse cursor index (from cursors.bam)*;
-\item STR_VAR \verb+fj_destination_area+ to the destination area resource reference (for travel regions);
-\item STR_VAR \verb+fj_destination_name+ to the entrance name in the destination area (for travel regions);
-\item INT_VAR \verb+fj_flags+ to the bitwise region flags;
-\item INT_VAR \verb+fj_info_point_strref+ to the information text string reference (for info points, default -1);
-\item INT_VAR \verb+fj_trap_detect+ to the trap detection difficulty percentage;
-\item INT_VAR \verb+fj_trap_remove+ to the trap removal difficulty percentage;
-\item INT_VAR \verb+fj_trap_active+ to whether the region is trapped (0=no, 1=yes);
-\item INT_VAR \verb+fj_trap_status+ to whether the trap is detected (0=no, 1=yes);
-\item INT_VAR \verb+fj_loc_x+ to the trap launch X coordinate*;
-\item INT_VAR \verb+fj_loc_y+ to the trap launch Y coordinate*;
-\item STR_VAR \verb+fj_key_resref+ to the filename of the region's key;
-\item STR_VAR \verb+fj_reg_script+ to the region script;
-\item INT_VAR \verb+fj_alt_x+ to the activation point X coordinate;
-\item INT_VAR \verb+fj_alt_y+ to the activation point Y coordinate;
-\item STR_VAR \verb+fj_sound+ to the sound resource reference (ONLY for PST);
-\item INT_VAR \verb+fj_talk_loc_x+ to the talk location point X coordinate (ONLY for PST);
-\item INT_VAR \verb+fj_talk_loc_y+ to the talk location point Y coordinate (ONLY for PST);
-\item INT_VAR \verb+fj_speaker_strref+ to the speaker's name string reference (default -1; ONLY for PST);
-\item STR_VAR \verb+fj_dialog+ to the region's dialogue file (ONLY for PST);
-\item INT_VAR \verb+fj_vertex_0+ to (X coordinate + (Y coordinate << 16)) for each vertex pair*;
-\end{itemize}
+\begin{weiduarguments}
+String variable & \verb+fj_name+ & the region's name*; & Empty string \\
+Integer variable & \verb+fj_type+ & the region type (0=trap, 1=info, 2=travel)*; & \verb+0+ \\
+Integer variable & \verb+fj_box_left+ & the leftmost X coordinate of the region's bounding box*; & \verb+0+ \\
+Integer variable & \verb+fj_box_top+ & the topmost Y coordinate of the region's bounding box*; & \verb+0+ \\
+Integer variable & \verb+fj_box_right+ & the rightmost X coordinate of the region's bounding box*; & \verb+0+ \\
+Integer variable & \verb+fj_box_bottom+ & the bottommost Y coordinate of the region's bounding box*; & \verb+0+ \\
+Integer variable & \verb+fj_cursor_idx+ & the region's mouse cursor index (from cursors.bam)*; & \verb+0+ \\
+String variable & \verb+fj_destination_area+ & the destination area resource reference (for travel regions); & Empty string \\
+String variable & \verb+fj_destination_name+ & the entrance name in the destination area (for travel regions); & Empty string \\
+Integer variable & \verb+fj_flags+ & the bitwise region flags; & \verb+0+ \\
+Integer variable & \verb+fj_info_point_strref+ & the information text string reference (for info points, default -1); & \verb+-1+ \\
+Integer variable & \verb+fj_trap_detect+ & the trap detection difficulty percentage; & \verb+0+ \\
+Integer variable & \verb+fj_trap_remove+ & the trap removal difficulty percentage; & \verb+0+ \\
+Integer variable & \verb+fj_trap_active+ & whether the region is trapped (0=no, 1=yes); & \verb+0+ \\
+Integer variable & \verb+fj_trap_status+ & whether the trap is detected (0=no, 1=yes); & \verb+0+ \\
+Integer variable & \verb+fj_loc_x+ & the trap launch X coordinate*; & \verb+0+ \\
+Integer variable & \verb+fj_loc_y+ & the trap launch Y coordinate*; & \verb+0+ \\
+String variable & \verb+fj_key_resref+ & the filename of the region's key; & Empty string \\
+String variable & \verb+fj_reg_script+ & the region script; & Empty string \\
+Integer variable & \verb+fj_alt_x+ & the activation point X coordinate; & \verb+0+ \\
+Integer variable & \verb+fj_alt_y+ & the activation point Y coordinate; & \verb+0+ \\
+String variable & \verb+fj_sound+ & the sound resource reference (ONLY for PST); & Empty string \\
+Integer variable & \verb+fj_talk_loc_x+ & the talk location point X coordinate (ONLY for PST); & \verb+0+ \\
+Integer variable & \verb+fj_talk_loc_y+ & the talk location point Y coordinate (ONLY for PST); & \verb+0+ \\
+Integer variable & \verb+fj_speaker_strref+ & the speaker's name string reference (default -1; ONLY for PST); & \verb+-1+ \\
+String variable & \verb+fj_dialog+ & the region's dialogue file (ONLY for PST); & Empty string \\
+Caller-scope integer series & \verb+fj_vertex_0+ & (X coordinate + (Y coordinate << 16)) for each vertex pair*. Define the series contiguously from index 0 before launching the function. & Required \\
+\end{weiduarguments}
+
 Spawn structure variables:
-\begin{itemize}
-\item STR_VAR \verb+fj_name+ to the spawn point's name*;
-\item INT_VAR \verb+fj_loc_x+ to the spawning X coordinate*;
-\item INT_VAR \verb+fj_loc_y+ to the spawning Y coordinate*;
-\item STR_VAR \verb+fj_cre_resref0+ to the resource reference of each creature spawned (0-9)*;
-\item INT_VAR \verb+fj_spawn_num+ to the count of spawn creatures*;
-\item INT_VAR \verb+fj_difficulty+ to the base number of creatures to spawn (encounter difficulty)*;
-\item INT_VAR \verb+fj_delay+ to the number of seconds between spawning (default 10);
-\item INT_VAR \verb+fj_method+ to the spawn method;
-\item INT_VAR \verb+fj_duration+ to the creature duration (default 1000);
-\item INT_VAR \verb+fj_wander_dist_spawn+ to the creature's random walk distance limit (default 1000);
-\item INT_VAR \verb+fj_mvmt_dist_spawn+ to the creature's movement distance limit (default 1000);
-\item INT_VAR \verb+fj_max_num+ to the maximum number of creatures to spawn*;
-\item INT_VAR \verb+fj_enable+ to the spawn point status (0=inactive, 1=active, default 1);
-\item INT_VAR \verb+fj_schedule+ to the hourly appearance schedule (bits 0-23, default -1 or always);
-\item INT_VAR \verb+fj_day_prob+ to the spawn point daytime probability (default 100);
-\item INT_VAR \verb+fj_night_prob+ to the spawn point nighttime probability (default 100);
-\item INT_VAR \verb+fj_spawn_freq+ to the spawn frequency in seconds (Enhanced Editions only);
-\item INT_VAR \verb+fj_countdown+ to the spawn countdown (Enhanced Editions only);
-\item INT_VAR \verb+fj_weight0...fj_weight9+ to the weight of the spawn creatures (Enhanced Editions only);
-\end{itemize}
+\begin{weiduarguments}
+String variable & \verb+fj_name+ & the spawn point's name*; & Empty string \\
+Integer variable & \verb+fj_loc_x+ & the spawning X coordinate*; & \verb+0+ \\
+Integer variable & \verb+fj_loc_y+ & the spawning Y coordinate*; & \verb+0+ \\
+String variable & \verb+fj_cre_resref0+ & the resource reference of each creature spawned (0-9)*; & Empty string \\
+Integer variable & \verb+fj_spawn_num+ & the count of spawn creatures*; & \verb+0+ \\
+Integer variable & \verb+fj_difficulty+ & the base number of creatures to spawn (encounter difficulty)*; & \verb+0+ \\
+Integer variable & \verb+fj_delay+ & the number of seconds between spawning; & \verb+0+ \\
+Integer variable & \verb+fj_method+ & the spawn method; & \verb+0+ \\
+Integer variable & \verb+fj_duration+ & the creature duration (default 1000); & \verb+1000+ \\
+Integer variable & \verb+fj_wander_dist_spawn+ & the creature's random walk distance limit (default 1000); & \verb+1000+ \\
+Integer variable & \verb+fj_mvmt_dist_spawn+ & the creature's movement distance limit (default 1000); & \verb+1000+ \\
+Integer variable & \verb+fj_max_num+ & the maximum number of creatures to spawn*; & \verb+0+ \\
+Integer variable & \verb+fj_enable+ & the spawn point status (0=inactive, 1=active, default 1); & \verb+1+ \\
+Integer variable & \verb+fj_schedule+ & the hourly appearance schedule (bits 0-23, default -1 or always); & \verb+-1+ \\
+Integer variable & \verb+fj_day_prob+ & the spawn point daytime probability (default 100); & \verb+100+ \\
+Integer variable & \verb+fj_night_prob+ & the spawn point nighttime probability (default 100); & \verb+100+ \\
+Integer variable & \verb+fj_spawn_freq+ & the spawn frequency in seconds (Enhanced Editions only); & \verb+0+ \\
+Integer variable & \verb+fj_countdown+ & the spawn countdown (Enhanced Editions only); & \verb+0+ \\
+Integer variable & \verb+fj_weight0...fj_weight9+ & the weight of the spawn creatures (Enhanced Editions only); & \verb+0+ \\
+\end{weiduarguments}
+
 Entrance structure variables:
-\begin{itemize}
-\item STR_VAR \verb+fj_name+ to the entrance's name*;
-\item INT_VAR \verb+fj_loc_x+ to the X coordinate*;
-\item INT_VAR \verb+fj_loc_y+ to the Y coordinate*;
-\item INT_VAR \verb+fj_orientation+ to the facing direction (0-15 where 0=south, 4=west, 8=north, 12=east)*;
-\end{itemize}
+\begin{weiduarguments}
+String variable & \verb+fj_name+ & the entrance's name*; & Empty string \\
+Integer variable & \verb+fj_loc_x+ & the X coordinate*; & \verb+0+ \\
+Integer variable & \verb+fj_loc_y+ & the Y coordinate*; & \verb+0+ \\
+Integer variable & \verb+fj_orientation+ & the facing direction (0-15 where 0=south, 4=west, 8=north, 12=east)*; & \verb+0+ \\
+\end{weiduarguments}
+
 Container structure variables:
-\begin{itemize}
-\item STR_VAR \verb+fj_name+ to the container's name*;
-\item INT_VAR \verb+fj_loc_x+ to the X coordinate*;
-\item INT_VAR \verb+fj_loc_y+ to the Y coordinate*;
-\item INT_VAR \verb+fj_type+ to the container type (1=bag, 2=chest, 3=drawer, 4=pile, 5=table, 6=shelf, 7=altar, 8=nonvisible, 9=spellbook, 10=body, 11=barrel, 12=crate)*;
-\item INT_VAR \verb+fj_lock_diff+ to the lock difficulty (default 100);
-\item INT_VAR \verb+fj_flags+ to the bitwise container flags (bit0=locked, bit3=trap resets, bit5=disabled);
-\item INT_VAR \verb+fj_trap_detect+ to the trap detection difficulty percentage;
-\item INT_VAR \verb+fj_trap_remove_diff+ to the trap removal difficulty percentage (default 100);
-\item INT_VAR \verb+fj_trap_active+ to whether the container is trapped (0=no, 1=yes);
-\item INT_VAR \verb+fj_trap_status+ to whether the trap is detected (0=no, 1=yes);
-\item INT_VAR \verb+fj_trap_loc_x+ to the trap launch X coordinate*;
-\item INT_VAR \verb+fj_trap_loc_y+ to the trap launch Y coordinate*;
-\item INT_VAR \verb+fj_box_left+ to the leftmost X coordinate of the trap's bounding box;
-\item INT_VAR \verb+fj_box_top+ to the topmost Y coordinate of the trap's bounding box;
-\item INT_VAR \verb+fj_box_right+ to the rightmost X coordinate of the trap's bounding box;
-\item INT_VAR \verb+fj_box_bottom+ to the bottommost Y coordinate of the trap's bounding box;
-\item STR_VAR \verb+fj_trap_script+ to the trap's script;
-\item INT_VAR \verb+fj_vertex_0+ to (X coordinate + (Y coordinate << 16)) for each vertex pair*;
-\item STR_VAR \verb+fj_key_resref+ to the filename of the container's key;
-\item INT_VAR \verb+fj_lockpick_strref+ to the lockpick string reference (default -1);
-\end{itemize}
+\begin{weiduarguments}
+String variable & \verb+fj_name+ & the container's name*; & Empty string \\
+Integer variable & \verb+fj_loc_x+ & the X coordinate*; & \verb+0+ \\
+Integer variable & \verb+fj_loc_y+ & the Y coordinate*; & \verb+0+ \\
+Integer variable & \verb+fj_type+ & the container type (1=bag, 2=chest, 3=drawer, 4=pile, 5=table, 6=shelf, 7=altar, 8=nonvisible, 9=spellbook, 10=body, 11=barrel, 12=crate)*; & \verb+0+ \\
+Integer variable & \verb+fj_lock_diff+ & the lock difficulty (default 100); & \verb+100+ \\
+Integer variable & \verb+fj_flags+ & the bitwise container flags (bit0=locked, bit3=trap resets, bit5=disabled); & \verb+0+ \\
+Integer variable & \verb+fj_trap_detect+ & the trap detection difficulty percentage; & \verb+0+ \\
+Integer variable & \verb+fj_trap_remove_diff+ & the trap removal difficulty percentage (default 100); & \verb+100+ \\
+Integer variable & \verb+fj_trap_active+ & whether the container is trapped (0=no, 1=yes); & \verb+0+ \\
+Integer variable & \verb+fj_trap_status+ & whether the trap is detected (0=no, 1=yes); & \verb+0+ \\
+Integer variable & \verb+fj_trap_loc_x+ & the trap launch X coordinate*; & \verb+0+ \\
+Integer variable & \verb+fj_trap_loc_y+ & the trap launch Y coordinate*; & \verb+0+ \\
+Integer variable & \verb+fj_box_left+ & the leftmost X coordinate of the trap's bounding box; & \verb+0+ \\
+Integer variable & \verb+fj_box_top+ & the topmost Y coordinate of the trap's bounding box; & \verb+0+ \\
+Integer variable & \verb+fj_box_right+ & the rightmost X coordinate of the trap's bounding box; & \verb+0+ \\
+Integer variable & \verb+fj_box_bottom+ & the bottommost Y coordinate of the trap's bounding box; & \verb+0+ \\
+String variable & \verb+fj_trap_script+ & the trap's script; & Empty string \\
+Caller-scope integer series & \verb+fj_vertex_0+ & (X coordinate + (Y coordinate << 16)) for each vertex pair*. Define the series contiguously from index 0 before launching the function. & Required \\
+String variable & \verb+fj_key_resref+ & the filename of the container's key; & Empty string \\
+Integer variable & \verb+fj_lockpick_strref+ & the lockpick string reference (default -1); & \verb+-1+ \\
+\end{weiduarguments}
+
 Item structure variables:
-\begin{itemize}
-\item STR_VAR \verb+fj_name+ to the item's resource reference (filename)*;
-\item INT_VAR \verb+fj_con_itm_idx+ to the index of the container to which the item is added*;
-\item INT_VAR \verb+fj_itm_expiry+ to the item expiration time (default 0);
-\item INT_VAR \verb+fj_charge0+ to the charges of the 1st ability (item quantity for stackables, default 0);
-\item INT_VAR \verb+fj_charge1+ to the charges of the 2nd ability (default 0);
-\item INT_VAR \verb+fj_charge2+ to the charges of the 3rd ability (default 0);
-\item INT_VAR \verb+fj_flags+ to the bitwise item flags (bit0=identified, bit1=unstealable, bit2=stolen, bit3=undroppable, default 0);
-\end{itemize}
+\begin{weiduarguments}
+String variable & \verb+fj_name+ & the item's resource reference (filename)*; & Empty string \\
+Integer variable & \verb+fj_con_itm_idx+ & the index of the container to which the item is added*; & \verb+-1+ \\
+Integer variable & \verb+fj_itm_expiry+ & the item expiration time (default 0); & \verb+0+ \\
+Integer variable & \verb+fj_charge0+ & the charges of the 1st ability (item quantity for stackables, default 0); & \verb+0+ \\
+Integer variable & \verb+fj_charge1+ & the charges of the 2nd ability (default 0); & \verb+0+ \\
+Integer variable & \verb+fj_charge2+ & the charges of the 3rd ability (default 0); & \verb+0+ \\
+Integer variable & \verb+fj_flags+ & the bitwise item flags (bit0=identified, bit1=unstealable, bit2=stolen, bit3=undroppable, default 0); & \verb+0+ \\
+\end{weiduarguments}
+
 Ambient structure variables:
-\begin{itemize}
-\item STR_VAR \verb+fj_name+ to the ambient's name*;
-\item INT_VAR \verb+fj_loc_x+ to the X coordinate*;
-\item INT_VAR \verb+fj_loc_y+ to the Y coordinate*;
-\item INT_VAR \verb+fj_radius+ to the sound radius (default 500);
-\item INT_VAR \verb+fj_loc_z+ to the Z coordinate (height);
-\item INT_VAR \verb+fj_pitch_variance+ to the pitch variance;
-\item INT_VAR \verb+fj_volume_variance+ to the volume variance;
-\item INT_VAR \verb+fj_volume+ to the volume percentage (default 80);
-\item STR_VAR \verb+fj_wav_resref0+ to the resource reference of each sound (0-9)*;
-\item INT_VAR \verb+fj_sound_num+ to the number of sounds*;
-\item INT_VAR \verb+fj_delay+ to the base interval in seconds between sounds from this ambient list;
-\item INT_VAR \verb+fj_variation+ to the base deviation from the base interval;
-\item INT_VAR \verb+fj_schedule+ to the hourly appearance schedule (bits 0-23, default -1 or always);
-\item INT_VAR \verb+fj_flags+ to the bitwise ambient flags*;
-\end{itemize}
+\begin{weiduarguments}
+String variable & \verb+fj_name+ & the ambient's name*; & Empty string \\
+Integer variable & \verb+fj_loc_x+ & the X coordinate*; & \verb+0+ \\
+Integer variable & \verb+fj_loc_y+ & the Y coordinate*; & \verb+0+ \\
+Integer variable & \verb+fj_radius+ & the sound radius (default 500); & \verb+500+ \\
+Integer variable & \verb+fj_loc_z+ & the Z coordinate (height); & \verb+0+ \\
+Integer variable & \verb+fj_pitch_variance+ & the pitch variance; & \verb+0+ \\
+Integer variable & \verb+fj_volume_variance+ & the volume variance; & \verb+0+ \\
+Integer variable & \verb+fj_volume+ & the volume percentage (default 80); & \verb+80+ \\
+String variable & \verb+fj_wav_resref0+ & the resource reference of each sound (0-9)*; & Empty string \\
+Integer variable & \verb+fj_sound_num+ & the number of sounds*; & \verb+0+ \\
+Integer variable & \verb+fj_delay+ & the base interval in seconds between sounds from this ambient list; & \verb+0+ \\
+Integer variable & \verb+fj_variation+ & the base deviation from the base interval; & \verb+0+ \\
+Integer variable & \verb+fj_schedule+ & the hourly appearance schedule (bits 0-23, default -1 or always); & \verb+-1+ \\
+Integer variable & \verb+fj_flags+ & the bitwise ambient flags*; & \verb+0+ \\
+\end{weiduarguments}
+
 Variable structure variables:
-\begin{itemize}
-\item STR_VAR \verb+fj_name+ to the variable's name*;
-\item INT_VAR \verb+fj_variable_value+ to the variable's value*;
-\end{itemize}
+\begin{weiduarguments}
+String variable & \verb+fj_name+ & the variable's name*; & Empty string \\
+Integer variable & \verb+fj_variable_value+ & the variable's value*; & \verb+0+ \\
+\end{weiduarguments}
+
 Door structure variables:
-\begin{itemize}
-\item STR_VAR \verb+fj_name+ to the door's name*;
-\item STR_VAR \verb+fj_door_wed_id+ to the door ID linked to the .wed file*;
-\item INT_VAR \verb+fj_flags+ to the bitwise door flags*;
-\item INT_VAR \verb+fj_open_box_left+ to the leftmost X coordinate of the open door's bounding box*;
-\item INT_VAR \verb+fj_open_box_top+ to the topmost Y coordinate of the open door's bounding box*;
-\item INT_VAR \verb+fj_open_box_right+ to the rightmost X coordinate of the open door's bounding box*;
-\item INT_VAR \verb+fj_open_box_bottom+ to the bottommost Y coordinate of the open door's bounding box*;
-\item INT_VAR \verb+fj_closed_box_left+ to the leftmost X coordinate of the closed door's bounding box*;
-\item INT_VAR \verb+fj_closed_box_top+ to the topmost Y coordinate of the closed door's bounding box*;
-\item INT_VAR \verb+fj_closed_box_right+ to the rightmost X coordinate of the closed door's bounding box*;
-\item INT_VAR \verb+fj_closed_box_bottom+ to the bottommost Y coordinate of the closed door's bounding box*;
-\item INT_VAR \verb+fj_door_open_vert_0+ to (X coordinate + (Y coordinate << 16)) for each vertex pair of the open door*;
-\item INT_VAR \verb+fj_door_closed_vert_0+ to (X coordinate + (Y coordinate << 16)) for each vertex pair of the closed door*;
-\item INT_VAR \verb+fj_cell_open_vert_0+ to (X coordinate + (Y coordinate << 16)) for each impeded search map cell of the open door*;
-\item INT_VAR \verb+fj_cell_closed_vert_0+ to (X coordinate + (Y coordinate << 16)) for each impeded search map cell of the closed door*;
-\item STR_VAR \verb+fj_door_open_wav+ to the door open sound;
-\item STR_VAR \verb+fj_door_close_wav+ to the door closed sound;
-\item INT_VAR \verb+fj_cursor_idx+ to the door's mouse cursor index (from cursors.bam)*;
-\item INT_VAR \verb+fj_trap_detect+ to the trap detection difficulty percentage;
-\item INT_VAR \verb+fj_trap_remove+ to the trap removal difficulty percentage;
-\item INT_VAR \verb+fj_trap_active+ to whether the door is trapped (0=no, 1=yes);
-\item INT_VAR \verb+fj_trap_status+ to whether the trap is detected (0=no, 1=yes);
-\item INT_VAR \verb+fj_trap_loc_x+ to the trap launch X coordinate*;
-\item INT_VAR \verb+fj_trap_loc_y+ to the trap launch Y coordinate*;
-\item STR_VAR \verb+fj_key_resref+ to the filename of the door's key;
-\item STR_VAR \verb+fj_door_script+ to the door script;
-\item INT_VAR \verb+fj_detect_diff+ to the detection difficulty (for secret doors);
-\item INT_VAR \verb+fj_locked_diff+ to the lock difficulty;
-\item INT_VAR \verb+fj_open_loc_x+ to the X coordinate for toggling the door's open state*;
-\item INT_VAR \verb+fj_open_loc_y+ to the Y coordinate for toggling the door's open state*;
-\item INT_VAR \verb+fj_closed_loc_x+ to the X coordinate for toggling the door's closed state*;
-\item INT_VAR \verb+fj_closed_loc_y+ to the Y coordinate for toggling the door's closed state*;
-\item INT_VAR \verb+fj_lockpick_strref+ to the lockpick string reference (default -1);
-\item STR_VAR \verb+fj_travel_trigger+ to the travel region name*;
-\item INT_VAR \verb+fj_dlg_strref+ to the dialogue string reference (default -1);
-\item STR_VAR \verb+fj_dlg_resref+ to the door's dialogue file;
-\end{itemize}
+\begin{weiduarguments}
+String variable & \verb+fj_name+ & the door's name*; & Empty string \\
+String variable & \verb+fj_door_wed_id+ & the door ID linked to the .wed file*; & Empty string \\
+Integer variable & \verb+fj_flags+ & the bitwise door flags*; & \verb+0+ \\
+Integer variable & \verb+fj_open_box_left+ & the leftmost X coordinate of the open door's bounding box*; & \verb+0+ \\
+Integer variable & \verb+fj_open_box_top+ & the topmost Y coordinate of the open door's bounding box*; & \verb+0+ \\
+Integer variable & \verb+fj_open_box_right+ & the rightmost X coordinate of the open door's bounding box*; & \verb+0+ \\
+Integer variable & \verb+fj_open_box_bottom+ & the bottommost Y coordinate of the open door's bounding box*; & \verb+0+ \\
+Integer variable & \verb+fj_closed_box_left+ & the leftmost X coordinate of the closed door's bounding box*; & \verb+0+ \\
+Integer variable & \verb+fj_closed_box_top+ & the topmost Y coordinate of the closed door's bounding box*; & \verb+0+ \\
+Integer variable & \verb+fj_closed_box_right+ & the rightmost X coordinate of the closed door's bounding box*; & \verb+0+ \\
+Integer variable & \verb+fj_closed_box_bottom+ & the bottommost Y coordinate of the closed door's bounding box*; & \verb+0+ \\
+Caller-scope integer series & \verb+fj_door_open_vert_0+ & (X coordinate + (Y coordinate << 16)) for each vertex pair of the open door*. Define the series contiguously from index 0 before launching the function. & Required \\
+Caller-scope integer series & \verb+fj_door_closed_vert_0+ & (X coordinate + (Y coordinate << 16)) for each vertex pair of the closed door*. Define the series contiguously from index 0 before launching the function. & Required \\
+Caller-scope integer series & \verb+fj_cell_open_vert_0+ & (X coordinate + (Y coordinate << 16)) for each impeded search map cell of the open door*. Define the series contiguously from index 0 before launching the function. & Required \\
+Caller-scope integer series & \verb+fj_cell_closed_vert_0+ & (X coordinate + (Y coordinate << 16)) for each impeded search map cell of the closed door*. Define the series contiguously from index 0 before launching the function. & Required \\
+String variable & \verb+fj_door_open_wav+ & the door open sound; & Empty string \\
+String variable & \verb+fj_door_close_wav+ & the door closed sound; & Empty string \\
+Integer variable & \verb+fj_cursor_idx+ & the door's mouse cursor index (from cursors.bam)*; & \verb+0+ \\
+Integer variable & \verb+fj_trap_detect+ & the trap detection difficulty percentage; & \verb+0+ \\
+Integer variable & \verb+fj_trap_remove+ & the trap removal difficulty percentage; & \verb+0+ \\
+Integer variable & \verb+fj_trap_active+ & whether the door is trapped (0=no, 1=yes); & \verb+0+ \\
+Integer variable & \verb+fj_trap_status+ & whether the trap is detected (0=no, 1=yes); & \verb+0+ \\
+Integer variable & \verb+fj_trap_loc_x+ & the trap launch X coordinate*; & \verb+0+ \\
+Integer variable & \verb+fj_trap_loc_y+ & the trap launch Y coordinate*; & \verb+0+ \\
+String variable & \verb+fj_key_resref+ & the filename of the door's key; & Empty string \\
+String variable & \verb+fj_door_script+ & the door script; & Empty string \\
+Integer variable & \verb+fj_detect_diff+ & the detection difficulty (for secret doors); & \verb+0+ \\
+Integer variable & \verb+fj_locked_diff+ & the lock difficulty; & \verb+0+ \\
+Integer variable & \verb+fj_open_loc_x+ & the X coordinate for toggling the door's open state*; & \verb+0+ \\
+Integer variable & \verb+fj_open_loc_y+ & the Y coordinate for toggling the door's open state*; & \verb+0+ \\
+Integer variable & \verb+fj_closed_loc_x+ & the X coordinate for toggling the door's closed state*; & \verb+0+ \\
+Integer variable & \verb+fj_closed_loc_y+ & the Y coordinate for toggling the door's closed state*; & \verb+0+ \\
+Integer variable & \verb+fj_lockpick_strref+ & the lockpick string reference (default -1); & \verb+-1+ \\
+String variable & \verb+fj_travel_trigger+ & the travel region name*; & Empty string \\
+Integer variable & \verb+fj_dlg_strref+ & the dialogue string reference (default -1); & \verb+-1+ \\
+String variable & \verb+fj_dlg_resref+ & the door's dialogue file; & Empty string \\
+\end{weiduarguments}
+
 Animation structure variables:
-\begin{itemize}
-\item STR_VAR \verb+fj_name+ to the animation name*;
-\item INT_VAR \verb+fj_loc_x+ to the X coordinate*;
-\item INT_VAR \verb+fj_loc_y+ to the Y coordinate*;
-\item INT_VAR \verb+fj_schedule+ to the hourly appearance schedule (bits 0-23, default -1 or always);
-\item STR_VAR \verb+fj_bam_resref+ to the animation resource reference (filename)*;
-\item INT_VAR \verb+fj_bam_seq+ to the BAM sequence number;
-\item INT_VAR \verb+fj_bam_frame+ to the BAM frame number;
-\item INT_VAR \verb+fj_flags+ to the bitwise animation flags*;
-\item INT_VAR \verb+fj_loc_z+ to the height;
-\item INT_VAR \verb+fj_transparent+ to the BAM transparency;
-\item INT_VAR \verb+fj_init_frame+ to the starting frame;
-\item INT_VAR \verb+fj_loop_chance+ to the chance of looping;
-\item INT_VAR \verb+fj_skip_cycles+ to start delay in frames;
-\item STR_VAR \verb+fj_bmp_resref+ to the palette bitmap;
-\item INT_VAR \verb+fj_width+ to the animation width (only required for WBM and PVRZ resources, Enhanced Editions only);
-\item INT_VAR \verb+fj_height+ to the animation height (only required for WBM and PVRZ resources, Enhanced Editions only);
-\end{itemize}
+\begin{weiduarguments}
+String variable & \verb+fj_name+ & the animation name*; & Empty string \\
+Integer variable & \verb+fj_loc_x+ & the X coordinate*; & \verb+0+ \\
+Integer variable & \verb+fj_loc_y+ & the Y coordinate*; & \verb+0+ \\
+Integer variable & \verb+fj_schedule+ & the hourly appearance schedule (bits 0-23, default -1 or always); & \verb+-1+ \\
+String variable & \verb+fj_bam_resref+ & the animation resource reference (filename)*; & Empty string \\
+Integer variable & \verb+fj_bam_seq+ & the BAM sequence number; & \verb+0+ \\
+Integer variable & \verb+fj_bam_frame+ & the BAM frame number; & \verb+0+ \\
+Integer variable & \verb+fj_flags+ & the bitwise animation flags*; & \verb+0+ \\
+Integer variable & \verb+fj_loc_z+ & the height; & \verb+0+ \\
+Integer variable & \verb+fj_transparent+ & the BAM transparency; & \verb+0+ \\
+Integer variable & \verb+fj_init_frame+ & the starting frame; & \verb+0+ \\
+Integer variable & \verb+fj_loop_chance+ & the chance of looping; & \verb+0+ \\
+Integer variable & \verb+fj_skip_cycles+ & start delay in frames; & \verb+0+ \\
+String variable & \verb+fj_bmp_resref+ & the palette bitmap; & Empty string \\
+Integer variable & \verb+fj_width+ & the animation width (only required for WBM and PVRZ resources, Enhanced Editions only); & \verb+0+ \\
+Integer variable & \verb+fj_height+ & the animation height (only required for WBM and PVRZ resources, Enhanced Editions only); & \verb+0+ \\
+\end{weiduarguments}
+
 Bitmask structure variables:
-\begin{itemize}
-\item STR_VAR \verb+fj_bitmask+ to ~path/to/binary.file~*;
-\end{itemize}
+\begin{weiduarguments}
+String variable & \verb+fj_bitmask+ & ~path/to/binary.file~*; & Empty string \\
+\end{weiduarguments}
+
 Songlist structure variables:
-\begin{itemize}
-\item INT_VAR \verb+fj_song_day+ to the day SONGLIST.2DA entry;
-\item INT_VAR \verb+fj_song_night+ to the night SONGLIST.2DA entry;
-\item INT_VAR \verb+fj_song_victory+ to the victory SONGLIST.2DA entry;
-\item INT_VAR \verb+fj_song_battle+ to the battle SONGLIST.2DA entry;
-\item INT_VAR \verb+fj_song_defeat+ to the defeat SONGLIST.2DA entry;
-\item INT_VAR \verb+fj_song_day_alt+ to the alternative day SONGLIST.2DA entry (default -1, Enhanced Editions only);
-\item INT_VAR \verb+fj_song_night_alt+ to the alternative night SONGLIST.2DA entry (default -1, Enhanced Editions only);
-\item INT_VAR \verb+fj_song_victory_alt+ to the alternative victory SONGLIST.2DA entry (default -1, Enhanced Editions only);
-\item INT_VAR \verb+fj_song_battle_alt+ to the alternative battle SONGLIST.2DA entry (default -1, Enhanced Editions only);
-\item INT_VAR \verb+fj_song_defeat_alt+ to the alternative defeat SONGLIST.2DA entry (default -1, Enhanced Editions only);
-\item STR_VAR \verb+fj_song_day0+ to the day song WAV resref;
-\item STR_VAR \verb+fj_song_day1+ to the night song WAV resref;
-\item INT_VAR \verb+fj_song_day_vol+ to the day songs volume (default 100);
-\item STR_VAR \verb+fj_song_night0+ to the night song WAV resref;
-\item STR_VAR \verb+fj_song_night1+ to the second night song WAV resref;
-\item INT_VAR \verb+fj_song_night_vol+ to the night songs volume (default 100);
-\end{itemize}
+\begin{weiduarguments}
+Integer variable & \verb+fj_song_day+ & the day SONGLIST.2DA entry; & \verb+0+ \\
+Integer variable & \verb+fj_song_night+ & the night SONGLIST.2DA entry; & \verb+0+ \\
+Integer variable & \verb+fj_song_victory+ & the victory SONGLIST.2DA entry; & \verb+0+ \\
+Integer variable & \verb+fj_song_battle+ & the battle SONGLIST.2DA entry; & \verb+0+ \\
+Integer variable & \verb+fj_song_defeat+ & the defeat SONGLIST.2DA entry; & \verb+0+ \\
+Integer variable & \verb+fj_song_day_alt+ & the alternative day SONGLIST.2DA entry (default -1, Enhanced Editions only); & \verb+-1+ \\
+Integer variable & \verb+fj_song_night_alt+ & the alternative night SONGLIST.2DA entry (default -1, Enhanced Editions only); & \verb+-1+ \\
+Integer variable & \verb+fj_song_victory_alt+ & the alternative victory SONGLIST.2DA entry (default -1, Enhanced Editions only); & \verb+-1+ \\
+Integer variable & \verb+fj_song_battle_alt+ & the alternative battle SONGLIST.2DA entry (default -1, Enhanced Editions only); & \verb+-1+ \\
+Integer variable & \verb+fj_song_defeat_alt+ & the alternative defeat SONGLIST.2DA entry (default -1, Enhanced Editions only); & \verb+-1+ \\
+String variable & \verb+fj_song_day0+ & the day song WAV resref; & Empty string \\
+String variable & \verb+fj_song_day1+ & the night song WAV resref; & Empty string \\
+Integer variable & \verb+fj_song_day_vol+ & the day songs volume (default 100); & \verb+100+ \\
+String variable & \verb+fj_song_night0+ & the night song WAV resref; & Empty string \\
+String variable & \verb+fj_song_night1+ & the second night song WAV resref; & Empty string \\
+Integer variable & \verb+fj_song_night_vol+ & the night songs volume (default 100); & \verb+100+ \\
+\end{weiduarguments}
+
 Rest interrupt structure variables
-\begin{itemize}
-\item STR_VAR \verb+fj_name+ to the name of the rest interrupts (for editor use only);
-\item INT_VAR \verb+fj_cre_strref0...fj_cre_strref9+ to string displayed upon party ambush (default -1);
-\item STR_VAR \verb+fj_cre_resref0...fj_cre_resref9+ to creature resref;
-\item STR_VAR \verb+fj_spawn_num+ to the number of spawned attackers;
-\item STR_VAR \verb+fj_difficulty+ to the difficulty of the encounter;
-\item STR_VAR \verb+fj_duration+ to the creature's duration (default 1000);
-\item STR_VAR \verb+fj_wander_distance+ to the creature's random walk distance limit (default 1000);
-\item STR_VAR \verb+fj_mvmt_distance+ to the creature's movement distance limit (default 1000);
-\item STR_VAR \verb+fj_max_num+ to maximum number of spawned creatures;
-\item STR_VAR \verb+fj_enable+ to whether rest interrupts are enabled (0=no, 1=yes);
-\item STR_VAR \verb+fj_day_prob+ to probability of daytime ambush;
-\item STR_VAR \verb+fj_night_prob+ to probability of nightime ambush;
-\end{itemize}
+\begin{weiduarguments}
+String variable & \verb+fj_name+ & the name of the rest interrupts (for editor use only); & Empty string \\
+Integer variable & \verb+fj_cre_strref0...fj_cre_strref9+ & string displayed upon party ambush (default -1); & \verb+-1+ \\
+String variable & \verb+fj_cre_resref0...fj_cre_resref9+ & creature resref; & Empty string \\
+Integer variable & \verb+fj_spawn_num+ & the number of spawned attackers; & \verb+0+ \\
+Integer variable & \verb+fj_difficulty+ & the difficulty of the encounter; & \verb+0+ \\
+Integer variable & \verb+fj_duration+ & the creature's duration (default 1000); & \verb+1000+ \\
+Integer variable & \verb+fj_wander_distance+ & the creature's random walk distance limit (default 1000); & \verb+1000+ \\
+Integer variable & \verb+fj_mvmt_distance+ & the creature's movement distance limit (default 1000); & \verb+1000+ \\
+Integer variable & \verb+fj_max_num+ & maximum number of spawned creatures; & \verb+0+ \\
+Integer variable & \verb+fj_enable+ & whether rest interrupts are enabled (0=no, 1=yes); & \verb+1+ \\
+Integer variable & \verb+fj_day_prob+ & probability of daytime ambush; & \verb+100+ \\
+Integer variable & \verb+fj_night_prob+ & probability of nighttime ambush; & \verb+100+ \\
+\end{weiduarguments}
+
 Map note structure variables:
-\begin{itemize}
-\item INT_VAR \verb+fj_loc_x+ to the X coordinate*;
-\item INT_VAR \verb+fj_loc_y+ to the Y coordinate*;
-\item INT_VAR \verb+fj_note_strref+ to the note string reference (default -1, BGII only)*;
-\item STR_VAR \verb+fj_note_text+ to the note text (PST only)*;
-\item INT_VAR \verb+fj_strref_loc+ to the strref location (0=external, 1=dialog.tlk, default 1);
-\item INT_VAR \verb+fj_color+ to the map marker color (0-7);
-\item INT_VAR \verb+fj_note_id+ to the note ID;
-\end{itemize}
+\begin{weiduarguments}
+Integer variable & \verb+fj_loc_x+ & the X coordinate*; & \verb+0+ \\
+Integer variable & \verb+fj_loc_y+ & the Y coordinate*; & \verb+0+ \\
+Integer variable & \verb+fj_note_strref+ & the note string reference (default -1, BGII only)*; & \verb+-1+ \\
+String variable & \verb+fj_note_text+ & the note text (PST only)*; & Empty string \\
+Integer variable & \verb+fj_strref_loc+ & the strref location (0=external, 1=dialog.tlk, default 1); & \verb+1+ \\
+Integer variable & \verb+fj_color+ & the map marker color (0-7); & \verb+0+ \\
+Integer variable & \verb+fj_note_id+ & the note ID; & \verb+0+ \\
+\end{weiduarguments}
+
 Projectile trap structure variables (not available on PST):
-\begin{itemize}
-\item STR_VAR \verb+fj_name+ to the projectile filename*;
-\item INT_VAR \verb+fj_eff_off+ to the effect block offset;
-\item INT_VAR \verb+fj_eff_size+ to the effect block size;
-\item INT_VAR \verb+fj_missile_num+ to the missile.ids reference (projectl.ids - 1);
-\item INT_VAR \verb+fj_frequency+ to the explosion length (in frames);
-\item INT_VAR \verb+fj_duration+ to the number of explosions;
-\item INT_VAR \verb+fj_loc_x+ to the X coordinate*;
-\item INT_VAR \verb+fj_loc_y+ to the Y coordinate*;
-\item INT_VAR \verb+fj_loc_z+ to the height;
-\item INT_VAR \verb+fj_target+ to the ea.ids value of the target;
-\item INT_VAR \verb+fj_creator+ to the index of the party member who created this projectile (0-5);
-\item STR_VAR \verb+fj_embedded_eff_0+ to ~path/to/v2.eff~ or eff resref containing to projectile's effects* Subsequent indices can be used for additional effects;
-\end{itemize}
+\begin{weiduarguments}
+String variable & \verb+fj_name+ & the projectile filename*; & Empty string \\
+Integer variable & \verb+fj_missile_num+ & the missile.ids reference (projectl.ids - 1); & \verb+-1+ \\
+Integer variable & \verb+fj_frequency+ & the explosion length (in frames); & \verb+0+ \\
+Integer variable & \verb+fj_duration+ & the number of explosions; & \verb+1000+ \\
+Integer variable & \verb+fj_loc_x+ & the X coordinate*; & \verb+0+ \\
+Integer variable & \verb+fj_loc_y+ & the Y coordinate*; & \verb+0+ \\
+Integer variable & \verb+fj_loc_z+ & the height; & \verb+0+ \\
+Integer variable & \verb+fj_target+ & the ea.ids value of the target; & \verb+0+ \\
+Integer variable & \verb+fj_creator+ & the index of the party member who created this projectile (0-5); & \verb+0+ \\
+Caller-scope string series & \verb+fj_embedded_eff_0+ & ~path/to/v2.eff~ or EFF resref containing the projectile's effects*. Define the series contiguously from index 0 before launching the function. & Required \\
+\end{weiduarguments}
+
 A few examples best illustrate the use of this function.
 
 Example 1: add an actor to an area
@@ -10449,23 +10513,25 @@ COPY_EXISTING ar0500.are override
 \end{verbatim}
 Example 2: add a region to an area (in this case, a travel trigger to another area)
 \begin{verbatim}
-  LPF fj_are_structure
-    INT_VAR
-    fj_type         = 2    //travel
-    fj_box_left     = 3415
-    fj_box_top      = 625
-    fj_box_right    = 3450
-    fj_box_bottom   = 700
-    fj_cursor_idx   = 30   //door
-    fj_vertex_0     = 3415 + (625 << 16)
-    fj_vertex_1     = 3450 + (650 << 16)
-    fj_vertex_2     = 3450 + (700 << 16)
-    fj_vertex_3     = 3415 + (676 << 16)
-    STR_VAR
-    fj_structure_type   = region
-    fj_name             = Tran0540
-    fj_destination_area = ag0540
-    fj_destination_name = Exit0500
+  PATCH_WITH_SCOPE BEGIN
+    SET fj_vertex_0 = 3415 + (625 << 16)
+    SET fj_vertex_1 = 3450 + (650 << 16)
+    SET fj_vertex_2 = 3450 + (700 << 16)
+    SET fj_vertex_3 = 3415 + (676 << 16)
+    LPF fj_are_structure
+      INT_VAR
+      fj_type         = 2    //travel
+      fj_box_left     = 3415
+      fj_box_top      = 625
+      fj_box_right    = 3450
+      fj_box_bottom   = 700
+      fj_cursor_idx   = 30   //door
+      STR_VAR
+      fj_structure_type   = region
+      fj_name             = Tran0540
+      fj_destination_area = ag0540
+      fj_destination_name = Exit0500
+    END
   END
 \end{verbatim}
 Example 3: add an entrance (from another area) to an area
@@ -10482,24 +10548,26 @@ Example 3: add an entrance (from another area) to an area
 \end{verbatim}
 Example 4: add a container to an area, then add an item to the new container
 \begin{verbatim}
-  LPF fj_are_structure
-    INT_VAR
-    fj_type        = 8 //nonvisible
-    fj_loc_x       = 4388
-    fj_loc_y       = 2876
-    fj_box_left    = 4372
-    fj_box_top     = 2826
-    fj_box_right   = 4420
-    fj_box_bottom  = 2858
-    fj_trap_loc_x  = 4380
-    fj_trap_loc_y  = 2870
-    fj_vertex_0    = 4411 + (2858 << 16)
-    fj_vertex_1    = 4372 + (2845 << 16)
-    fj_vertex_2    = 4382 + (2826 << 16)
-    fj_vertex_3    = 4420 + (2839 << 16)
-    STR_VAR
-    fj_structure_type = container
-    fj_name           = ~Cornerstone~
+  PATCH_WITH_SCOPE BEGIN
+    SET fj_vertex_0 = 4411 + (2858 << 16)
+    SET fj_vertex_1 = 4372 + (2845 << 16)
+    SET fj_vertex_2 = 4382 + (2826 << 16)
+    SET fj_vertex_3 = 4420 + (2839 << 16)
+    LPF fj_are_structure
+      INT_VAR
+      fj_type        = 8 //nonvisible
+      fj_loc_x       = 4388
+      fj_loc_y       = 2876
+      fj_box_left    = 4372
+      fj_box_top     = 2826
+      fj_box_right   = 4420
+      fj_box_bottom  = 2858
+      fj_trap_loc_x  = 4380
+      fj_trap_loc_y  = 2870
+      STR_VAR
+      fj_structure_type = container
+      fj_name           = ~Cornerstone~
+    END
   END
   LPF fj_are_structure
     INT_VAR
@@ -10512,50 +10580,52 @@ Example 4: add a container to an area, then add an item to the new container
 \end{verbatim}
 Example 5: add a door to an area
 \begin{verbatim}
-  LPF fj_are_structure
-    INT_VAR
-    fj_flags               = 0b100000000
-    fj_open_box_left       = 520
-    fj_open_box_top        = 724
-    fj_open_box_right      = 545
-    fj_open_box_bottom     = 830
-    fj_closed_box_left     = 507
-    fj_closed_box_top      = 761
-    fj_closed_box_right    = 562
-    fj_closed_box_bottom   = 869
-    fj_cursor_idx          = 30
-    fj_trap_loc_x          = 500
-    fj_trap_loc_y          = 852
-    fj_open_loc_x          = 517
-    fj_open_loc_y          = 881
-    fj_closed_loc_x        = 562
-    fj_closed_loc_y        = 814
-    fj_door_open_vert_0    = 520 + (826 << 16)
-    fj_door_open_vert_1    = 527 + (830 << 16)
-    fj_door_open_vert_2    = 545 + (798 << 16)
-    fj_door_open_vert_3    = 545 + (727 << 16)
-    fj_door_open_vert_4    = 539 + (724 << 16)
-    fj_door_open_vert_5    = 520 + (750 << 16)
-    fj_door_closed_vert_0  = 507 + (831 << 16)
-    fj_door_closed_vert_1  = 562 + (869 << 16)
-    fj_door_closed_vert_2  = 562 + (799 << 16)
-    fj_door_closed_vert_3  = 507 + (761 << 16)
-    fj_cell_open_vert_0    = 32 + (68 << 16)
-    fj_cell_open_vert_1    = 33 + (67 << 16)
-    fj_cell_open_vert_2    = 32 + (67 << 16)
-    fj_cell_closed_vert_0  = 32 + (70 << 16)
-    fj_cell_closed_vert_1  = 33 + (71 << 16)
-    fj_cell_closed_vert_2  = 34 + (72 << 16)
-    fj_cell_closed_vert_3  = 34 + (71 << 16)
-    fj_cell_closed_vert_4  = 33 + (70 << 16)
-    fj_cell_closed_vert_5  = 32 + (69 << 16)
-    fj_cell_closed_vert_6  = 32 + (68 << 16)
-    fj_cell_closed_vert_7  = 33 + (69 << 16)
-    fj_cell_closed_vert_8  = 34 + (70 << 16)
-    STR_VAR
-    fj_structure_type      = door
-    fj_name                = Door10
-    fj_door_wed_id         = DOOR10
+  PATCH_WITH_SCOPE BEGIN
+    SET fj_door_open_vert_0   = 520 + (826 << 16)
+    SET fj_door_open_vert_1   = 527 + (830 << 16)
+    SET fj_door_open_vert_2   = 545 + (798 << 16)
+    SET fj_door_open_vert_3   = 545 + (727 << 16)
+    SET fj_door_open_vert_4   = 539 + (724 << 16)
+    SET fj_door_open_vert_5   = 520 + (750 << 16)
+    SET fj_door_closed_vert_0 = 507 + (831 << 16)
+    SET fj_door_closed_vert_1 = 562 + (869 << 16)
+    SET fj_door_closed_vert_2 = 562 + (799 << 16)
+    SET fj_door_closed_vert_3 = 507 + (761 << 16)
+    SET fj_cell_open_vert_0   = 32 + (68 << 16)
+    SET fj_cell_open_vert_1   = 33 + (67 << 16)
+    SET fj_cell_open_vert_2   = 32 + (67 << 16)
+    SET fj_cell_closed_vert_0 = 32 + (70 << 16)
+    SET fj_cell_closed_vert_1 = 33 + (71 << 16)
+    SET fj_cell_closed_vert_2 = 34 + (72 << 16)
+    SET fj_cell_closed_vert_3 = 34 + (71 << 16)
+    SET fj_cell_closed_vert_4 = 33 + (70 << 16)
+    SET fj_cell_closed_vert_5 = 32 + (69 << 16)
+    SET fj_cell_closed_vert_6 = 32 + (68 << 16)
+    SET fj_cell_closed_vert_7 = 33 + (69 << 16)
+    SET fj_cell_closed_vert_8 = 34 + (70 << 16)
+    LPF fj_are_structure
+      INT_VAR
+      fj_flags               = 0b100000000
+      fj_open_box_left       = 520
+      fj_open_box_top        = 724
+      fj_open_box_right      = 545
+      fj_open_box_bottom     = 830
+      fj_closed_box_left     = 507
+      fj_closed_box_top      = 761
+      fj_closed_box_right    = 562
+      fj_closed_box_bottom   = 869
+      fj_cursor_idx          = 30
+      fj_trap_loc_x          = 500
+      fj_trap_loc_y          = 852
+      fj_open_loc_x          = 517
+      fj_open_loc_y          = 881
+      fj_closed_loc_x        = 562
+      fj_closed_loc_y        = 814
+      STR_VAR
+      fj_structure_type      = door
+      fj_name                = Door10
+      fj_door_wed_id         = DOOR10
+    END
   END
 \end{verbatim}
 Example 6: add an animation to an area
@@ -10588,24 +10658,25 @@ Example 7: delete all ambients from an area
 Adds an area to the worldmap. All variables are zero or blank by default unless otherwise indicated.
 This is an ACTION function.
 
-\begin{itemize}
-\item ACTION_DEFINE_ASSOCIATIVE_ARRAY \verb+toNewArea+ to the area references that lead to the new area;
-\item ACTION_DEFINE_ASSOCIATIVE_ARRAY \verb+fromNewArea+ to the area references that lead away from the new area;
-\item STR_VAR \verb+areName+ to the resource reference of the area to add (like "ar0700");
-\item STR_VAR \verb+strName+ to the descriptive name of the area (like "Waukeen's Promenade");
-\item STR_VAR \verb+strDesc+ to the area description that will show up when hovering the cursor over the area on the worldmap;
-\item STR_VAR \verb+worldmap+ to the name of the .wmp file you want patched (default is "worldmap");
-\item INT_VAR \verb+mapIcon+ to the area's map icon index (from mapicons.bam);
-\item INT_VAR \verb+xCoord+ to the area's X (east-west) coordinate;
-\item INT_VAR \verb+yCoord+ to the area's Y (north-south) coordinate;
-\item INT_VAR \verb+tTime+ to the area's travel time in hours * 4 (so 2 = 8 hours);
-\item INT_VAR \verb+inclSv+ to 1 if you want to patch saved game worldmaps as well as the master worldmap. \textbf{NB:} changes to saved games are uninstallable;
-\item INT_VAR \verb+visible+ to 1 if you want the 'visible' flag to be set;
-\item INT_VAR \verb+visibleAdjacent+ to 1 if you want the 'visible from adjacent' flag to be set;
-\item INT_VAR \verb+reachable+ to 1 if you want the 'reachable' flag to be set;
-\item INT_VAR \verb+visited+ to 1 if you want the 'visited' flag to be set;
-\item RET \verb+areNum+ returns the worldmap entry number for the new area;
-\end{itemize}
+\begin{weiduarguments}
+Associative array & \verb+toNewArea+ & the area references that lead to the new area; & Not applicable \\
+Associative array & \verb+fromNewArea+ & the area references that lead away from the new area; & Not applicable \\
+String variable & \verb+areName+ & the resource reference of the area to add (like "ar0700"); & \emph{Not specified} \\
+String variable & \verb+strName+ & the descriptive name of the area (like "Waukeen's Promenade"); & Empty string \\
+String variable & \verb+strDesc+ & the area description that will show up when hovering the cursor over the area on the worldmap; & Empty string \\
+String variable & \verb+worldmap+ & the name of the .wmp file you want patched (default is "worldmap"); & \verb+worldmap+ \\
+Integer variable & \verb+mapIcon+ & the area's map icon index (from mapicons.bam); & \emph{Not specified} \\
+Integer variable & \verb+xCoord+ & the area's X (east-west) coordinate; & \emph{Not specified} \\
+Integer variable & \verb+yCoord+ & the area's Y (north-south) coordinate; & \emph{Not specified} \\
+Integer variable & \verb+tTime+ & the area's travel time in hours * 4 (so 2 = 8 hours); & \emph{Not specified} \\
+Integer variable & \verb+inclSv+ & 1 if you want to patch saved game worldmaps as well as the master worldmap. \textbf{NB:} changes to saved games are uninstallable; & \verb+0+ \\
+Integer variable & \verb+visible+ & 1 if you want the 'visible' flag to be set; & \verb+0+ \\
+Integer variable & \verb+visibleAdjacent+ & 1 if you want the 'visible from adjacent' flag to be set; & \verb+0+ \\
+Integer variable & \verb+reachable+ & 1 if you want the 'reachable' flag to be set; & \verb+0+ \\
+Integer variable & \verb+visited+ & 1 if you want the 'visited' flag to be set; & \verb+0+ \\
+Return value & \verb+areNum+ & the worldmap entry number for the new area; & Not applicable \\
+\end{weiduarguments}
+
 An example best illustrates the use of this function.
 
 \begin{verbatim}

--- a/src/tph/include/fj_are_struct.tpa
+++ b/src/tph/include/fj_are_struct.tpa
@@ -68,7 +68,8 @@ DEFINE_PATCH_FUNCTION fj_are_structure
   // spawns
   fj_spawn_num         = 0
   fj_difficulty        = 0
-  fj_delay             = 10
+  // Shared by spawn points and ambients. Keep one effective function default.
+  fj_delay             = 0
   fj_method            = 0
   fj_duration          = 1000
   fj_wander_dist_spawn = 1000
@@ -111,7 +112,6 @@ DEFINE_PATCH_FUNCTION fj_are_structure
   fj_volume_variance   = 0
   fj_volume            = 80
   fj_sound_num         = 0
-  fj_delay             = 0
   fj_variation         = 0
 
   // variables
@@ -268,8 +268,9 @@ DEFINE_PATCH_FUNCTION fj_are_structure
 
 BEGIN
 
-// we must set $num(0) == num_0 when using function input
-// otherwise WeiDU won't recognize that they're synonymous
+// Convert contiguous caller-scope series into the arrays used below. These
+// dynamically named values are not formal function arguments and must be set
+// before launching fj_are_structure.
 PATCH_FOR_EACH value IN
   vertex door_open_vert door_closed_vert cell_open_vert cell_closed_vert
 BEGIN


### PR DESCRIPTION
## Summary

Replace the standard-library macro and function parameter lists with consistent four-column tables covering:

- variable type;
- variable name;
- description;
- default value.

The resulting documentation contains 88 tables and 864 documented rows.

This also performs an interface-accuracy audit so the tables do not present caller-scope variables, dynamically discovered series, or unused names as formal function arguments.

Closes #49.

Addresses the documentation and calling-convention concerns described in #182.

## Interface accuracy

### Formal arguments versus caller-scope variables

The documentation now establishes the following distinction:

- function inputs are formal arguments unless explicitly identified otherwise;
- macro inputs are caller-scope variables;
- dynamically named caller-scope series must be defined before launching a function and must not be placed in its `INT_VAR` or `STR_VAR` block.

This distinction is particularly important when `MODDER fun_args` checking is enabled.

### `FJ_CRE_VALIDITY` and `FJ_CRE_REINDEX`

The parameter tables now belong to the conventional wrapper interfaces:

- `FL#FJ_CRE_VALIDITY`;
- `FL#FJ_CRE_REINDEX`.

The legacy `FJ_CRE_VALIDITY` and `FJ_CRE_REINDEX` implementations declare no formal arguments. Their documentation now states that they read the corresponding values from caller scope and directs callers using `INT_VAR` to the `FL#` wrappers.

### `fj_are_structure`

The following dynamically numbered inputs are now explicitly documented as caller-scope series rather than formal arguments:

- `fj_vertex_0`, `fj_vertex_1`, …;
- `fj_door_open_vert_0`, `fj_door_open_vert_1`, …;
- `fj_door_closed_vert_0`, `fj_door_closed_vert_1`, …;
- `fj_cell_open_vert_0`, `fj_cell_open_vert_1`, …;
- `fj_cell_closed_vert_0`, `fj_cell_closed_vert_1`, …;
- `fj_embedded_eff_0`, `fj_embedded_eff_1`, ….

Each series must be contiguous from index 0 and defined before launching `fj_are_structure`.

The region, container, and door examples now use `PATCH_WITH_SCOPE`, define these series with `SET` outside the function argument block, and pass only declared arguments through `INT_VAR` and `STR_VAR`.

The corresponding implementation comment in `fj_are_struct.tpa` has been updated to describe the actual caller-scope-to-array conversion.

### Removed nonexistent inputs

The projectile documentation no longer lists:

- `fj_eff_off`;
- `fj_eff_size`.

Neither name is declared nor read by the current `fj_are_structure` implementation.

### Corrected defaults

The audit also corrected the documented defaults for the ranged formal arguments:

- `fj_weight0...fj_weight9`: `0`;
- `fj_cre_strref0...fj_cre_strref9`: `-1`;
- `fj_cre_resref0...fj_cre_resref9`: empty string.

`fj_delay` previously appeared twice in the function declaration with conflicting values (`10` and `0`). WeiDU applies function defaults in declaration order, so the later `0` declaration was already the effective runtime default. The declaration has been consolidated to one documented `0` default without changing runtime behavior.

### `ADD_AREA_REGION_TRIGGER`

The `ab_RT_*` table is now explicitly identified as the working macro interface.

The same-named function declares an `AREA_RT_*` interface but launches the current `ab_RT_*` macro without forwarding those formal arguments. The documentation no longer presents the macro variables as working function parameters.

The dynamically constructed `ab_RT_Vx_X_n` and `ab_RT_Vx_Y_n` values are explicitly labeled caller-scope series.

## Validation

A temporary, branch-specific GitHub Actions workflow was used for validation:

https://github.com/4Luke4/weidu/actions/runs/32709908955

The successful job:

1. rendered `README-WeiDU.html`;
2. derived the expected table and row totals from `doc/base.tex` rather than hardcoding them;
3. verified parity between the TeX source and rendered HTML;
4. verified that every rendered row contains exactly four non-empty cells;
5. checked every documented non-return name against `src/tph`;
6. required names without a literal implementation declaration to be explicitly classified as caller-scope series;
7. checked that documentation examples do not pass caller-scope series through function argument blocks;
8. built WeiDU using the archived OCaml 4.08.1 unsafe-string configuration from PR #381;
9. ran `--nogame --parse-check TPA src/tph/include/fj_are_struct.tpa`;
10. required WeiDU's explicit successful-parse confirmation instead of relying solely on its process exit status.

Reported audit result:

```text
validated 88 rendered tables, 864 rows, and 9 explicit caller-scope series
File [src/tph/include/fj_are_struct.tpa] was successfully parsed as type [TPA]
```

The temporary workflow and its temporary exclusion from the normal workflow were removed from branch history after validation. The final branch contains no `.github` changes.

## Existing workflow failures

The cleanup push also invoked the repository's existing `main` workflow:

https://github.com/4Luke4/weidu/actions/runs/32710091868

Its results reproduce the unrelated baseline failures covered by the existing pull requests:

- Linux fails during OCaml setup because the unmodified workflow cannot resolve `4.08.1+default-unsafe-string`; this is the exact failure addressed by [PR #381](https://github.com/WeiDUorg/weidu/pull/381).
- Windows fails while compiling the unchanged `src/reg.c` Win32 API calls; this is the exact failure addressed by [PR #382](https://github.com/WeiDUorg/weidu/pull/382).
- Both macOS builds succeed.

Those failures occur outside the files changed by this pull request and are not used as validation evidence.