### PR TITLE
Fix --extract-kits on Enhanced Edition table layouts

### DIFF
--- a/README-WeiDU-Changes.txt
+++ b/README-WeiDU-Changes.txt
@@ -1,4 +1,8 @@
 Version 251:
+  * Fix --extract-kits on Enhanced Edition games. Table lookups are now
+    case-insensitive, WEAPPROF and 25STWEAP columns follow KITLIST's
+    PROFICIENCY value, optional kit tables are supported, and missing
+    ability tables are reported instead of being silently substituted.
   * CREATE called within CREATE works as expected.
   * CREATE sets SOURCE_* and DEST_* variables.
   * Auto-update does not fail if the filename of the newest WeiDU

--- a/doc/base.tex
+++ b/doc/base.tex
@@ -1234,8 +1234,11 @@ commands of the form \t{STRING_SET "Hello" @1} instead of \t{STRING_SET \#1
 \multicolumn{2}{c}{ \color{red} Automatic Module Packaging Options} \\
 \DEFINE{--automate} \t{X}&   Automatically create a \ttref{TP2} file for resources in folder \t{X}. See \ttref{--out}. \\
 \DEFINE{--automate-min} \t{X}& Only \ttref{--automate} string references above \t{X}. If not specified, it is assumed as 62169 (that is, the number of strings in unmodded SoA). \\
-\DEFINE{--extract-kits} \t{X} & Extract all kits starting with kit \#\t{X}
-and create \ttref{TP2} actions to install those kits as part of a module.  \\
+\DEFINE{--extract-kits} \t{X} & Extract all kits whose numeric
+\t{KITLIST.2DA} row is greater than or equal to the positive integer \t{X},
+and create \ttref{ADD_KIT} actions to install those kits as part of a module.
+The extraction covers the data represented by \ttref{ADD_KIT}; other
+engine-specific kit metadata is not copied.  \\
 \\
 \multicolumn{2}{c}{ \color{red} Logging Options } \\
 

--- a/src/kit.ml
+++ b/src/kit.ml
@@ -10,178 +10,314 @@ open Util
 let lines buffer = Str.split (Str.regexp "[\r\n]+") buffer
 let words buffer = Str.split (Str.regexp "[ \t]+") buffer
 
-let extract game o output_dir min_num =
-  let load name =
-    let buff, path = Load.load_resource "extract kit" game true name "2DA" in
-    lines buff
-  in
-  let kitlist_l  = load "KITLIST"  in
-  let clasweap_l = load "CLASWEAP" in
-  let abclasrq_l = load "ABCLASRQ" in
-  let abclsmod_l = load "ABCLSMOD" in
-  let abdcdsrq_l = load "ABDCDSRQ" in
-  let abdcscrq_l = load "ABDCSCRQ" in
-  let alignmnt_l = load "ALIGNMNT" in
-  let dualclas_l = load "DUALCLAS" in
-  let kittable_l = load "KITTABLE" in
-  let weapprof_l = load "WEAPPROF" in
-  let tfstweap_l = load "25STWEAP" in
-  let luabbr_l   = load "LUABBR" in
+let fix_me = "!XXX YOU MUST FIX ME XXX!"
 
-  let rec get_line_starting_with line_list s_regexp = match line_list with
-  | [] -> raise Not_found
-  | hd :: tl ->
-      begin
-        try
-          let i = Str.search_forward s_regexp hd 0 in
-          if i = 0 then hd
-          else raise Not_found
-        with _ -> get_line_starting_with tl s_regexp
-      end
+type table = {
+  resource : string;
+  default : string;
+  headers : string array;
+  rows : string array list;
+}
+
+type extracted_kit = {
+  name : string;
+  lower : string;
+  mixed : string;
+  help : string;
+  abilities : string;
+  ability_buffer : string;
+  clasweap : string;
+  weapprof : string;
+  abclasrq : string;
+  abclsmod : string;
+  abdcdsrq : string;
+  abdcscrq : string;
+  alignmnt : string;
+  dualclas : string;
+  include_in : string list;
+  unusable : string;
+  klass : string;
+  luabbr : string;
+  tfstweap : string list;
+}
+
+let equal_ci a b = String.lowercase a = String.lowercase b
+
+let int_of_string_opt string =
+  try Some (int_of_string string) with Failure _ -> None
+
+let parse_table resource buffer =
+  let token_lines =
+    List.filter (fun line -> line <> [])
+      (List.map words (lines buffer))
   in
-  let get_line line_list str =
-    let s_regexp = Str.regexp str in
-    try
-      get_line_starting_with line_list s_regexp
-    with _ -> begin
-      log_and_print "Kit.extract: cannot find line starting with ~%s~\n" str ;
-      "!XXX YOU MUST FIX ME XXX!"
-    end
+  match token_lines with
+  | signature :: default :: headers :: rows
+      when signature <> [] && equal_ci (List.hd signature) "2DA" &&
+           default <> [] && headers <> [] ->
+      { resource = resource;
+        default = List.hd default;
+        headers = Array.of_list headers;
+        rows = List.map Array.of_list rows; }
+  | _ ->
+      failwith (Printf.sprintf
+        "ERROR: --extract-kits cannot parse %s.2DA: invalid 2DA structure"
+        resource)
+
+let load_table game resource =
+  let buffer, _ =
+    Load.load_resource "extracting kits" game true resource "2DA"
   in
+  parse_table resource buffer
+
+let load_required_table game resource =
+  if not (Load.resource_exists game resource "2DA") then
+    failwith (Printf.sprintf
+      "ERROR: --extract-kits requires %s.2DA, but that resource is not present"
+      resource);
+  load_table game resource
+
+let load_optional_table game resource =
+  if Load.resource_exists game resource "2DA" then
+    Some (load_table game resource)
+  else
+    None
+
+let find_row table name =
+  List.find (fun row ->
+    Array.length row > 0 && equal_ci row.(0) name) table.rows
+
+let row_or_fix table name =
+  try String.concat " " (Array.to_list (find_row table name))
+  with Not_found ->
+    log_and_print
+      "Kit.extract: cannot find row ~%s~ in %s.2DA\n"
+      name table.resource;
+    fix_me
+
+let find_header table name =
+  let result = ref None in
+  Array.iteri (fun index header ->
+    if !result = None && equal_ci header name then result := Some index)
+    table.headers;
+  !result
+
+let column_at table index =
+  if index < 0 || index >= Array.length table.headers then
+    failwith (Printf.sprintf
+      "ERROR: --extract-kits: column %d is outside %s.2DA's %d-column header"
+      index table.resource (Array.length table.headers));
+  List.map (fun row ->
+    let value_index = index + 1 in
+    if value_index < Array.length row then row.(value_index)
+    else table.default) table.rows
+
+let write_file path buffer =
+  let channel = Case_ins.perv_open_out_bin path in
+  try
+    output_string channel buffer;
+    close_out channel
+  with e ->
+    close_out_noerr channel;
+    raise e
+
+let extract game o output_dir min_num =
+  if min_num < 1 then
+    failwith "ERROR: --extract-kits requires a positive starting kit number";
+
+  (* These resources hold fields required by ADD_KIT. The remaining tables
+     are optional because ADD_KIT itself updates them only IF_EXISTS. *)
+  let kitlist = load_required_table game "KITLIST" in
+  let clasweap = load_required_table game "CLASWEAP" in
+  let abclasrq = load_required_table game "ABCLASRQ" in
+  let abclsmod = load_required_table game "ABCLSMOD" in
+  let abdcdsrq = load_required_table game "ABDCDSRQ" in
+  let abdcscrq = load_required_table game "ABDCSCRQ" in
+  let alignmnt = load_required_table game "ALIGNMNT" in
+  let dualclas = load_required_table game "DUALCLAS" in
+  let weapprof = load_required_table game "WEAPPROF" in
+  let kittable = load_optional_table game "KITTABLE" in
+  let tfstweap = load_optional_table game "25STWEAP" in
+  let luabbr = load_optional_table game "LUABBR" in
 
   let kittable_list = ref [] in
-
-  List.iter (fun ktl ->
-    let ktw = words ktl in
-    if (List.length ktw >= 8) then begin
-      List.iter (fun ktw ->
-        try
-          Load.skip_next_load_error := true ;
-          let buff, _ = Load.load_resource "extract kit" game true ktw "2DA" in
-          kittable_list := (ktw,(lines buff)) :: !kittable_list
-        with _ -> ()) ktw
-    end) kittable_l ;
+  begin match kittable with
+  | None -> ()
+  | Some table ->
+      let seen = Hashtbl.create 31 in
+      List.iter (fun row ->
+        for index = 1 to Array.length row - 1 do
+          let resource = row.(index) in
+          let key = String.lowercase resource in
+          if not (Hashtbl.mem seen key) then begin
+            Hashtbl.add seen key true;
+            if Load.resource_exists game resource "2DA" then
+              kittable_list :=
+                (resource, load_table game resource) :: !kittable_list
+          end
+        done) table.rows
+  end;
 
   let kittable_mentions id =
-    let partial = List.filter (fun (nom, lines) ->
-      List.exists (fun line ->
-        let words = words line in
-        List.length words > 1 && (
-        try int_of_string (List.nth words 1) == id
-        with _ -> false)) lines) !kittable_list in
-    List.map (fun (nom,_) -> nom) partial
+    let mentions_id (_, table) =
+      List.exists (fun row ->
+        Array.length row > 1 && int_of_string_opt row.(1) = Some id)
+        table.rows
+    in
+    List.map fst (List.filter mentions_id (List.rev !kittable_list))
   in
 
-  let get_col ll name =
-    let where = ref (-1) in
-    let res = ref [] in
-    List.iter (fun line ->
-      let w = Array.of_list (words line) in
-      if (!where = -1) then begin
-        for i = 0 to (Array.length w) - 1 do
-          if w.(i) = name then where := (i+1)
-        done
-      end else begin
-        res := w.(!where) :: !res
-      end) ll ;
-    List.rev !res
+  let selected_rows =
+    List.fold_left (fun selected row ->
+      if Array.length row = 0 then selected
+      else match int_of_string_opt row.(0) with
+      | None -> selected
+      | Some id when id < min_num -> selected
+      | Some id when Array.length row < 9 ->
+          failwith (Printf.sprintf
+            "ERROR: --extract-kits: kit %d in KITLIST.2DA has %d fields; expected at least 9"
+            id (Array.length row))
+      | Some _ -> row :: selected) [] kitlist.rows
+    |> List.rev
   in
 
-  let abils = Hashtbl.create 511 in
-  let process_ability buff =
+  let abilities = Hashtbl.create 31 in
+  let spells = Hashtbl.create 511 in
+  let process_ability buffer =
     List.iter (fun line ->
       List.iter (fun word ->
-        if (String.length word > 4 && word.[2] = '_') then begin
-          let spl = Str.string_after word 3 in
-          Hashtbl.add abils spl true
-        end) (words line)) (lines buff)
+        if String.length word > 4 && word.[2] = '_' then
+          Hashtbl.replace spells (Str.string_after word 3) true)
+        (words line)) (lines buffer)
   in
 
-  List.iter (fun kitlist_line ->
-    let kitlist_w = words kitlist_line in
-    try
-      if (List.length kitlist_w >= 9) &&
-        int_of_string (List.hd kitlist_w) > min_num then begin
-          let id = int_of_string (List.hd kitlist_w) in
-          let name = List.nth kitlist_w 1 in
-          let lower = List.nth kitlist_w 2 in
-          let mixed = List.nth kitlist_w 3 in
-          let help = List.nth kitlist_w 4 in
-          let abilities = List.nth kitlist_w 5 in
-          let prof = List.nth kitlist_w 6 in
-          let unusable = List.nth kitlist_w 7 in
-          let klass = List.nth kitlist_w 8 in
-          log_and_print "Kit.extract: Processing %s\n" name ;
-
-
-          o (Printf.sprintf "ADD_KIT ~%s~\n" name) ;
-          o (Printf.sprintf "~%s~\n" (get_line clasweap_l name)) ;
-          o (Printf.sprintf "~%s" name) ;
-          List.iter (fun w -> o (Printf.sprintf " %s " w))
-            (get_col weapprof_l name) ;
-          o (Printf.sprintf "~\n" ) ;
-          List.iter (fun ll ->
-            o (Printf.sprintf "~%s~\n" (get_line ll name)) ;
-                    ) [ abclasrq_l ; abclsmod_l ; abdcdsrq_l ; abdcscrq_l ;
-                        alignmnt_l ; dualclas_l ; ] ;
-
-          let buff, _ =
-            try Load.load_resource "extract kit" game true abilities "2DA"
-            with _ ->
-              Load.load_resource "extract kit" game true "clabfi01" "2DA" in
-          let dst = Printf.sprintf "%s/%s.2DA" output_dir abilities in
-          o (Printf.sprintf "~%s~\n" dst) ;
-          let oc = Case_ins.perv_open_out_bin dst in
-          output_string oc buff ;
-          close_out oc ;
-          process_ability buff;
-
-          o (Printf.sprintf "~" ) ;
-          List.iter (fun s -> o (Printf.sprintf " %s " s))
-            (kittable_mentions id) ;
-          o (Printf.sprintf "~\n" ) ;
-
-          o (Printf.sprintf "~%s %s~\n" unusable klass) ;
-
-          let ll = try
-            let the_line = get_line luabbr_l name in
-            let the_words = words the_line in
-            List.nth the_words 1
-          with _ -> "Fi0"
-          in
-          o (Printf.sprintf "~%s~\n" ll) ;
-
-          o (Printf.sprintf "~" ) ;
-          List.iter (fun w -> o (Printf.sprintf " %s " w))
-            (get_col tfstweap_l name) ;
-          o (Printf.sprintf "~\n" ) ;
-
-          List.iter (fun str ->
-            let i = int_of_string str in
-            let male = Tlk.pretty_print (Load.get_active_dialog game) i in
-            let female = Tlk.pretty_print_opt
-                (Load.get_active_dialogf_opt game) i in
-            if (female = "" || male = female) then
-              o (Printf.sprintf "SAY %s\n" male)
-            else
-              o (Printf.sprintf "SAY %s %s\n" male female))
-            [ lower ; mixed ; help ] ;
-
-          o "\n\n/**************************************************************************/\n\n"
+  let prepare_kit row =
+    let id = int_of_string row.(0) in
+    let name = row.(1) in
+    let ability = row.(5) in
+    let proficiency = match int_of_string_opt row.(6) with
+    | Some value -> value
+    | None -> failwith (Printf.sprintf
+        "ERROR: --extract-kits: kit %s has invalid PROFICIENCY value ~%s~ in KITLIST.2DA"
+        name row.(6))
+    in
+    if proficiency < 0 || proficiency >= Array.length weapprof.headers then
+      failwith (Printf.sprintf
+        "ERROR: --extract-kits: kit %s refers to missing WEAPPROF.2DA column %d"
+        name proficiency);
+    let ability_buffer =
+      try Hashtbl.find abilities (String.lowercase ability)
+      with Not_found ->
+        if not (Load.resource_exists game ability "2DA") then
+          failwith (Printf.sprintf
+            "ERROR: --extract-kits: kit %s refers to missing ability table %s.2DA"
+            name ability);
+        let buffer, _ =
+          Load.load_resource "extracting a kit ability table" game true
+            ability "2DA"
+        in
+        Hashtbl.add abilities (String.lowercase ability) buffer;
+        process_ability buffer;
+        buffer
+    in
+    let profile_name = weapprof.headers.(proficiency) in
+    let tfstweap_values = match tfstweap with
+    | None -> []
+    | Some table ->
+        let column = match find_header table name with
+        | Some index -> Some index
+        | None -> find_header table profile_name
+        in
+        begin match column with
+        | Some index -> column_at table index
+        | None ->
+            log_and_print
+              "Kit.extract: cannot find kit ~%s~ or proficiency profile ~%s~ in %s.2DA; using its default column\n"
+              name profile_name table.resource;
+            List.map (fun _ -> table.default) table.rows
         end
-    with e -> begin
-      log_and_print "\nKit.extract: ~%s~\n\t%s\n\n" kitlist_line
-        (printexc_to_string e) ; exit 1
-    end) kitlist_l ;
+    in
+    let luabbr_value = match luabbr with
+    | None -> ""
+    | Some table ->
+        try
+          let row = find_row table name in
+          if Array.length row > 1 then row.(1) else table.default
+        with Not_found ->
+          log_and_print
+            "Kit.extract: cannot find row ~%s~ in %s.2DA\n"
+            name table.resource;
+          fix_me
+    in
+    { name = name;
+      lower = row.(2);
+      mixed = row.(3);
+      help = row.(4);
+      abilities = ability;
+      ability_buffer = ability_buffer;
+      clasweap = row_or_fix clasweap name;
+      weapprof = String.concat " " (name :: column_at weapprof proficiency);
+      abclasrq = row_or_fix abclasrq name;
+      abclsmod = row_or_fix abclsmod name;
+      abdcdsrq = row_or_fix abdcdsrq name;
+      abdcscrq = row_or_fix abdcscrq name;
+      alignmnt = row_or_fix alignmnt name;
+      dualclas = row_or_fix dualclas name;
+      include_in = kittable_mentions id;
+      unusable = row.(7);
+      klass = row.(8);
+      luabbr = luabbr_value;
+      tfstweap = tfstweap_values; }
+  in
 
-  Hashtbl.iter (fun k _ ->
-    try
-      let buff, _ = Load.load_resource "extract kit" game true k "SPL" in
-      let dst = Printf.sprintf "%s/%s.SPL" output_dir k in
-      let oc = Case_ins.perv_open_out_bin dst in
-      output_string oc buff ;
-      close_out oc ;
-    with _ -> ()) abils ;
-  Automate.automate game [output_dir] 0 o ;
+  (* Prepare every kit, referenced table and string before creating output. *)
+  let kits = List.map prepare_kit selected_rows in
+  let spell_files = Hashtbl.fold (fun spell _ files ->
+    if Load.resource_exists game spell "SPL" then
+      let buffer, _ =
+        Load.load_resource "extracting a kit ability" game true spell "SPL"
+      in
+      (spell, buffer) :: files
+    else files) spells []
+  in
+  let output = Buffer.create 4096 in
+  let add format = Printf.bprintf output format in
+  List.iter (fun kit ->
+    log_and_print "Kit.extract: Processing %s\n" kit.name;
+    add "ADD_KIT ~%s~\n" kit.name;
+    add "~%s~\n" kit.clasweap;
+    add "~%s~\n" kit.weapprof;
+    List.iter (fun row -> add "~%s~\n" row)
+      [ kit.abclasrq; kit.abclsmod; kit.abdcdsrq; kit.abdcscrq;
+        kit.alignmnt; kit.dualclas ];
+    add "~%s/%s.2DA~\n" output_dir kit.abilities;
+    add "~%s~\n" (String.concat " " kit.include_in);
+    add "~%s %s~\n" kit.unusable kit.klass;
+    add "~%s~\n" kit.luabbr;
+    add "~%s~\n" (String.concat " " kit.tfstweap);
+    List.iter (fun string_ref ->
+      let index = match int_of_string_opt string_ref with
+      | Some value -> value
+      | None -> failwith (Printf.sprintf
+          "ERROR: --extract-kits: kit %s has invalid string reference ~%s~ in KITLIST.2DA"
+          kit.name string_ref)
+      in
+      let male = Tlk.pretty_print (Load.get_active_dialog game) index in
+      let female =
+        Tlk.pretty_print_opt (Load.get_active_dialogf_opt game) index
+      in
+      if female = "" || male = female then add "SAY %s\n" male
+      else add "SAY %s %s\n" male female)
+      [ kit.lower; kit.mixed; kit.help ];
+    add "\n\n/**************************************************************************/\n\n")
+    kits;
 
-  ()
+  List.iter (fun kit ->
+    write_file
+      (Printf.sprintf "%s/%s.2DA" output_dir kit.abilities)
+      kit.ability_buffer) kits;
+  List.iter (fun (spell, buffer) ->
+    write_file (Printf.sprintf "%s/%s.SPL" output_dir spell) buffer)
+    spell_files;
+  o (Buffer.contents output);
+  Automate.automate game [output_dir] 0 o

--- a/src/main.ml
+++ b/src/main.ml
@@ -1414,7 +1414,7 @@ let main () =
   let tlk_merge = ref [] in
 
   let extract_tlk = ref false in
-  let extract_kits = ref (0) in
+  let extract_kits = ref None in
 
   let tp_list = ref [] in
 
@@ -1598,7 +1598,7 @@ let main () =
     "--out", Myarg.String (set_theout false), "X\temit to file or directory X" ;
     "--append", Myarg.String (set_theout true), "X\tappend to file or directory X" ;
     "--backup", Myarg.String (fun s -> backup_dir := Some(s)), "X\tbackup files to directory X before overwriting" ;
-    "--extract-kits", Myarg.Int (fun d -> extract_kits := d), "X\textract all kits starting with kit #X";
+    "--extract-kits", Myarg.Int (fun d -> extract_kits := Some d), "X\textract all kits starting with kit #X";
     "--tlkout", Myarg.String (fun s -> output_dialog := Some(s) ; test_output_tlk_p := true), "X\temit X as new DIALOG.TLK" ;
     "--ftlkout", Myarg.String (fun s -> output_dialogf := Some(s) ; test_output_tlk_p := true), "X\temit X as new DIALOGF.TLK" ;
 
@@ -1868,8 +1868,13 @@ let main () =
   end);
 
 
-  (if !extract_kits > 0 then Kit.extract game (output_string (Lazy.force theout.chan)) theout.dir
-      !extract_kits) ;
+  (match !extract_kits with
+  | Some min_kit ->
+      if_bgee_check_lang_or_fail game ;
+      Kit.extract game
+        (fun string -> output_string (Lazy.force theout.chan) string)
+        theout.dir min_kit
+  | None -> ()) ;
 
 
   if !cmp_dest <> None then


### PR DESCRIPTION
Closes #283

## Summary

- Parse kit-related 2DA resources structurally and match row/header keys exactly but case-insensitively, handling the capitalization differences present in Enhanced Edition tables.
- Select WEAPPROF data from KITLIST.PROFICIENCY and use that resolved profile as the fallback for 25STWEAP, which supports shared profiles without kit-specific assumptions.
- Treat KITTABLE, LUABBR, and 25STWEAP as optional, while reporting missing required resources and referenced CLAB tables with contextual errors.
- Make the starting kit number inclusive as documented, reject non-positive values, preflight all selected kits before emitting output, and require EE language selection before resolving TLK strings.
- Document that extraction covers the data represented by ADD_KIT, rather than additional engine-specific metadata.

## Validation

- [Disposable issue #283 workflow](https://github.com/4Luke4/weidu/actions/runs/32874465642): built WeiDU with OCaml 4.08 and derived fixtures from pinned IESDP revision `28326f4597722ddb2ea514df7f0472fdbad2c34e`. It dynamically exercised case-mismatched rows, a shared PROFICIENCY profile, the inclusive cutoff, optional-table absence, required-resource and CLAB failures, PSTEE missing-resource reporting, generated-action parsing, and a clean-fixture ADD_KIT round trip with table-by-table comparisons.
- [Full build/package matrix](https://github.com/4Luke4/weidu/actions/runs/32874465495): Linux, Windows, Apple Silicon macOS, and Intel macOS all passed. The exact current heads of #381 (`23006f5`) and #382 (`92a77d3`) were temporarily layered solely to avoid their known unrelated failures.
- The disposable workflow, fixture driver, and temporary #381/#382 commits were removed from branch history after validation; the PR branch contains only the production commit.