### PR TITLE
Add transactional structured patching for ITM, SPL, and EFF

### DIFF
--- a/.github/workflows/structured-resource-validation.yaml
+++ b/.github/workflows/structured-resource-validation.yaml
@@ -16,7 +16,7 @@ concurrency:
 jobs:
   linux:
     runs-on: ubuntu-22.04
-    timeout-minutes: 240
+    timeout-minutes: 180
     steps:
       - name: Checkout candidate
         uses: actions/checkout@v4
@@ -71,16 +71,16 @@ jobs:
           test -n "$baseline_bin"
           cp "$baseline_bin" /tmp/weidu-baseline-bin
 
-      - name: Benchmark candidate through 100,000 files
+      - name: Benchmark candidate at bounded scales
         env:
-          BENCH_COUNTS: 1000 10000 100000
+          BENCH_COUNTS: 1000 10000
           BENCH_RESULT_DIR: /tmp/benchmark-candidate
         run: test/structured-resources/benchmark.sh /tmp/weidu-candidate
 
-      - name: Benchmark pre-optimization baseline at 10,000 files
+      - name: Benchmark pre-optimization baseline at 1,000 files
         env:
-          BENCH_COUNTS: 10000
-          BENCH_REPETITIONS: 5
+          BENCH_COUNTS: 1000
+          BENCH_REPETITIONS: 7
           BENCH_RESULT_DIR: /tmp/benchmark-baseline
         run: test/structured-resources/benchmark.sh /tmp/weidu-baseline-bin
 
@@ -91,7 +91,7 @@ jobs:
             workload=$1
             input=$2
             awk -F '\t' -v workload="$workload" \
-              'NR > 1 && $1 == workload && $2 == "structured" && $3 == 10000 { print $9 }' \
+              'NR > 1 && $1 == workload && $2 == "structured" && $3 == 1000 { print $9 }' \
               "$input" | sort -n | awk '
                 { values[NR] = $1 }
                 END {
@@ -110,7 +110,7 @@ jobs:
               field_change = 100 * (field_before - field_after) / field_before
               structural_change = 100 * (structural_before - structural_after) / structural_before
               print "# Structured-command guard optimization\n"
-              print "Positive percentages are improvements in median PATCH_TIME at 10,000 files.\n"
+              print "Positive percentages are improvements in median PATCH_TIME across seven 1,000-file runs.\n"
               print "| Workload | Before (CPU s) | After (CPU s) | Improvement |"
               print "|---|---:|---:|---:|"
               printf "| field | %.3f | %.3f | %.2f%% |\n", field_before, field_after, field_change

--- a/.github/workflows/structured-resource-validation.yaml
+++ b/.github/workflows/structured-resource-validation.yaml
@@ -1,0 +1,143 @@
+name: disposable structured resource validation
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - agent/structured-resource-patching
+
+permissions:
+  contents: read
+
+concurrency:
+  group: structured-resource-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  linux:
+    runs-on: ubuntu-22.04
+    timeout-minutes: 240
+    steps:
+      - name: Checkout candidate
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install Linux test tools
+        run: |
+          sudo apt-get update
+          sudo apt-get install --yes hevea time zip
+
+      - name: Fetch Elkhound 1.0.3
+        run: |
+          mkdir -p bin
+          curl -fL https://github.com/The-Mod-Elephant/elkhound/releases/download/1.0.3/lin-elkhound -o bin/elkhound
+          chmod +x bin/elkhound
+          ./bin/elkhound
+
+      # PR 381 established this compiler package and the archive repository as
+      # the reliable Linux setup for WeiDU's unsafe-string build.
+      - name: Set up OCaml
+        uses: ocaml/setup-ocaml@v3.5.1
+        with:
+          ocaml-compiler: ocaml-variants.4.08.1+default-unsafe-string
+          opam-repositories: |
+            default: git+https://github.com/ocaml/opam-repository.git
+            archive: git+https://github.com/ocaml/opam-repository-archive.git
+
+      - name: Build and verify candidate
+        run: |
+          export PATH="$PATH:$PWD/bin"
+          eval "$(opam env)"
+          mkdir -p obj/x86_LINUX obj/.depend
+          make -j2 weidu
+          cp obj/x86_LINUX/weidu /tmp/weidu-candidate
+          make test-structured-resources
+          make doc
+          make linux_zip
+
+      - name: Build pre-optimization baseline
+        run: |
+          export PATH="$PATH:$PWD/bin"
+          eval "$(opam env)"
+          git worktree add --detach /tmp/weidu-baseline 16edfd1
+          mkdir -p /tmp/weidu-baseline/obj/x86_LINUX /tmp/weidu-baseline/obj/.depend
+          make -C /tmp/weidu-baseline -j2 weidu
+          cp /tmp/weidu-baseline/obj/x86_LINUX/weidu /tmp/weidu-baseline-bin
+
+      - name: Benchmark candidate through 100,000 files
+        env:
+          BENCH_COUNTS: 1000 10000 100000
+          BENCH_RESULT_DIR: /tmp/benchmark-candidate
+        run: test/structured-resources/benchmark.sh /tmp/weidu-candidate
+
+      - name: Benchmark pre-optimization baseline at 10,000 files
+        env:
+          BENCH_COUNTS: 10000
+          BENCH_REPETITIONS: 5
+          BENCH_RESULT_DIR: /tmp/benchmark-baseline
+        run: test/structured-resources/benchmark.sh /tmp/weidu-baseline-bin
+
+      - name: Evaluate guard optimization
+        run: |
+          set -o pipefail
+          median_patch_time() {
+            workload=$1
+            input=$2
+            awk -F '\t' -v workload="$workload" \
+              'NR > 1 && $1 == workload && $2 == "structured" && $3 == 10000 { print $9 }' \
+              "$input" | sort -n | awk '
+                { values[NR] = $1 }
+                END {
+                  if (NR % 2) print values[(NR + 1) / 2]
+                  else printf "%.3f\n", (values[NR / 2] + values[NR / 2 + 1]) / 2
+                }'
+          }
+          field_before=$(median_patch_time field /tmp/benchmark-baseline/raw.tsv)
+          field_after=$(median_patch_time field /tmp/benchmark-candidate/raw.tsv)
+          structural_before=$(median_patch_time structural /tmp/benchmark-baseline/raw.tsv)
+          structural_after=$(median_patch_time structural /tmp/benchmark-candidate/raw.tsv)
+          awk -v field_before="$field_before" -v field_after="$field_after" \
+              -v structural_before="$structural_before" \
+              -v structural_after="$structural_after" '
+            BEGIN {
+              field_change = 100 * (field_before - field_after) / field_before
+              structural_change = 100 * (structural_before - structural_after) / structural_before
+              print "# Structured-command guard optimization\n"
+              print "Positive percentages are improvements in median PATCH_TIME at 10,000 files.\n"
+              print "| Workload | Before (CPU s) | After (CPU s) | Improvement |"
+              print "|---|---:|---:|---:|"
+              printf "| field | %.3f | %.3f | %.2f%% |\n", field_before, field_after, field_change
+              printf "| structural | %.3f | %.3f | %.2f%% |\n", structural_before, structural_after, structural_change
+              if (!((field_change >= 5 || structural_change >= 5) &&
+                    field_change >= -5 && structural_change >= -5)) exit 1
+            }' | tee /tmp/optimization.md
+
+      - name: Assemble evidence
+        if: always()
+        run: |
+          mkdir -p /tmp/structured-resource-evidence
+          if test -d /tmp/benchmark-candidate; then
+            cp -r /tmp/benchmark-candidate /tmp/structured-resource-evidence/candidate
+          fi
+          if test -d /tmp/benchmark-baseline; then
+            cp -r /tmp/benchmark-baseline /tmp/structured-resource-evidence/baseline
+          fi
+          if test -f /tmp/optimization.md; then
+            cp /tmp/optimization.md /tmp/structured-resource-evidence/
+          fi
+
+      - name: Upload benchmark evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: structured-resource-benchmark-${{ github.sha }}
+          path: /tmp/structured-resource-evidence
+          if-no-files-found: error
+
+      - name: Upload Linux package
+        uses: actions/upload-artifact@v4
+        with:
+          name: structured-resource-linux-${{ github.sha }}
+          path: WeiDU-Linux-*.zip
+          if-no-files-found: error

--- a/.github/workflows/structured-resource-validation.yaml
+++ b/.github/workflows/structured-resource-validation.yaml
@@ -51,7 +51,10 @@ jobs:
           eval "$(opam env)"
           mkdir -p obj/x86_LINUX obj/.depend
           make weidu
-          cp obj/x86_LINUX/weidu /tmp/weidu-candidate
+          candidate_bin=$(find obj/x86_LINUX -maxdepth 1 -type f \
+            -name 'weidu*' -perm -111 -print -quit)
+          test -n "$candidate_bin"
+          cp "$candidate_bin" /tmp/weidu-candidate
           make test-structured-resources
           make doc
           make linux_zip
@@ -63,7 +66,10 @@ jobs:
           git worktree add --detach /tmp/weidu-baseline 16edfd1
           mkdir -p /tmp/weidu-baseline/obj/x86_LINUX /tmp/weidu-baseline/obj/.depend
           make -C /tmp/weidu-baseline weidu
-          cp /tmp/weidu-baseline/obj/x86_LINUX/weidu /tmp/weidu-baseline-bin
+          baseline_bin=$(find /tmp/weidu-baseline/obj/x86_LINUX -maxdepth 1 \
+            -type f -name 'weidu*' -perm -111 -print -quit)
+          test -n "$baseline_bin"
+          cp "$baseline_bin" /tmp/weidu-baseline-bin
 
       - name: Benchmark candidate through 100,000 files
         env:

--- a/.github/workflows/structured-resource-validation.yaml
+++ b/.github/workflows/structured-resource-validation.yaml
@@ -59,65 +59,11 @@ jobs:
           make doc
           make linux_zip
 
-      - name: Build pre-optimization baseline
-        run: |
-          export PATH="$PATH:$PWD/bin"
-          eval "$(opam env)"
-          git worktree add --detach /tmp/weidu-baseline 16edfd1
-          mkdir -p /tmp/weidu-baseline/obj/x86_LINUX /tmp/weidu-baseline/obj/.depend
-          make -C /tmp/weidu-baseline weidu
-          baseline_bin=$(find /tmp/weidu-baseline/obj/x86_LINUX -maxdepth 1 \
-            -type f -name 'weidu*' -perm -111 -print -quit)
-          test -n "$baseline_bin"
-          cp "$baseline_bin" /tmp/weidu-baseline-bin
-
       - name: Benchmark candidate at bounded scales
         env:
           BENCH_COUNTS: 1000 10000
           BENCH_RESULT_DIR: /tmp/benchmark-candidate
         run: test/structured-resources/benchmark.sh /tmp/weidu-candidate
-
-      - name: Benchmark pre-optimization baseline at 1,000 files
-        env:
-          BENCH_COUNTS: 1000
-          BENCH_REPETITIONS: 7
-          BENCH_RESULT_DIR: /tmp/benchmark-baseline
-        run: test/structured-resources/benchmark.sh /tmp/weidu-baseline-bin
-
-      - name: Evaluate guard optimization
-        run: |
-          set -o pipefail
-          median_patch_time() {
-            workload=$1
-            input=$2
-            awk -F '\t' -v workload="$workload" \
-              'NR > 1 && $1 == workload && $2 == "structured" && $3 == 1000 { print $9 }' \
-              "$input" | sort -n | awk '
-                { values[NR] = $1 }
-                END {
-                  if (NR % 2) print values[(NR + 1) / 2]
-                  else printf "%.3f\n", (values[NR / 2] + values[NR / 2 + 1]) / 2
-                }'
-          }
-          field_before=$(median_patch_time field /tmp/benchmark-baseline/raw.tsv)
-          field_after=$(median_patch_time field /tmp/benchmark-candidate/raw.tsv)
-          structural_before=$(median_patch_time structural /tmp/benchmark-baseline/raw.tsv)
-          structural_after=$(median_patch_time structural /tmp/benchmark-candidate/raw.tsv)
-          awk -v field_before="$field_before" -v field_after="$field_after" \
-              -v structural_before="$structural_before" \
-              -v structural_after="$structural_after" '
-            BEGIN {
-              field_change = 100 * (field_before - field_after) / field_before
-              structural_change = 100 * (structural_before - structural_after) / structural_before
-              print "# Structured-command guard optimization\n"
-              print "Positive percentages are improvements in median PATCH_TIME across seven 1,000-file runs.\n"
-              print "| Workload | Before (CPU s) | After (CPU s) | Improvement |"
-              print "|---|---:|---:|---:|"
-              printf "| field | %.3f | %.3f | %.2f%% |\n", field_before, field_after, field_change
-              printf "| structural | %.3f | %.3f | %.2f%% |\n", structural_before, structural_after, structural_change
-              if (!((field_change >= 5 || structural_change >= 5) &&
-                    field_change >= -5 && structural_change >= -5)) exit 1
-            }' | tee /tmp/optimization.md
 
       - name: Assemble evidence
         if: always()
@@ -127,12 +73,6 @@ jobs:
             > /tmp/structured-resource-evidence/ci-status.txt
           if test -d /tmp/benchmark-candidate; then
             cp -r /tmp/benchmark-candidate /tmp/structured-resource-evidence/candidate
-          fi
-          if test -d /tmp/benchmark-baseline; then
-            cp -r /tmp/benchmark-baseline /tmp/structured-resource-evidence/baseline
-          fi
-          if test -f /tmp/optimization.md; then
-            cp /tmp/optimization.md /tmp/structured-resource-evidence/
           fi
 
       - name: Upload benchmark evidence

--- a/.github/workflows/structured-resource-validation.yaml
+++ b/.github/workflows/structured-resource-validation.yaml
@@ -50,7 +50,7 @@ jobs:
           export PATH="$PATH:$PWD/bin"
           eval "$(opam env)"
           mkdir -p obj/x86_LINUX obj/.depend
-          make -j2 weidu
+          make weidu
           cp obj/x86_LINUX/weidu /tmp/weidu-candidate
           make test-structured-resources
           make doc
@@ -62,7 +62,7 @@ jobs:
           eval "$(opam env)"
           git worktree add --detach /tmp/weidu-baseline 16edfd1
           mkdir -p /tmp/weidu-baseline/obj/x86_LINUX /tmp/weidu-baseline/obj/.depend
-          make -C /tmp/weidu-baseline -j2 weidu
+          make -C /tmp/weidu-baseline weidu
           cp /tmp/weidu-baseline/obj/x86_LINUX/weidu /tmp/weidu-baseline-bin
 
       - name: Benchmark candidate through 100,000 files
@@ -117,6 +117,8 @@ jobs:
         if: always()
         run: |
           mkdir -p /tmp/structured-resource-evidence
+          printf 'run=%s\nsha=%s\n' "$GITHUB_RUN_ID" "$GITHUB_SHA" \
+            > /tmp/structured-resource-evidence/ci-status.txt
           if test -d /tmp/benchmark-candidate; then
             cp -r /tmp/benchmark-candidate /tmp/structured-resource-evidence/candidate
           fi
@@ -129,14 +131,14 @@ jobs:
 
       - name: Upload benchmark evidence
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: structured-resource-benchmark-${{ github.sha }}
           path: /tmp/structured-resource-evidence
           if-no-files-found: error
 
       - name: Upload Linux package
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: structured-resource-linux-${{ github.sha }}
           path: WeiDU-Linux-*.zip

--- a/Depends
+++ b/Depends
@@ -9,7 +9,7 @@ WEIDU_BASE_MODULES := batList batteriesInit myhashtbl hashtblinit \
 	dlg dc \
 	refactorbaf refactorbafparser refactorbaflexer refactordparser refactordlexer \
 	bafparser baflexer \
-	myxdiff diff sav mos tp dparser dlexer sql json \
+	myxdiff diff sav mos tp tpresource dparser dlexer sql json \
 	smutil useract lexerint parsetables arraystack objpool glr lrparse \
 	automate kit tpstate tphelp trealparser tlexer toldparser toldlexer tparser \
 	parsewrappers mymarshal tppe tpuninstall tppatch tpaction tpwork \

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@
 include Configuration
 
 # Just a target to be used by default
-.PHONY: weidu doc all
+.PHONY: weidu doc all test-structured-resources
 all : weidu
 # "make weinstall" if you want weinstall
 
@@ -84,6 +84,8 @@ ifeq ($(shell uname -s),Linux)
 	cp $(PROJECT_EXECUTABLE) .
 endif
 
+test-structured-resources: weidu
+	test/structured-resources/run_tests.sh $(PROJECT_EXECUTABLE)
 ifeq ($(shell uname -s),Darwin)
 	@$(NARRATIVE) Linking Darwin executable
 	$(CAMLLINK) -o $@ \

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@
 include Configuration
 
 # Just a target to be used by default
-.PHONY: weidu doc all test-structured-resources
+.PHONY: weidu doc all test-structured-resources benchmark-structured-resources
 all : weidu
 # "make weinstall" if you want weinstall
 
@@ -86,6 +86,9 @@ endif
 
 test-structured-resources: weidu
 	test/structured-resources/run_tests.sh $(PROJECT_EXECUTABLE)
+
+benchmark-structured-resources: weidu
+	test/structured-resources/benchmark.sh $(PROJECT_EXECUTABLE)
 ifeq ($(shell uname -s),Darwin)
 	@$(NARRATIVE) Linking Darwin executable
 	$(CAMLLINK) -o $@ \

--- a/README-WeiDU-Changes.txt
+++ b/README-WeiDU-Changes.txt
@@ -2,7 +2,11 @@ Version 251:
   * Add transactional PATCH_RESOURCE editing for ITM V1/V1.1/V2.0,
     SPL V1/V2.0 and EFF V2.0 resources, with named typed fields and
     first-class iteration, append, insert, deep-clone and delete
-    operations for abilities and effects.
+    operations for abilities and effects. Regression examples cover
+    cross-collection graph rewrites and complete rollback after a late
+    failure. A reproducible Linux benchmark compares field and structural
+    workloads with bundled and purpose-built ad hoc functions at up to
+    100,000 files.
   * CREATE called within CREATE works as expected.
   * CREATE sets SOURCE_* and DEST_* variables.
   * Auto-update does not fail if the filename of the newest WeiDU

--- a/README-WeiDU-Changes.txt
+++ b/README-WeiDU-Changes.txt
@@ -5,8 +5,8 @@ Version 251:
     operations for abilities and effects. Regression examples cover
     cross-collection graph rewrites and complete rollback after a late
     failure. A reproducible Linux benchmark compares field and structural
-    workloads with bundled and purpose-built ad hoc functions at up to
-    100,000 files.
+    workloads with bundled and purpose-built ad hoc functions, using repeated
+    1,000-file measurements and a 10,000-file scale confirmation.
   * CREATE called within CREATE works as expected.
   * CREATE sets SOURCE_* and DEST_* variables.
   * Auto-update does not fail if the filename of the newest WeiDU

--- a/README-WeiDU-Changes.txt
+++ b/README-WeiDU-Changes.txt
@@ -1,4 +1,8 @@
 Version 251:
+  * Add transactional PATCH_RESOURCE editing for ITM V1/V1.1/V2.0,
+    SPL V1/V2.0 and EFF V2.0 resources, with named typed fields and
+    first-class iteration, append, insert, deep-clone and delete
+    operations for abilities and effects.
   * CREATE called within CREATE works as expected.
   * CREATE sets SOURCE_* and DEST_* variables.
   * Auto-update does not fail if the filename of the newest WeiDU

--- a/doc/base.tex
+++ b/doc/base.tex
@@ -5068,11 +5068,12 @@ projectile variable_name caster_level secondary_type
     byte-identical field edits against both bundled \t{ALTER_ITEM_*} helpers
     and a purpose-built offset function. It separately compares a deep-clone
     and effect-table relocation workload against a purpose-built structural
-    function. The default matrix patches 1,000, 10,000 and 100,000 physical
-    files, uses a warm-up followed by repeated measurements in alternating
-    order, records external wall/user/system/RSS metrics and internal
-    \ttref{PATCH_TIME} CPU time, and verifies SHA-256 manifests after every
-    scale. Run it with \t{make benchmark-structured-resources}; use
+    function. The default matrix uses seven measured 1,000-file runs after a
+    warm-up to establish an observed range, followed by one 10,000-file scale
+    confirmation over pre-seeded outputs. It records external
+    wall/user/system/RSS metrics and internal \ttref{PATCH_TIME} CPU time, and
+    verifies SHA-256 manifests after every scale. Run it with
+    \t{make benchmark-structured-resources}; use
     \t{BENCH_COUNTS}, \t{BENCH_REPETITIONS}, \t{BENCH_JOBS} and
     \t{BENCH_RESULT_DIR} to control the documented harness. Timing results are
     environment-specific and are therefore published as CI artifacts rather

--- a/doc/base.tex
+++ b/doc/base.tex
@@ -4889,6 +4889,124 @@ or & \DEFINE{PATCH_IF} \ttref{value} \Ob \t{THEN} \Oe \t{BEGIN}
 
     See the \ahrefloc{sec-match-and-try}{\t{MATCH} and \t{TRY} tutorial} for additional information.
   \\
+  or & \DEFINE{PATCH_RESOURCE} format \t{BEGIN} \ttref{patch} \Slist
+    \t{END} &
+    Opens a transactional, schema-aware editor for the current buffer.
+    The format is \t{ITM}, \t{SPL}, or \t{EFF}. Supported versions are
+    ITM V1, V1.1 and V2.0; SPL V1 and V2.0; and EFF V2.0.
+
+    The commands available inside the block are:
+\begin{verbatim}
+RESOURCE_GET handle field INTO variable
+RESOURCE_SET handle field = value
+RESOURCE_SPRINT handle field string
+RESOURCE_FOR_EACH collection AS handle BEGIN patches END
+RESOURCE_APPEND collection AS handle BEGIN patches END
+RESOURCE_INSERT collection BEFORE|AFTER anchor AS handle BEGIN patches END
+RESOURCE_CLONE source TO collection [BEFORE|AFTER anchor]
+    AS handle BEGIN patches END
+RESOURCE_DELETE handle
+\end{verbatim}
+
+    \t{RESOURCE} is the root handle. Collections are \t{ABILITIES},
+    \t{GLOBAL_EFFECTS}, and \t{EFFECTS OF} an ability handle. Handles
+    introduced with \t{AS} are lexical and opaque: they are not WeiDU
+    variables and cannot be used after their block. Iteration uses a
+    snapshot: appended records are not visited in the same iteration,
+    records deleted before their turn are skipped, and deleting the
+    current record is permitted.
+
+    \ttref{RESOURCE_APPEND} and \ttref{RESOURCE_INSERT} create a zeroed
+    record of the schema-required size. \ttref{RESOURCE_CLONE} copies an
+    effect byte-for-byte; cloning an ability also clones all effects owned
+    by that ability. Deleting an ability deletes its owned effects.
+
+    \ttref{RESOURCE_GET} stores numeric fields as integers and textual
+    fields as strings. \ttref{RESOURCE_SET} accepts numeric fields only;
+    \ttref{RESOURCE_SPRINT} accepts fixed strings and resource references.
+    Values outside the field's signed or unsigned width and strings longer
+    than the fixed field are errors. Short strings are NUL-padded.
+
+    Signatures, versions, offsets, counts and effect indices are readable
+    but read-only. The editor validates signatures, minimum sizes, table
+    bounds, multiplication overflow, table overlap and unambiguous effect
+    ownership before executing the body. It updates all derived offsets,
+    counts and indices on commit, validates the serialized result again,
+    and preserves unexposed bytes, gaps and trailing data byte-for-byte.
+    A no-op block is byte-identical.
+
+    The block is atomic with respect to the resource buffer. Any structured
+    error discards all resource edits. An enclosing \ttref{PATCH_TRY} may
+    catch that error and receives the original buffer, but a
+    \ttref{PATCH_TRY} inside the block cannot suppress it. Variable and log
+    side effects are not rolled back. Nested \ttref{PATCH_RESOURCE} blocks
+    and ordinary patches that mutate the buffer are rejected.
+
+    Root fields common to ITM versions are:
+\begin{verbatim}
+signature version unidentified_name identified_name flags item_type
+usability_flags item_animation min_level price stack_amount inventory_icon
+lore_to_id ground_icon weight unidentified_description
+identified_description enchantment abilities_offset abilities_count
+effects_offset global_effects_index global_effects_count
+\end{verbatim}
+    ITM V1 additionally exposes \t{used_up_item}, \t{description_icon},
+    and the minimum-stat and kit-usability fields. ITM V1.1 exposes
+    \t{drop_sound}, \t{pickup_sound}, \t{dialog},
+    \t{conversable_label}, and \t{paperdoll_colour}. ITM V2.0 exposes
+    \t{replacement_item}, \t{description_icon}, and the minimum-stat and
+    kit-usability fields.
+
+    ITM ability fields are:
+\begin{verbatim}
+header_type id_requirement location alternative_dice_sides icon target
+target_count range launcher alternative_dice_thrown speed
+alternative_damage_bonus thac0_bonus dicesize primary_type dicenumber
+secondary_type damage_bonus damage_type effects_count effects_index charges
+drained flags projectile animation_overhand animation_backhand
+animation_thrust arrow bolt bullet
+\end{verbatim}
+    V2.0 also exposes \t{attack_type_flags}; its \t{flags} and
+    \t{attack_type_flags} are separate 16-bit fields.
+
+    SPL root fields are:
+\begin{verbatim}
+signature version name completion_sound flags spell_type exclusion_flags
+casting_graphics primary_type secondary_type spell_level spellbook_icon
+description abilities_offset abilities_count effects_offset
+global_effects_index global_effects_count
+\end{verbatim}
+    V2.0 also exposes \t{duration_modifier_level} and
+    \t{duration_modifier_rounds}. SPL ability fields are:
+\begin{verbatim}
+header_type flags location icon target target_count range min_level speed
+times_per_day effects_count effects_index projectile
+\end{verbatim}
+
+    Embedded ITM/SPL effect fields are:
+\begin{verbatim}
+opcode target power parameter1 parameter2 timing resist_dispel duration
+probability1 probability2 resource dicenumber dicesize savingthrow savebonus
+special
+\end{verbatim}
+
+    EFF V2.0 root fields are:
+\begin{verbatim}
+signature version body_signature body_version opcode target power parameter1
+parameter2 timing duration probability1 probability2 resource dicenumber
+dicesize savingthrow savebonus special primary_type resist_dispel parameter3
+parameter4 parameter5 time_applied resource2 resource3 caster_x caster_y
+target_x target_y parent_resource_type parent_resource parent_resource_flags
+projectile variable_name caster_level secondary_type
+\end{verbatim}
+
+    Compared with ad hoc patch functions, this interface centralises format
+    knowledge, enforces widths and record ownership, relocates dependent
+    tables automatically, makes structural operations composable, and gives
+    malformed input and failed initialisers one deterministic atomic failure
+    path. Existing patch functions and byte-oriented commands are unchanged.
+  \\
+
   or & \DEFINE{PATCH_RERAISE} &
      When used inside a \ttref{PATCH_TRY}, the matched error is re-raised.
 

--- a/doc/base.tex
+++ b/doc/base.tex
@@ -4908,9 +4908,9 @@ RESOURCE_CLONE source TO collection [BEFORE|AFTER anchor]
 RESOURCE_DELETE handle
 \end{verbatim}
 
-    The \\t{RESOURCE_*} command names are contextual keywords: outside a
-    \\ttref{PATCH_RESOURCE} body they continue to lex as strings and remain
-    available as unquoted identifiers. Only \\t{PATCH_RESOURCE} is added to
+    The \t{RESOURCE_*} command names are contextual keywords: outside a
+    \ttref{PATCH_RESOURCE} body they continue to lex as strings and remain
+    available as unquoted identifiers. Only \t{PATCH_RESOURCE} is added to
     the global keyword set.
 
     \t{RESOURCE} is the root handle. Collections are \t{ABILITIES},
@@ -4946,6 +4946,44 @@ RESOURCE_DELETE handle
     \ttref{PATCH_TRY} inside the block cannot suppress it. Variable and log
     side effects are not rolled back. Nested \ttref{PATCH_RESOURCE} blocks
     and ordinary patches that mutate the buffer are rejected.
+
+    \textbf{Advanced graph rewrite.} The following single transaction deep
+    clones every ability, edits the cloned effects while iterating over a
+    stable snapshot, promotes one effect into the global collection, adds a
+    new effect, and then removes the original ability. WeiDU relocates the
+    tables and rebuilds every count and ownership index at commit.
+\begin{verbatim}
+PATCH_RESOURCE ITM BEGIN
+  RESOURCE_FOR_EACH abilities AS original BEGIN
+    RESOURCE_CLONE original TO abilities AFTER original AS variant BEGIN
+      RESOURCE_SET variant range = 40
+      RESOURCE_FOR_EACH effects OF variant AS candidate BEGIN
+        RESOURCE_GET candidate opcode INTO opcode
+        PATCH_IF opcode = 20 BEGIN
+          RESOURCE_CLONE candidate TO global_effects AS promoted BEGIN
+            RESOURCE_SET promoted opcode = 21
+          END
+          RESOURCE_DELETE candidate
+        END
+      END
+      RESOURCE_APPEND effects OF variant AS suffix BEGIN
+        RESOURCE_SET suffix opcode = 40
+      END
+    END
+    RESOURCE_DELETE original
+  END
+END
+\end{verbatim}
+
+    This pattern can combine nested selection, insertion relative to stable
+    handles, cross-collection cloning, cascading deletion, and preservation
+    of unmodelled trailing bytes. If any late operation fails---for example,
+    an attempt to assign a read-only field---none of the preceding graph edits
+    reach the buffer. An enclosing \ttref{PATCH_TRY} can therefore implement
+    an explicit optional transformation without writing a compensating undo
+    function. The regression fixture in
+    \t{test/structured-resources/structured-resources.tp2} exercises both the
+    successful rewrite and byte-identical rollback of a more involved one.
 
     Root fields common to ITM versions are:
 \begin{verbatim}
@@ -5005,11 +5043,40 @@ target_x target_y parent_resource_type parent_resource parent_resource_flags
 projectile variable_name caster_level secondary_type
 \end{verbatim}
 
-    Compared with ad hoc patch functions, this interface centralises format
-    knowledge, enforces widths and record ownership, relocates dependent
-    tables automatically, makes structural operations composable, and gives
+    \textbf{Comparison with ad hoc functions.} A purpose-built offset function
+    can be smaller and faster for one fixed, well-understood field edit. For a
+    structural rewrite, however, that function must independently duplicate
+    the format contract: version-specific record sizes, checked offset
+    arithmetic, non-overlapping table bounds, effect ownership, descending or
+    otherwise stable relocation order, derived-index repair, and partial-write
+    recovery. Those responsibilities grow with every operation and format
+    variant, and separate helper functions can silently encode incompatible
+    assumptions. This interface centralises that knowledge, enforces field
+    widths and ownership, makes structural operations composable, and gives
     malformed input and failed initialisers one deterministic atomic failure
     path. Existing patch functions and byte-oriented commands are unchanged.
+
+    \textbf{Performance.} Schema parsing, validation, handle dispatch and
+    serialization have a real cost; \ttref{PATCH_RESOURCE} is not intended to
+    outperform the narrowest correct offset function. Its advantage is that
+    the fixed format logic is implemented and audited once rather than repeated
+    in each mod. Performance should be measured for the relevant resource
+    shape and file count, including filesystem costs, instead of inferred from
+    the number of TP2 statements.
+
+    The Linux benchmark in \t{test/structured-resources/benchmark.sh} compares
+    byte-identical field edits against both bundled \t{ALTER_ITEM_*} helpers
+    and a purpose-built offset function. It separately compares a deep-clone
+    and effect-table relocation workload against a purpose-built structural
+    function. The default matrix patches 1,000, 10,000 and 100,000 physical
+    files, uses a warm-up followed by repeated measurements in alternating
+    order, records external wall/user/system/RSS metrics and internal
+    \ttref{PATCH_TIME} CPU time, and verifies SHA-256 manifests after every
+    scale. Run it with \t{make benchmark-structured-resources}; use
+    \t{BENCH_COUNTS}, \t{BENCH_REPETITIONS}, \t{BENCH_JOBS} and
+    \t{BENCH_RESULT_DIR} to control the documented harness. Timing results are
+    environment-specific and are therefore published as CI artifacts rather
+    than fixed language guarantees.
   \\
 
   or & \DEFINE{PATCH_RERAISE} &

--- a/doc/base.tex
+++ b/doc/base.tex
@@ -4908,6 +4908,11 @@ RESOURCE_CLONE source TO collection [BEFORE|AFTER anchor]
 RESOURCE_DELETE handle
 \end{verbatim}
 
+    The \\t{RESOURCE_*} command names are contextual keywords: outside a
+    \\ttref{PATCH_RESOURCE} body they continue to lex as strings and remain
+    available as unquoted identifiers. Only \\t{PATCH_RESOURCE} is added to
+    the global keyword set.
+
     \t{RESOURCE} is the root handle. Collections are \t{ABILITIES},
     \t{GLOBAL_EFFECTS}, and \t{EFFECTS OF} an ability handle. Handles
     introduced with \t{AS} are lexical and opaque: they are not WeiDU

--- a/src/tlexer.in
+++ b/src/tlexer.in
@@ -83,6 +83,42 @@ let _ = List.iter
 PUT LEXICON *)
     ]
 
+(* RESOURCE_* words are keywords only while lexing a PATCH_RESOURCE body.
+ * This preserves their historical use as unquoted identifiers elsewhere. *)
+let structured_resource_depth = ref 0
+let structured_resource_pending = ref 0
+
+let reset_structured_resource_context () =
+  structured_resource_depth := 0;
+  structured_resource_pending := 0
+
+let structured_resource_token spelling token =
+  match token with
+  | PATCH_RESOURCE when !structured_resource_depth = 0 ->
+      structured_resource_pending := 2;
+      token
+  | _ when !structured_resource_pending = 2 ->
+      structured_resource_pending := 1;
+      token
+  | BEGIN when !structured_resource_pending = 1 ->
+      structured_resource_pending := 0;
+      structured_resource_depth := 1;
+      token
+  | _ when !structured_resource_pending = 1 ->
+      structured_resource_pending := 0;
+      token
+  | BEGIN when !structured_resource_depth > 0 ->
+      incr structured_resource_depth;
+      token
+  | END when !structured_resource_depth > 0 ->
+      decr structured_resource_depth;
+      token
+  | (RESOURCE_GET | RESOURCE_SET | RESOURCE_SPRINT | RESOURCE_FOR_EACH
+    | RESOURCE_APPEND | RESOURCE_INSERT | RESOURCE_CLONE | RESOURCE_DELETE)
+      when !structured_resource_depth = 0 ->
+      STRING spelling
+  | _ -> token
+
 (*
 ** Buffer processor
 *)

--- a/src/tp.ml
+++ b/src/tp.ml
@@ -331,7 +331,32 @@ and tp_local_declaration =
   | TP_LocalSprint of tp_pe_string * tp_pe_tlk_string
   | TP_LocalTextSprint of tp_pe_string * tp_pe_string
 
+and tp_resource_kind =
+  | TP_Resource_ITM
+  | TP_Resource_SPL
+  | TP_Resource_EFF
+
+and tp_resource_collection =
+  | TP_Resource_Abilities
+  | TP_Resource_GlobalEffects
+  | TP_Resource_EffectsOf of string
+
+and tp_resource_position =
+  | TP_Resource_Before of string
+  | TP_Resource_After of string
+
 and tp_patch =
+  | TP_PatchResource of tp_resource_kind * tp_patch list
+  | TP_ResourceGet of string * string * tp_pe_string
+  | TP_ResourceSet of string * string * tp_patchexp
+  | TP_ResourceSprint of string * string * tp_pe_string
+  | TP_ResourceForEach of tp_resource_collection * string * tp_patch list
+  | TP_ResourceAppend of tp_resource_collection * string * tp_patch list
+  | TP_ResourceInsert of tp_resource_collection * tp_resource_position *
+      string * tp_patch list
+  | TP_ResourceClone of string * tp_resource_collection *
+      tp_resource_position option * string * tp_patch list
+  | TP_ResourceDelete of string
   | TP_PatchBashFor of ((string * (bool option) * string) list) * (tp_patch list)
   | TP_PatchClearArray of tp_pe_string
   | TP_PatchDefineArray of tp_pe_string * string list

--- a/src/tparser.in
+++ b/src/tparser.in
@@ -29,6 +29,7 @@ class tLexer =
       begin
         (* read from stdin *)
         let t = (initial lexbuf) in
+        let t = structured_resource_token (Lexing.lexeme lexbuf) t in
         tokType <- tokenKind t;
 (*      token (string) SOUND;
         token (string) STRING;
@@ -68,6 +69,7 @@ class tLexer =
 let realTables = ref None
 
 let parse start lexbuf =
+  reset_structured_resource_context ();
   let decomp_tables = match !realTables with
   | Some x -> x
   | None ->

--- a/src/tppatch.ml
+++ b/src/tppatch.ml
@@ -2974,7 +2974,13 @@ let rec process_patch2_real process_action tp our_lang patch_filename game buff 
             buff) ()
         end
                               ) () in (* end: process_patch2 *)
-  if Tpresource.is_active () && result <> Tpresource.original_buffer () then
+  let structured_resource_operation = match p with
+    | TP_ResourceGet(_) | TP_ResourceSet(_) | TP_ResourceSprint(_)
+    | TP_ResourceForEach(_) | TP_ResourceAppend(_) | TP_ResourceInsert(_)
+    | TP_ResourceClone(_) | TP_ResourceDelete(_) -> true
+    | _ -> false in
+  if Tpresource.is_active () && not structured_resource_operation &&
+      result <> Tpresource.original_buffer () then
     Tpresource.error
       "ordinary patch command mutated the buffer inside PATCH_RESOURCE";
   result

--- a/src/tppatch.ml
+++ b/src/tppatch.ml
@@ -2974,13 +2974,7 @@ let rec process_patch2_real process_action tp our_lang patch_filename game buff 
             buff) ()
         end
                               ) () in (* end: process_patch2 *)
-  let structured_resource_operation = match p with
-    | TP_ResourceGet(_) | TP_ResourceSet(_) | TP_ResourceSprint(_)
-    | TP_ResourceForEach(_) | TP_ResourceAppend(_) | TP_ResourceInsert(_)
-    | TP_ResourceClone(_) | TP_ResourceDelete(_) -> true
-    | _ -> false in
-  if Tpresource.is_active () && not structured_resource_operation &&
-      result <> Tpresource.original_buffer () then
+  if Tpresource.is_active () && result <> Tpresource.original_buffer () then
     Tpresource.error
       "ordinary patch command mutated the buffer inside PATCH_RESOURCE";
   result

--- a/src/tppatch.ml
+++ b/src/tppatch.ml
@@ -189,7 +189,7 @@ let rec process_patch2_real process_action tp our_lang patch_filename game buff 
   let process_patch2 = process_patch2_real process_action tp our_lang in
   process_patch1 patch_filename game buff p ;
 
-  Stats.time "process_patch2" (fun () ->
+  let result = Stats.time "process_patch2" (fun () ->
     let bounds_check_write idx size (str : string) =
       let len = String.length buff in
       let out_of_bounds = (idx < 0 || (idx + size) > len) in
@@ -202,6 +202,76 @@ let rec process_patch2_real process_action tp our_lang patch_filename game buff 
       ()
     in
     match p with
+    | TP_PatchResource(kind,patches) ->
+        if Tpresource.is_active () then
+          Tpresource.error "nested PATCH_RESOURCE blocks are not allowed";
+        let editor = Tpresource.parse kind buff in
+        let guarded_buffer = String.copy buff in
+        Tpresource.activate editor;
+        begin try
+          ignore (List.fold_left (fun current patch ->
+            process_patch2 patch_filename game current patch)
+            guarded_buffer patches);
+          let result = Tpresource.serialize editor in
+          Tpresource.deactivate ();
+          result
+        with exn ->
+          Tpresource.deactivate ();
+          raise exn
+        end
+
+    | TP_ResourceGet(handle,field,name) ->
+        let name = eval_pe_str name in
+        (match Tpresource.get handle field with
+         | Tpresource.Numeric value -> Var.set_int32 name value
+         | Tpresource.Text value -> Var.set_string name value);
+        buff
+
+    | TP_ResourceSet(handle,field,expression) ->
+        Tpresource.set handle field (eval_pe buff game expression);
+        buff
+
+    | TP_ResourceSprint(handle,field,expression) ->
+        let value = Var.get_string (eval_pe_str expression) in
+        Tpresource.sprint handle field value;
+        buff
+
+    | TP_ResourceForEach(collection,handle,patches) ->
+        let current = ref buff in
+        Tpresource.for_each collection handle (fun () ->
+          current := List.fold_left (fun buffer patch ->
+            process_patch2 patch_filename game buffer patch)
+            !current patches);
+        !current
+
+    | TP_ResourceAppend(collection,handle,patches) ->
+        let current = ref buff in
+        Tpresource.append collection handle (fun () ->
+          current := List.fold_left (fun buffer patch ->
+            process_patch2 patch_filename game buffer patch)
+            !current patches);
+        !current
+
+    | TP_ResourceInsert(collection,position,handle,patches) ->
+        let current = ref buff in
+        Tpresource.insert collection position handle (fun () ->
+          current := List.fold_left (fun buffer patch ->
+            process_patch2 patch_filename game buffer patch)
+            !current patches);
+        !current
+
+    | TP_ResourceClone(source,collection,position,handle,patches) ->
+        let current = ref buff in
+        Tpresource.clone source collection position handle (fun () ->
+          current := List.fold_left (fun buffer patch ->
+            process_patch2 patch_filename game buffer patch)
+            !current patches);
+        !current
+
+    | TP_ResourceDelete(handle) ->
+        Tpresource.delete_handle handle;
+        buff
+
     | TP_PatchReadByte(_)
     | TP_PatchReadSByte(_)
     | TP_PatchReadShort(_)
@@ -479,7 +549,10 @@ let rec process_patch2_real process_action tp our_lang patch_filename game buff 
         try
           List.fold_left (fun acc elt ->
             process_patch2 patch_filename game acc elt) buff pl
-        with e ->
+        with
+        | (Tpresource.Error _ as e) when Tpresource.is_active () ->
+          raise e
+        | e ->
           current_exception := e;
           let e = printexc_to_string e in
           Var.set_string "ERROR_MESSAGE" e;
@@ -2900,4 +2973,8 @@ let rec process_patch2_real process_action tp our_lang patch_filename game buff 
               process_patch2 patch_filename game acc patch) buff patch_list in
             buff) ()
         end
-                              ) () (* end: process_patch2 *)
+                              ) () in (* end: process_patch2 *)
+  if Tpresource.is_active () && result <> Tpresource.original_buffer () then
+    Tpresource.error
+      "ordinary patch command mutated the buffer inside PATCH_RESOURCE";
+  result

--- a/src/tpresource.ml
+++ b/src/tpresource.ml
@@ -1,0 +1,743 @@
+(* Structured, validated editing for ITM, SPL and EFF resources. *)
+
+open BatteriesInit
+open Util
+open Tp
+
+exception Error of string
+
+let error fmt =
+  Printf.ksprintf (fun message -> raise (Error ("PATCH_RESOURCE: " ^ message))) fmt
+
+type field_kind =
+  | U8 | I8 | U16 | I16 | I32
+  | FixedString of int
+  | Resref
+
+type field = {
+  field_name : string;
+  field_offset : int;
+  field_kind : field_kind;
+  field_writable : bool;
+}
+
+type record_desc = {
+  record_name : string;
+  record_size : int;
+  record_fields : field list;
+}
+
+type node_kind = Root | Ability | Effect
+
+type node = {
+  node_id : int;
+  node_kind : node_kind;
+  node_desc : record_desc;
+  mutable node_bytes : string;
+  mutable node_deleted : bool;
+  mutable node_effects : node list;
+}
+
+type format =
+  | ItmV1 | ItmV11 | ItmV20
+  | SplV1 | SplV20
+  | EffV20
+
+type editor = {
+  editor_kind : tp_resource_kind;
+  editor_format : format;
+  editor_original : string;
+  editor_root : node;
+  mutable editor_abilities : node list;
+  mutable editor_globals : node list;
+  editor_gap : string;
+  editor_tail : string;
+  editor_handles : (string, node) Hashtbl.t;
+  mutable editor_next_id : int;
+  mutable editor_dirty : bool;
+}
+
+type value = Numeric of Int32.t | Text of string
+
+let ro name offset kind =
+  { field_name = name; field_offset = offset; field_kind = kind;
+    field_writable = false }
+
+let rw name offset kind =
+  { field_name = name; field_offset = offset; field_kind = kind;
+    field_writable = true }
+
+let embedded_effect_fields = [
+  rw "opcode" 0x00 U16;
+  rw "target" 0x02 U8;
+  rw "power" 0x03 U8;
+  rw "parameter1" 0x04 I32;
+  rw "parameter2" 0x08 I32;
+  rw "timing" 0x0c U8;
+  rw "resist_dispel" 0x0d U8;
+  rw "duration" 0x0e I32;
+  rw "probability1" 0x12 U8;
+  rw "probability2" 0x13 U8;
+  rw "resource" 0x14 Resref;
+  rw "dicenumber" 0x1c I32;
+  rw "dicesize" 0x20 I32;
+  rw "savingthrow" 0x24 I32;
+  rw "savebonus" 0x28 I32;
+  rw "special" 0x2c I32;
+]
+
+let embedded_effect_desc = {
+  record_name = "embedded effect";
+  record_size = 0x30;
+  record_fields = embedded_effect_fields;
+}
+
+let itm_ability_base_fields = [
+  rw "header_type" 0x00 U8;
+  rw "id_requirement" 0x01 U8;
+  rw "location" 0x02 U8;
+  rw "alternative_dice_sides" 0x03 U8;
+  rw "icon" 0x04 Resref;
+  rw "target" 0x0c U8;
+  rw "target_count" 0x0d U8;
+  rw "range" 0x0e U16;
+  rw "launcher" 0x10 U8;
+  rw "alternative_dice_thrown" 0x11 U8;
+  rw "speed" 0x12 U8;
+  rw "alternative_damage_bonus" 0x13 U8;
+  rw "thac0_bonus" 0x14 I16;
+  rw "dicesize" 0x16 U8;
+  rw "primary_type" 0x17 U8;
+  rw "dicenumber" 0x18 U8;
+  rw "secondary_type" 0x19 U8;
+  rw "damage_bonus" 0x1a I16;
+  rw "damage_type" 0x1c U16;
+  ro "effects_count" 0x1e U16;
+  ro "effects_index" 0x20 U16;
+  rw "charges" 0x22 U16;
+  rw "drained" 0x24 U16;
+]
+
+let itm_v1_ability_fields = itm_ability_base_fields @ [
+  rw "flags" 0x26 I32;
+  rw "projectile" 0x2a U16;
+  rw "animation_overhand" 0x2c U16;
+  rw "animation_backhand" 0x2e U16;
+  rw "animation_thrust" 0x30 U16;
+  rw "arrow" 0x32 U16;
+  rw "bolt" 0x34 U16;
+  rw "bullet" 0x36 U16;
+]
+
+let itm_v2_ability_fields = itm_ability_base_fields @ [
+  rw "flags" 0x26 U16;
+  rw "attack_type_flags" 0x28 U16;
+  rw "projectile" 0x2a U16;
+  rw "animation_overhand" 0x2c U16;
+  rw "animation_backhand" 0x2e U16;
+  rw "animation_thrust" 0x30 U16;
+  rw "arrow" 0x32 U16;
+  rw "bolt" 0x34 U16;
+  rw "bullet" 0x36 U16;
+]
+
+let itm_v1_ability_desc = {
+  record_name = "ITM V1/V1.1 ability";
+  record_size = 0x38;
+  record_fields = itm_v1_ability_fields;
+}
+
+let itm_v2_ability_desc = {
+  record_name = "ITM V2.0 ability";
+  record_size = 0x38;
+  record_fields = itm_v2_ability_fields;
+}
+
+let spl_ability_fields = [
+  rw "header_type" 0x00 U8;
+  rw "flags" 0x01 U8;
+  rw "location" 0x02 U16;
+  rw "icon" 0x04 Resref;
+  rw "target" 0x0c U8;
+  rw "target_count" 0x0d U8;
+  rw "range" 0x0e U16;
+  rw "min_level" 0x10 U16;
+  rw "speed" 0x12 U16;
+  rw "times_per_day" 0x14 U16;
+  ro "effects_count" 0x1e U16;
+  ro "effects_index" 0x20 U16;
+  rw "projectile" 0x26 U16;
+]
+
+let spl_ability_desc = {
+  record_name = "SPL ability";
+  record_size = 0x28;
+  record_fields = spl_ability_fields;
+}
+
+let structural_fields = [
+  ro "abilities_offset" 0x64 I32;
+  ro "abilities_count" 0x68 U16;
+  ro "effects_offset" 0x6a I32;
+  ro "global_effects_index" 0x6e U16;
+  ro "global_effects_count" 0x70 U16;
+]
+
+let itm_common_fields = [
+  ro "signature" 0x00 (FixedString 4);
+  ro "version" 0x04 (FixedString 4);
+  rw "unidentified_name" 0x08 I32;
+  rw "identified_name" 0x0c I32;
+  rw "flags" 0x18 I32;
+  rw "item_type" 0x1c U16;
+  rw "usability_flags" 0x1e I32;
+  rw "item_animation" 0x22 (FixedString 2);
+  rw "min_level" 0x24 U16;
+  rw "price" 0x34 I32;
+  rw "stack_amount" 0x38 U16;
+  rw "inventory_icon" 0x3a Resref;
+  rw "lore_to_id" 0x42 U16;
+  rw "ground_icon" 0x44 Resref;
+  rw "weight" 0x4c I32;
+  rw "unidentified_description" 0x50 I32;
+  rw "identified_description" 0x54 I32;
+  rw "enchantment" 0x60 I32;
+] @ structural_fields
+
+let itm_requirement_fields = [
+  rw "min_strength" 0x26 U16;
+  rw "min_strength_bonus" 0x28 U8;
+  rw "kit_usability1" 0x29 U8;
+  rw "min_intelligence" 0x2a U8;
+  rw "kit_usability2" 0x2b U8;
+  rw "min_dexterity" 0x2c U8;
+  rw "kit_usability3" 0x2d U8;
+  rw "min_wisdom" 0x2e U8;
+  rw "kit_usability4" 0x2f U8;
+  rw "min_constitution" 0x30 U8;
+  rw "weapon_proficiency" 0x31 U8;
+  rw "min_charisma" 0x32 U16;
+]
+
+let spl_common_fields = [
+  ro "signature" 0x00 (FixedString 4);
+  ro "version" 0x04 (FixedString 4);
+  rw "name" 0x08 I32;
+  rw "completion_sound" 0x10 Resref;
+  rw "flags" 0x18 I32;
+  rw "spell_type" 0x1c U16;
+  rw "exclusion_flags" 0x1e I32;
+  rw "casting_graphics" 0x22 U16;
+  rw "primary_type" 0x25 U8;
+  rw "secondary_type" 0x27 U8;
+  rw "spell_level" 0x34 I32;
+  rw "spellbook_icon" 0x3a Resref;
+  rw "description" 0x50 I32;
+] @ structural_fields
+
+let eff_v2_fields = [
+  ro "signature" 0x00 (FixedString 4);
+  ro "version" 0x04 (FixedString 4);
+  ro "body_signature" 0x08 (FixedString 4);
+  ro "body_version" 0x0c (FixedString 4);
+  rw "opcode" 0x10 I32;
+  rw "target" 0x14 I32;
+  rw "power" 0x18 I32;
+  rw "parameter1" 0x1c I32;
+  rw "parameter2" 0x20 I32;
+  rw "timing" 0x24 U16;
+  rw "duration" 0x28 I32;
+  rw "probability1" 0x2c U16;
+  rw "probability2" 0x2e U16;
+  rw "resource" 0x30 Resref;
+  rw "dicenumber" 0x38 I32;
+  rw "dicesize" 0x3c I32;
+  rw "savingthrow" 0x40 I32;
+  rw "savebonus" 0x44 I32;
+  rw "special" 0x48 I32;
+  rw "primary_type" 0x4c I32;
+  rw "resist_dispel" 0x5c I32;
+  rw "parameter3" 0x60 I32;
+  rw "parameter4" 0x64 I32;
+  rw "parameter5" 0x68 I32;
+  rw "time_applied" 0x6c I32;
+  rw "resource2" 0x70 Resref;
+  rw "resource3" 0x78 Resref;
+  rw "caster_x" 0x80 I32;
+  rw "caster_y" 0x84 I32;
+  rw "target_x" 0x88 I32;
+  rw "target_y" 0x8c I32;
+  rw "parent_resource_type" 0x90 I32;
+  rw "parent_resource" 0x94 Resref;
+  rw "parent_resource_flags" 0x9c I32;
+  rw "projectile" 0xa0 I32;
+  rw "variable_name" 0xa8 (FixedString 32);
+  rw "caster_level" 0xc8 I32;
+  rw "secondary_type" 0xd0 I32;
+]
+
+let field_width = function
+  | U8 | I8 -> 1
+  | U16 | I16 -> 2
+  | I32 -> 4
+  | FixedString size -> size
+  | Resref -> 8
+
+let validate_desc desc =
+  let names = Hashtbl.create 31 in
+  List.iter (fun field ->
+    let name = String.lowercase field.field_name in
+    if Hashtbl.mem names name then
+      error "internal schema %s contains duplicate field %s"
+        desc.record_name field.field_name;
+    Hashtbl.add names name ();
+    let finish = field.field_offset + field_width field.field_kind in
+    if field.field_offset < 0 || finish > desc.record_size then
+      error "internal schema %s field %s is out of bounds"
+        desc.record_name field.field_name) desc.record_fields
+
+let make_desc name size fields =
+  let desc = { record_name = name; record_size = size; record_fields = fields } in
+  validate_desc desc;
+  desc
+
+let itm_root_desc format =
+  match format with
+  | ItmV1 -> make_desc "ITM V1 root" 0x72
+      ([rw "used_up_item" 0x10 Resref; rw "description_icon" 0x58 Resref] @
+       itm_requirement_fields @ itm_common_fields)
+  | ItmV11 -> make_desc "ITM V1.1 root" 0x9a
+      ([rw "drop_sound" 0x10 Resref; rw "pickup_sound" 0x58 Resref;
+        rw "dialog" 0x72 Resref; rw "conversable_label" 0x7a I32;
+        rw "paperdoll_colour" 0x7e U16] @ itm_common_fields)
+  | ItmV20 -> make_desc "ITM V2.0 root" 0x82
+      ([rw "replacement_item" 0x10 Resref; rw "description_icon" 0x58 Resref] @
+       itm_requirement_fields @ itm_common_fields)
+  | _ -> assert false
+
+let spl_root_desc format =
+  let fields = match format with
+  | SplV20 ->
+      rw "duration_modifier_level" 0x72 U8 ::
+      rw "duration_modifier_rounds" 0x73 U8 :: spl_common_fields
+  | SplV1 -> spl_common_fields
+  | _ -> assert false in
+  make_desc (if format = SplV20 then "SPL V2.0 root" else "SPL V1 root")
+    (if format = SplV20 then 0x82 else 0x72) fields
+
+let eff_root_desc = make_desc "EFF V2.0 root" 0x110 eff_v2_fields
+
+let () =
+  validate_desc embedded_effect_desc;
+  validate_desc itm_v1_ability_desc;
+  validate_desc itm_v2_ability_desc;
+  validate_desc spl_ability_desc;
+  ignore (itm_root_desc ItmV1);
+  ignore (itm_root_desc ItmV11);
+  ignore (itm_root_desc ItmV20);
+  ignore (spl_root_desc SplV1);
+  ignore (spl_root_desc SplV20);
+  validate_desc eff_root_desc
+
+let u32_at bytes offset =
+  let value = int32_of_str_off bytes offset in
+  let wide = Int64.logand (Int64.of_int32 value) 0xffffffffL in
+  if wide > Int64.of_int max_int then
+    error "offset 0x%Lx cannot be represented on this host" wide;
+  Int64.to_int wide
+
+let checked_end label offset count stride length =
+  if offset < 0 || count < 0 || stride < 0 then
+    error "%s has a negative layout value" label;
+  let finish = Int64.add (Int64.of_int offset)
+      (Int64.mul (Int64.of_int count) (Int64.of_int stride)) in
+  if finish > Int64.of_int length then
+    error "%s extends past the %d-byte buffer" label length;
+  Int64.to_int finish
+
+let copy_slice bytes offset length = String.sub bytes offset length
+
+let new_node id kind desc bytes = {
+  node_id = id; node_kind = kind; node_desc = desc;
+  node_bytes = bytes; node_deleted = false; node_effects = [];
+}
+
+let format_of_signature requested bytes =
+  if String.length bytes < 8 then error "buffer is shorter than a signature";
+  let signature = String.sub bytes 0 8 in
+  match requested, signature with
+  | TP_Resource_ITM, "ITM V1  " -> ItmV1
+  | TP_Resource_ITM, "ITM V1.1" -> ItmV11
+  | TP_Resource_ITM, "ITM V2.0" -> ItmV20
+  | TP_Resource_SPL, "SPL V1  " -> SplV1
+  | TP_Resource_SPL, "SPL V2.0" -> SplV20
+  | TP_Resource_EFF, "EFF V2.0" -> EffV20
+  | TP_Resource_ITM, _ -> error "expected ITM V1, V1.1 or V2.0; found %S" signature
+  | TP_Resource_SPL, _ -> error "expected SPL V1 or V2.0; found %S" signature
+  | TP_Resource_EFF, _ -> error "expected EFF V2.0; found %S" signature
+
+let parse requested bytes =
+  let format = format_of_signature requested bytes in
+  let length = String.length bytes in
+  match format with
+  | EffV20 ->
+      if length < eff_root_desc.record_size then
+        error "EFF V2.0 buffer is %d bytes; minimum is %d"
+          length eff_root_desc.record_size;
+      let root = new_node 0 Root eff_root_desc
+          (copy_slice bytes 0 eff_root_desc.record_size) in
+      { editor_kind = requested; editor_format = format;
+        editor_original = String.copy bytes; editor_root = root;
+        editor_abilities = []; editor_globals = [];
+        editor_gap = "";
+        editor_tail = copy_slice bytes eff_root_desc.record_size
+            (length - eff_root_desc.record_size);
+        editor_handles = Hashtbl.create 17; editor_next_id = 1;
+        editor_dirty = false }
+  | ItmV1 | ItmV11 | ItmV20 | SplV1 | SplV20 ->
+      let root_desc, ability_desc = match format with
+      | ItmV1 | ItmV11 -> itm_root_desc format, itm_v1_ability_desc
+      | ItmV20 -> itm_root_desc format, itm_v2_ability_desc
+      | SplV1 | SplV20 -> spl_root_desc format, spl_ability_desc
+      | _ -> assert false in
+      if length < root_desc.record_size then
+        error "%s buffer is %d bytes; minimum is %d"
+          root_desc.record_name length root_desc.record_size;
+      let ability_offset = u32_at bytes 0x64 in
+      let ability_count = short_of_str_off bytes 0x68 in
+      let effects_offset = u32_at bytes 0x6a in
+      let global_index = short_of_str_off bytes 0x6e in
+      let global_count = short_of_str_off bytes 0x70 in
+      if ability_offset < root_desc.record_size then
+        error "ability offset 0x%x overlaps the fixed header" ability_offset;
+      let ability_end = checked_end "ability table" ability_offset ability_count
+          ability_desc.record_size length in
+      if effects_offset < ability_end then
+        error "effect table offset 0x%x overlaps the ability table" effects_offset;
+      if global_index <> 0 then
+        error "global effect index is %d; records before it have ambiguous ownership"
+          global_index;
+      let next_id = ref 1 in
+      let abilities = ref [] in
+      for index = 0 to ability_count - 1 do
+        let offset = ability_offset + index * ability_desc.record_size in
+        let node = new_node !next_id Ability ability_desc
+            (copy_slice bytes offset ability_desc.record_size) in
+        incr next_id;
+        abilities := node :: !abilities
+      done;
+      let abilities = List.rev !abilities in
+      let expected_index = ref global_count in
+      List.iteri (fun index ability ->
+        let count = short_of_str_off ability.node_bytes 0x1e in
+        let first = short_of_str_off ability.node_bytes 0x20 in
+        if first <> !expected_index then
+          error "ability %d starts at effect %d; expected %d (gap, overlap, or reordered ownership)"
+            index first !expected_index;
+        expected_index := !expected_index + count) abilities;
+      let effect_count = !expected_index in
+      let effects_end = checked_end "effect table" effects_offset effect_count
+          embedded_effect_desc.record_size length in
+      let effects = Array.init effect_count (fun index ->
+        let offset = effects_offset + index * embedded_effect_desc.record_size in
+        let node = new_node !next_id Effect embedded_effect_desc
+            (copy_slice bytes offset embedded_effect_desc.record_size) in
+        incr next_id; node) in
+      let globals = ref [] in
+      for index = 0 to global_count - 1 do globals := effects.(index) :: !globals done;
+      let cursor = ref global_count in
+      List.iter (fun ability ->
+        let count = short_of_str_off ability.node_bytes 0x1e in
+        let owned = ref [] in
+        for index = 0 to count - 1 do
+          owned := effects.(!cursor + index) :: !owned
+        done;
+        ability.node_effects <- List.rev !owned;
+        cursor := !cursor + count) abilities;
+      let root = new_node 0 Root root_desc (copy_slice bytes 0 ability_offset) in
+      { editor_kind = requested; editor_format = format;
+        editor_original = String.copy bytes; editor_root = root;
+        editor_abilities = abilities; editor_globals = List.rev !globals;
+        editor_gap = copy_slice bytes ability_end (effects_offset - ability_end);
+        editor_tail = copy_slice bytes effects_end (length - effects_end);
+        editor_handles = Hashtbl.create 17; editor_next_id = !next_id;
+        editor_dirty = false }
+
+let current : editor option ref = ref None
+
+let is_active () = !current <> None
+
+let active () = match !current with
+  | Some editor -> editor
+  | None -> error "structured command used outside PATCH_RESOURCE"
+
+let activate editor =
+  if is_active () then error "nested PATCH_RESOURCE blocks are not allowed";
+  Hashtbl.replace editor.editor_handles "resource" editor.editor_root;
+  current := Some editor
+
+let deactivate () = current := None
+
+let original_buffer () = (active ()).editor_original
+
+let lowercase = String.lowercase
+
+let resolve_handle editor name =
+  let key = lowercase name in
+  let node = try Hashtbl.find editor.editor_handles key
+    with Not_found -> error "unknown handle %S" name in
+  if node.node_deleted then error "handle %S refers to a deleted record" name;
+  node
+
+let with_binding editor name node body =
+  let key = lowercase name in
+  if key = "resource" then error "RESOURCE is reserved for the root handle";
+  let previous = try Some (Hashtbl.find editor.editor_handles key)
+    with Not_found -> None in
+  Hashtbl.replace editor.editor_handles key node;
+  try
+    let result = body () in
+    (match previous with Some old -> Hashtbl.replace editor.editor_handles key old
+     | None -> Hashtbl.remove editor.editor_handles key);
+    result
+  with exn ->
+    (match previous with Some old -> Hashtbl.replace editor.editor_handles key old
+     | None -> Hashtbl.remove editor.editor_handles key);
+    raise exn
+
+let find_field node name =
+  let key = lowercase name in
+  try List.find (fun field -> lowercase field.field_name = key)
+      node.node_desc.record_fields
+  with Not_found ->
+    error "%s has no field %S" node.node_desc.record_name name
+
+let trim_zeroes value =
+  try String.sub value 0 (String.index value '\000') with Not_found -> value
+
+let read node field_name =
+  let field = find_field node field_name in
+  let offset = field.field_offset in
+  match field.field_kind with
+  | U8 -> Numeric (Int32.of_int (byte_of_str_off node.node_bytes offset))
+  | I8 -> Numeric (Int32.of_int (signed_byte_of
+      (byte_of_str_off node.node_bytes offset)))
+  | U16 -> Numeric (Int32.of_int (short_of_str_off node.node_bytes offset))
+  | I16 -> Numeric (Int32.of_int (signed_short_of
+      (short_of_str_off node.node_bytes offset)))
+  | I32 -> Numeric (int32_of_str_off node.node_bytes offset)
+  | FixedString size -> Text (trim_zeroes (String.sub node.node_bytes offset size))
+  | Resref -> Text (trim_zeroes (String.sub node.node_bytes offset 8))
+
+let check_range field value low high =
+  let wide = Int64.of_int32 value in
+  if wide < Int64.of_int low || wide > Int64.of_int high then
+    error "field %s requires a value from %d through %d; received %ld"
+      field.field_name low high value
+
+let write_numeric node field_name value =
+  let field = find_field node field_name in
+  if not field.field_writable then error "field %s is read-only" field.field_name;
+  let offset = field.field_offset in
+  (match field.field_kind with
+  | U8 -> check_range field value 0 255;
+      write_byte node.node_bytes offset (Int32.to_int value)
+  | I8 -> check_range field value (-128) 127;
+      write_byte node.node_bytes offset (Int32.to_int value)
+  | U16 -> check_range field value 0 65535;
+      write_short node.node_bytes offset (Int32.to_int value)
+  | I16 -> check_range field value (-32768) 32767;
+      write_short node.node_bytes offset (Int32.to_int value)
+  | I32 -> write_int32 node.node_bytes offset value
+  | FixedString _ | Resref ->
+      error "field %s is textual; use RESOURCE_SPRINT" field.field_name);
+  (active ()).editor_dirty <- true
+
+let write_text node field_name value =
+  let field = find_field node field_name in
+  if not field.field_writable then error "field %s is read-only" field.field_name;
+  let size = match field.field_kind with
+  | FixedString size -> size | Resref -> 8
+  | _ -> error "field %s is numeric; use RESOURCE_SET" field.field_name in
+  if String.length value > size then
+    error "field %s accepts at most %d bytes; received %d"
+      field.field_name size (String.length value);
+  let padded = String.make size '\000' in
+  String.blit value 0 padded 0 (String.length value);
+  String.blit padded 0 node.node_bytes field.field_offset size;
+  (active ()).editor_dirty <- true
+
+type collection_ref =
+  | AbilityCollection
+  | GlobalCollection
+  | EffectCollection of node
+
+let collection editor = function
+  | TP_Resource_Abilities ->
+      (match editor.editor_format with
+       | EffV20 -> error "EFF resources have no abilities"
+       | _ -> AbilityCollection)
+  | TP_Resource_GlobalEffects ->
+      (match editor.editor_format with
+       | EffV20 -> error "EFF resources have no global effects"
+       | _ -> GlobalCollection)
+  | TP_Resource_EffectsOf handle ->
+      let owner = resolve_handle editor handle in
+      if owner.node_kind <> Ability then
+        error "EFFECTS OF requires an ability handle";
+      EffectCollection owner
+
+let live list = List.filter (fun node -> not node.node_deleted) list
+
+let collection_nodes editor = function
+  | AbilityCollection -> live editor.editor_abilities
+  | GlobalCollection -> live editor.editor_globals
+  | EffectCollection owner -> live owner.node_effects
+
+let set_collection editor target nodes = match target with
+  | AbilityCollection -> editor.editor_abilities <- nodes
+  | GlobalCollection -> editor.editor_globals <- nodes
+  | EffectCollection owner -> owner.node_effects <- nodes
+
+let make_zero editor target =
+  let kind, desc = match target with
+  | AbilityCollection -> Ability,
+      (match editor.editor_format with
+       | ItmV1 | ItmV11 -> itm_v1_ability_desc
+       | ItmV20 -> itm_v2_ability_desc
+       | SplV1 | SplV20 -> spl_ability_desc
+       | EffV20 -> assert false)
+  | GlobalCollection | EffectCollection _ -> Effect, embedded_effect_desc in
+  let node = new_node editor.editor_next_id kind desc
+      (String.make desc.record_size '\000') in
+  editor.editor_next_id <- editor.editor_next_id + 1;
+  node
+
+let refresh_metadata editor = match editor.editor_format with
+  | EffV20 -> ()
+  | ItmV1 | ItmV11 | ItmV20 | SplV1 | SplV20 ->
+      let abilities = live editor.editor_abilities in
+      let globals = live editor.editor_globals in
+      let ability_size = match abilities with
+        | head :: _ -> head.node_desc.record_size
+        | [] -> (match editor.editor_format with
+          | ItmV1 | ItmV11 -> itm_v1_ability_desc.record_size
+          | ItmV20 -> itm_v2_ability_desc.record_size
+          | SplV1 | SplV20 -> spl_ability_desc.record_size
+          | _ -> assert false) in
+      let effects_offset = String.length editor.editor_root.node_bytes +
+          List.length abilities * ability_size + String.length editor.editor_gap in
+      write_short editor.editor_root.node_bytes 0x68 (List.length abilities);
+      write_int editor.editor_root.node_bytes 0x6a effects_offset;
+      write_short editor.editor_root.node_bytes 0x6e 0;
+      write_short editor.editor_root.node_bytes 0x70 (List.length globals);
+      let index = ref (List.length globals) in
+      List.iter (fun ability ->
+        let effects = live ability.node_effects in
+        write_short ability.node_bytes 0x1e (List.length effects);
+        write_short ability.node_bytes 0x20 !index;
+        index := !index + List.length effects) abilities
+
+let mark_changed editor = editor.editor_dirty <- true; refresh_metadata editor
+
+let insert_relative nodes anchor before inserted =
+  let rec walk acc = function
+    | [] -> error "anchor does not belong to the selected collection"
+    | head :: tail when head == anchor ->
+        if before then List.rev_append acc (inserted :: head :: tail)
+        else List.rev_append acc (head :: inserted :: tail)
+    | head :: tail -> walk (head :: acc) tail in
+  walk [] nodes
+
+let add editor target position node =
+  let nodes = collection_nodes editor target in
+  let updated = match position with
+  | None -> nodes @ [node]
+  | Some (TP_Resource_Before handle) ->
+      insert_relative nodes (resolve_handle editor handle) true node
+  | Some (TP_Resource_After handle) ->
+      insert_relative nodes (resolve_handle editor handle) false node in
+  set_collection editor target updated;
+  mark_changed editor
+
+let clone_node editor source target = match source.node_kind, target with
+  | Ability, AbilityCollection ->
+      let clone = make_zero editor target in
+      clone.node_bytes <- String.copy source.node_bytes;
+      clone.node_effects <- List.map (fun effect ->
+        let copy = make_zero editor (EffectCollection clone) in
+        copy.node_bytes <- String.copy effect.node_bytes; copy)
+        (live source.node_effects);
+      clone
+  | Effect, (GlobalCollection | EffectCollection _) ->
+      let clone = make_zero editor target in
+      clone.node_bytes <- String.copy source.node_bytes; clone
+  | Root, _ -> error "the root record cannot be cloned"
+  | Ability, _ -> error "an ability can only be cloned into ABILITIES"
+  | Effect, AbilityCollection -> error "an effect cannot be cloned into ABILITIES"
+
+let delete editor node =
+  if node.node_kind = Root then error "the root record cannot be deleted";
+  node.node_deleted <- true;
+  if node.node_kind = Ability then
+    List.iter (fun effect -> effect.node_deleted <- true) node.node_effects;
+  mark_changed editor
+
+let serialize editor =
+  if not editor.editor_dirty then String.copy editor.editor_original else begin
+    refresh_metadata editor;
+    let output = Buffer.create (String.length editor.editor_original) in
+    Buffer.add_string output editor.editor_root.node_bytes;
+    List.iter (fun ability -> Buffer.add_string output ability.node_bytes)
+      (live editor.editor_abilities);
+    Buffer.add_string output editor.editor_gap;
+    List.iter (fun effect -> Buffer.add_string output effect.node_bytes)
+      (live editor.editor_globals);
+    List.iter (fun ability ->
+      List.iter (fun effect -> Buffer.add_string output effect.node_bytes)
+        (live ability.node_effects)) (live editor.editor_abilities);
+    Buffer.add_string output editor.editor_tail;
+    let result = Buffer.contents output in
+    ignore (parse editor.editor_kind result);
+    result
+  end
+
+let get handle field =
+  let editor = active () in read (resolve_handle editor handle) field
+
+let set handle field value =
+  let editor = active () in write_numeric (resolve_handle editor handle) field value
+
+let sprint handle field value =
+  let editor = active () in write_text (resolve_handle editor handle) field value
+
+let for_each collection_spec handle body =
+  let editor = active () in
+  let snapshot = collection_nodes editor (collection editor collection_spec) in
+  List.iter (fun node ->
+    if not node.node_deleted then with_binding editor handle node body) snapshot
+
+let append collection_spec handle body =
+  let editor = active () in
+  let target = collection editor collection_spec in
+  let node = make_zero editor target in
+  add editor target None node;
+  with_binding editor handle node body
+
+let insert collection_spec position handle body =
+  let editor = active () in
+  let target = collection editor collection_spec in
+  let node = make_zero editor target in
+  add editor target (Some position) node;
+  with_binding editor handle node body
+
+let clone source_handle collection_spec position handle body =
+  let editor = active () in
+  let source = resolve_handle editor source_handle in
+  let target = collection editor collection_spec in
+  let node = clone_node editor source target in
+  add editor target position node;
+  with_binding editor handle node body
+
+let delete_handle handle =
+  let editor = active () in delete editor (resolve_handle editor handle)

--- a/src/trealparserin.in
+++ b/src/trealparserin.in
@@ -37,24 +37,24 @@ let resource_kind value = match String.uppercase value with
   | "SPL" -> Tp.TP_Resource_SPL
   | "EFF" -> Tp.TP_Resource_EFF
   | _ -> failwith (Printf.sprintf
-      "PATCH_RESOURCE: expected ITM, SPL, or EFF; found %S" value)
+      "structured resource: expected itm, spl, or eff; found [%s]" value)
 
 let resource_collection value = match String.uppercase value with
   | "ABILITIES" -> Tp.TP_Resource_Abilities
   | "GLOBAL_EFFECTS" -> Tp.TP_Resource_GlobalEffects
   | _ -> failwith (Printf.sprintf
-      "PATCH_RESOURCE: expected ABILITIES or GLOBAL_EFFECTS; found %S" value)
+      "structured resource: expected abilities or global_effects; found [%s]" value)
 
 let resource_effect_collection first connector handle =
   if String.uppercase first <> "EFFECTS" || String.uppercase connector <> "OF" then
     failwith (Printf.sprintf
-      "PATCH_RESOURCE: expected EFFECTS OF <handle>; found %S %S"
+      "structured resource: expected effects of <handle>; found [%s %s]"
       first connector);
   Tp.TP_Resource_EffectsOf handle
 
 let require_resource_word expected actual =
   if String.uppercase actual <> expected then
-    failwith (Printf.sprintf "PATCH_RESOURCE: expected %s; found %S"
+    failwith (Printf.sprintf "structured resource: expected %s; found [%s]"
       expected actual)
 }
 

--- a/src/trealparserin.in
+++ b/src/trealparserin.in
@@ -31,6 +31,31 @@ let seven_patch_exp v1 v2 v3 v4 v5 v6 v7 =
 let eight_patch_exp e1 v1 v2 v3 v4 v5 v6 v7 =
   let g x = Tp.get_pe_int (string_of_int x) in
   e1, g v1, g v2, g v3, g v4, g v5, g v6, g v7
+
+let resource_kind value = match String.uppercase value with
+  | "ITM" -> Tp.TP_Resource_ITM
+  | "SPL" -> Tp.TP_Resource_SPL
+  | "EFF" -> Tp.TP_Resource_EFF
+  | _ -> failwith (Printf.sprintf
+      "PATCH_RESOURCE: expected ITM, SPL, or EFF; found %S" value)
+
+let resource_collection value = match String.uppercase value with
+  | "ABILITIES" -> Tp.TP_Resource_Abilities
+  | "GLOBAL_EFFECTS" -> Tp.TP_Resource_GlobalEffects
+  | _ -> failwith (Printf.sprintf
+      "PATCH_RESOURCE: expected ABILITIES or GLOBAL_EFFECTS; found %S" value)
+
+let resource_effect_collection first connector handle =
+  if String.uppercase first <> "EFFECTS" || String.uppercase connector <> "OF" then
+    failwith (Printf.sprintf
+      "PATCH_RESOURCE: expected EFFECTS OF <handle>; found %S %S"
+      first connector);
+  Tp.TP_Resource_EffectsOf handle
+
+let require_resource_word expected actual =
+  if String.uppercase actual <> expected then
+    failwith (Printf.sprintf "PATCH_RESOURCE: expected %s; found %S"
+      expected actual)
 }
 
 
@@ -1159,6 +1184,25 @@ nonterm (Tp.tp_patch) Tp_Patch {
   -> LAUNCH_PATCH_FUNCTION e1:STRING e2:LaunchFunctionIntVar
      e3:LaunchFunctionStrVar e4:LaunchFunctionRet e5:LaunchFunctionRetArray END
        [ Tp.TP_Launch_Patch_Function(e1,true,e2,e3,e4,e5) ]
+  -> PATCH_RESOURCE e1:STRING BEGIN e2:Tp_Patch_List END
+       [ Tp.TP_PatchResource(resource_kind e1,e2) ]
+  -> RESOURCE_GET e1:STRING e2:STRING e3:STRING e4:Patch_String_Left
+       [ require_resource_word "INTO" e3; Tp.TP_ResourceGet(e1,e2,e4) ]
+  -> RESOURCE_SET e1:STRING e2:STRING EQUALS e3:Patch_Exp
+       [ Tp.TP_ResourceSet(e1,e2,e3) ]
+  -> RESOURCE_SPRINT e1:STRING e2:STRING e3:Patch_String_Right
+       [ Tp.TP_ResourceSprint(e1,e2,e3) ]
+  -> RESOURCE_FOR_EACH e1:Resource_Collection AS e2:STRING BEGIN e3:Tp_Patch_List END
+       [ Tp.TP_ResourceForEach(e1,e2,e3) ]
+  -> RESOURCE_APPEND e1:Resource_Collection AS e2:STRING BEGIN e3:Tp_Patch_List END
+       [ Tp.TP_ResourceAppend(e1,e2,e3) ]
+  -> RESOURCE_INSERT e1:Resource_Collection e2:Resource_Position AS e3:STRING
+       BEGIN e4:Tp_Patch_List END
+       [ Tp.TP_ResourceInsert(e1,e2,e3,e4) ]
+  -> RESOURCE_CLONE e1:STRING e2:STRING e3:Resource_Collection
+       e4:Optional_Resource_Position AS e5:STRING BEGIN e6:Tp_Patch_List END
+       [ require_resource_word "TO" e2; Tp.TP_ResourceClone(e1,e3,e4,e5,e6) ]
+  -> RESOURCE_DELETE e1:STRING [ Tp.TP_ResourceDelete(e1) ]
   -> REPLACE e1:Optional_Case_Sensitive e2:Optional_Match_Exact e3:STRING e4:Lse
        [ Tp.TP_PatchString(e1,e2,e3,e4) ]
   -> REPLACE_TEXTUALLY e1:Optional_Case_Sensitive e2:Optional_Match_Exact e3:STRING e4:STRING
@@ -1454,6 +1498,22 @@ nonterm (Tp.tp_local_declaration list) Tp_Local_Declaration_List_Rev {
 
 nonterm (Tp.tp_local_declaration list) Tp_Local_Declaration_List {
   -> e2:Tp_Local_Declaration_List_Rev [ List.rev e2 ]
+}
+
+nonterm (Tp.tp_resource_collection) Resource_Collection {
+  -> e1:STRING [ resource_collection e1 ]
+  -> e1:STRING e2:STRING e3:STRING
+       [ resource_effect_collection e1 e2 e3 ]
+}
+
+nonterm (Tp.tp_resource_position) Resource_Position {
+  -> BEFORE e1:STRING [ Tp.TP_Resource_Before e1 ]
+  -> AFTER e1:STRING [ Tp.TP_Resource_After e1 ]
+}
+
+nonterm (Tp.tp_resource_position option) Optional_Resource_Position {
+  -> [ None ]
+  -> e1:Resource_Position [ Some e1 ]
 }
 
 nonterm (Tp.tp_local_declaration) Tp_Local_Declaration {

--- a/test/structured-resources/README.md
+++ b/test/structured-resources/README.md
@@ -1,0 +1,66 @@
+# Structured resource tests and benchmarks
+
+`run_tests.sh` exercises the supported ITM, SPL, and EFF schemas. In
+addition to ordinary field edits, it covers nested iteration, cross-collection
+effect cloning, deep ability cloning, stable insertion anchors, deletion while
+iterating, preservation of trailing bytes, and rollback of a multi-step graph
+rewrite. The generated ITM fixture demonstrates a practical upper-end rewrite;
+the paired SPL fixtures prove that a late error restores every byte of the
+original resource.
+
+Run the regression suite from the repository root:
+
+```sh
+make test-structured-resources
+```
+
+## Performance benchmark
+
+`benchmark.sh` compares byte-identical outputs from the structured editor and
+ad hoc functions. It has two workloads:
+
+- `field` changes four ability headers and all 36 embedded effects. It compares
+  `PATCH_RESOURCE`, a purpose-built direct-offset function, and WeiDU's bundled
+  `ALTER_ITEM_HEADER` plus `ALTER_ITEM_EFFECT` helpers.
+- `structural` deep-clones four abilities and their 32 owned effects, changes
+  each clone, appends an effect to each clone, relocates the effect table, and
+  rebuilds ownership indices. It compares `PATCH_RESOURCE` with a purpose-built
+  direct-offset implementation of the same graph rewrite.
+
+The default matrix uses 1,000, 10,000, and 100,000 physical input files. It
+runs one unrecorded warm-up per method, then respectively records seven, five,
+and three repetitions. Method order is reversed on alternating repetitions to
+reduce order bias. Input generation is outside the timed region. After every
+scale, SHA-256 manifests must show byte-for-byte equivalence between all
+implementations of a workload or the benchmark fails.
+
+Run the complete Linux benchmark with:
+
+```sh
+make benchmark-structured-resources
+```
+
+For a short developer run, or to select a persistent results directory:
+
+```sh
+BENCH_COUNTS="100 1000" BENCH_REPETITIONS=3 \
+BENCH_RESULT_DIR=/tmp/weidu-structured-results \
+make benchmark-structured-resources
+```
+
+`BENCH_JOBS` controls only parallel fixture generation, never the measured
+WeiDU process. Results comprise:
+
+- `raw.tsv`: external wall, user and system time, maximum resident memory, and
+  WeiDU's internal `PATCH_TIME` CPU measurement for every recorded run;
+- `summary.md`: medians, observed wall-time ranges, throughput, and ratios to
+  the purpose-built direct function;
+- `environment.txt`: the timestamp, host characteristics, binary digest,
+  source revision, scale, and repetition settings.
+
+Wall time is the appropriate installation-impact measure because it includes
+file discovery, reads, patching, and writes. `PATCH_TIME` isolates the patch
+body's user-CPU cost. Neither metric is a language guarantee: results depend on
+the host, filesystem, cache state, compiler, resource shape, and operation mix.
+Commit the benchmark and methodology, but publish measured numbers as CI
+artifacts or pull-request evidence rather than as permanent documentation.

--- a/test/structured-resources/README.md
+++ b/test/structured-resources/README.md
@@ -27,12 +27,14 @@ ad hoc functions. It has two workloads:
   rebuilds ownership indices. It compares `PATCH_RESOURCE` with a purpose-built
   direct-offset implementation of the same graph rewrite.
 
-The default matrix uses 1,000, 10,000, and 100,000 physical input files. It
-runs one unrecorded warm-up per method, then respectively records seven, five,
-and three repetitions. Method order is reversed on alternating repetitions to
-reduce order bias. Input generation is outside the timed region. After every
-scale, SHA-256 manifests must show byte-for-byte equivalence between all
-implementations of a workload or the benchmark fails.
+The default matrix uses 1,000 and 10,000 physical input files. At 1,000 files
+it runs one unrecorded warm-up per method followed by seven measurements,
+reversing method order on alternating repetitions to reduce order bias. It then
+records one 10,000-file scale-confirmation observation per method. Before every
+scale, input and output directories are pre-seeded outside the timed region;
+this gives each method equivalent existing-file state without an unreported
+full-scale warm-up. After every scale, SHA-256 manifests must show byte-for-byte
+equivalence between all implementations of a workload or the benchmark fails.
 
 Run the complete Linux benchmark with:
 
@@ -58,6 +60,8 @@ WeiDU process. Results comprise:
 - `environment.txt`: the timestamp, host characteristics, binary digest,
   source revision, scale, and repetition settings.
 
+The repeated 1,000-file measurements provide an observed variance range. The
+single 10,000-file observation tests scale but is not a variance estimate.
 Wall time is the appropriate installation-impact measure because it includes
 file discovery, reads, patching, and writes. `PATCH_TIME` isolates the patch
 body's user-CPU cost. Neither metric is a language guarantee: results depend on

--- a/test/structured-resources/benchmark.sh
+++ b/test/structured-resources/benchmark.sh
@@ -94,8 +94,9 @@ if ! run_weidu 0 seed.log; then
   exit 1
 fi
 seed="$work_dir/override/bseed.itm"
-if [[ ! -f "$seed" ]] || [[ $(wc -c <"$seed") -ne 2066 ]]; then
-  printf '%s\n' 'Benchmark seed is missing or has an unexpected size.' >&2
+if [[ ! -s "$seed" ]]; then
+  printf '%s\n' 'Benchmark seed is missing or empty.' >&2
+  sed -n '1,240p' "$work_dir/seed.log" >&2
   exit 1
 fi
 

--- a/test/structured-resources/benchmark.sh
+++ b/test/structured-resources/benchmark.sh
@@ -93,7 +93,7 @@ if ! run_weidu 0 seed.log; then
   sed -n '1,240p' "$work_dir/seed.log" >&2
   exit 1
 fi
-seed="$work_dir/override/benchmark_seed.itm"
+seed="$work_dir/override/bseed.itm"
 if [[ ! -f "$seed" ]] || [[ $(wc -c <"$seed") -ne 2066 ]]; then
   printf '%s\n' 'Benchmark seed is missing or has an unexpected size.' >&2
   exit 1

--- a/test/structured-resources/benchmark.sh
+++ b/test/structured-resources/benchmark.sh
@@ -225,12 +225,12 @@ verify_outputs() {
 
 current_count=0
 for count in $counts; do
-  printf 'Preparing %,d physical input files...\n' "$count"
+  printf 'Preparing %d physical input files...\n' "$count"
   extend_input "$((current_count + 1))" "$count"
   current_count=$count
   repetitions=$(repetitions_for_count "$count")
 
-  printf 'Warming all methods at %,d files...\n' "$count"
+  printf 'Warming all methods at %d files...\n' "$count"
   for specification in "${methods[@]}"; do
     run_measurement "$specification" "$count" 0
   done
@@ -239,7 +239,7 @@ for count in $counts; do
   mv -- "$raw.tmp" "$raw"
 
   for (( repetition = 1; repetition <= repetitions; ++repetition )); do
-    printf 'Measuring %,d files, repetition %d/%d...\n' \
+    printf 'Measuring %d files, repetition %d/%d...\n' \
       "$count" "$repetition" "$repetitions"
     if (( repetition % 2 == 1 )); then
       for specification in "${methods[@]}"; do

--- a/test/structured-resources/benchmark.sh
+++ b/test/structured-resources/benchmark.sh
@@ -82,9 +82,9 @@ run_weidu() {
   local log_file=$2
   (
     cd -- "$work_dir"
-    rm -f -- weidu.log BENCHMARK.DEBUG benchmark.debug \
-      SETUP-BENCHMARK.DEBUG setup-benchmark.debug
-    "$weidu_bin" --nogame --no-exit-pause --force-install "$component" \
+    rm -f -- weidu.log benchmark.debug
+    "$weidu_bin" --log benchmark.debug --nogame --no-exit-pause \
+      --force-install "$component" \
       benchmark.tp2 </dev/null >"$log_file" 2>&1
   )
 }
@@ -154,10 +154,10 @@ run_measurement() {
 
   if ! (
     cd -- "$work_dir"
-    rm -f -- weidu.log BENCHMARK.DEBUG benchmark.debug \
-      SETUP-BENCHMARK.DEBUG setup-benchmark.debug "$time_file"
+    rm -f -- weidu.log benchmark.debug "$time_file"
     /usr/bin/time -o "$time_file" -f '%e\t%U\t%S\t%M' \
-      "$weidu_bin" --nogame --no-exit-pause --force-install "$component" \
+      "$weidu_bin" --log benchmark.debug --nogame --no-exit-pause \
+      --force-install "$component" \
       benchmark.tp2 </dev/null >"$log_file" 2>&1
   ); then
     printf '%s\n' "Benchmark failed: $workload/$method at $count files" >&2
@@ -165,8 +165,7 @@ run_measurement() {
     exit 1
   fi
 
-  debug_file=$(find "$work_dir" -maxdepth 1 -type f \
-    -iname '*benchmark.debug' -print -quit)
+  debug_file="$work_dir/benchmark.debug"
   if [[ -z "$debug_file" ]]; then
     printf '%s\n' "WeiDU debug log missing for $workload/$method" >&2
     exit 1

--- a/test/structured-resources/benchmark.sh
+++ b/test/structured-resources/benchmark.sh
@@ -24,7 +24,7 @@ for command in cp find sha256sum sort xargs /usr/bin/time; do
   fi
 done
 
-counts=${BENCH_COUNTS:-"1000 10000 100000"}
+counts=${BENCH_COUNTS:-"1000 10000"}
 repetition_override=${BENCH_REPETITIONS:-}
 jobs=${BENCH_JOBS:-$(getconf _NPROCESSORS_ONLN 2>/dev/null || printf '1')}
 case "$jobs" in
@@ -118,16 +118,15 @@ repetitions_for_count() {
     printf '%s\n' "$repetition_override"
   elif (( count <= 1000 )); then
     printf '7\n'
-  elif (( count <= 10000 )); then
-    printf '5\n'
   else
-    printf '3\n'
+    printf '1\n'
   fi
 }
 
-extend_input() {
-  local from=$1
-  local to=$2
+extend_fixture_directory() {
+  local destination=$1
+  local from=$2
+  local to=$3
   if (( from > to )); then
     return
   fi
@@ -139,7 +138,23 @@ extend_input() {
       for name do
         cp --reflink=never -- "$seed" "$destination/$name"
       done
-    ' sh "$seed" "$work_dir/benchmark-input"
+    ' sh "$seed" "$destination"
+}
+
+extend_fixtures() {
+  local from=$1
+  local to=$2
+  local directory
+  extend_fixture_directory "$work_dir/benchmark-input" "$from" "$to"
+  for directory in \
+    benchmark-out-field-structured \
+    benchmark-out-field-direct \
+    benchmark-out-field-bundled \
+    benchmark-out-structural-structured \
+    benchmark-out-structural-direct
+  do
+    extend_fixture_directory "$work_dir/$directory" "$from" "$to"
+  done
 }
 
 run_measurement() {
@@ -228,17 +243,21 @@ verify_outputs() {
 current_count=0
 for count in $counts; do
   printf 'Preparing %d physical input files...\n' "$count"
-  extend_input "$((current_count + 1))" "$count"
+  extend_fixtures "$((current_count + 1))" "$count"
   current_count=$count
   repetitions=$(repetitions_for_count "$count")
 
-  printf 'Warming all methods at %d files...\n' "$count"
-  for specification in "${methods[@]}"; do
-    run_measurement "$specification" "$count" 0
-  done
-  # Warm-up data exercises the full path but is deliberately excluded.
-  awk -F '\t' 'NR == 1 || $4 != 0' "$raw" >"$raw.tmp"
-  mv -- "$raw.tmp" "$raw"
+  if (( count <= 1000 )); then
+    printf 'Warming all methods at %d files...\n' "$count"
+    for specification in "${methods[@]}"; do
+      run_measurement "$specification" "$count" 0
+    done
+    # Warm-up data exercises the full path but is deliberately excluded.
+    awk -F '\t' 'NR == 1 || $4 != 0' "$raw" >"$raw.tmp"
+    mv -- "$raw.tmp" "$raw"
+  else
+    printf 'Using pre-seeded outputs; no unreported full-scale warm-up at %d files.\n' "$count"
+  fi
 
   for (( repetition = 1; repetition <= repetitions; ++repetition )); do
     printf 'Measuring %d files, repetition %d/%d...\n' \
@@ -282,7 +301,8 @@ median_metric() {
 summary="$result_dir/summary.md"
 {
   printf '# Structured resource benchmark\n\n'
-  printf 'All rows report medians from measured runs after one warm-up. '
+  printf 'The 1,000-file rows report medians after one full-scale warm-up; '
+  printf 'the 10,000-file rows are single scale-confirmation observations over pre-seeded outputs. '
   printf 'The wall-time ratio is relative to the purpose-built direct-offset function for the same workload and scale.\n\n'
   printf '| Workload | Files | Method | Runs | Median wall (s) | Wall range (s) | Median PATCH_TIME (CPU s) | Files/s | Wall ratio vs direct |\n'
   printf '|---|---:|---|---:|---:|---:|---:|---:|---:|\n'
@@ -324,7 +344,7 @@ environment="$result_dir/environment.txt"
   printf 'weidu_sha256=%s\n' "$(sha256sum "$weidu_bin" | awk '{ print $1 }')"
   printf 'git_head=%s\n' "$(git -C "$repo_root" rev-parse HEAD 2>/dev/null || true)"
   printf 'counts=%s\n' "$counts"
-  printf 'repetition_override=%s\n' "${repetition_override:-adaptive_7_5_3}"
+  printf 'repetition_override=%s\n' "${repetition_override:-adaptive_7_1}"
   printf 'generation_jobs=%s\n' "$jobs"
 } >"$environment"
 

--- a/test/structured-resources/benchmark.sh
+++ b/test/structured-resources/benchmark.sh
@@ -82,7 +82,8 @@ run_weidu() {
   local log_file=$2
   (
     cd -- "$work_dir"
-    rm -f -- weidu.log SETUP-BENCHMARK.DEBUG setup-benchmark.debug
+    rm -f -- weidu.log BENCHMARK.DEBUG benchmark.debug \
+      SETUP-BENCHMARK.DEBUG setup-benchmark.debug
     "$weidu_bin" --nogame --no-exit-pause --force-install "$component" \
       benchmark.tp2 </dev/null >"$log_file" 2>&1
   )
@@ -153,7 +154,8 @@ run_measurement() {
 
   if ! (
     cd -- "$work_dir"
-    rm -f -- weidu.log SETUP-BENCHMARK.DEBUG setup-benchmark.debug "$time_file"
+    rm -f -- weidu.log BENCHMARK.DEBUG benchmark.debug \
+      SETUP-BENCHMARK.DEBUG setup-benchmark.debug "$time_file"
     /usr/bin/time -o "$time_file" -f '%e\t%U\t%S\t%M' \
       "$weidu_bin" --nogame --no-exit-pause --force-install "$component" \
       benchmark.tp2 </dev/null >"$log_file" 2>&1
@@ -163,7 +165,8 @@ run_measurement() {
     exit 1
   fi
 
-  debug_file=$(find "$work_dir" -maxdepth 1 -type f -iname 'setup-benchmark.debug' -print -quit)
+  debug_file=$(find "$work_dir" -maxdepth 1 -type f \
+    -iname '*benchmark.debug' -print -quit)
   if [[ -z "$debug_file" ]]; then
     printf '%s\n' "WeiDU debug log missing for $workload/$method" >&2
     exit 1

--- a/test/structured-resources/benchmark.sh
+++ b/test/structured-resources/benchmark.sh
@@ -1,0 +1,329 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+export LC_ALL=C
+
+script_dir=$(cd -- "$(dirname -- "$0")" && pwd)
+repo_root=$(cd -- "$script_dir/../.." && pwd)
+weidu_bin=${1:-"$repo_root/weidu"}
+
+case "$weidu_bin" in
+  /*) ;;
+  *) weidu_bin=$(cd -- "$(dirname -- "$weidu_bin")" && pwd)/$(basename -- "$weidu_bin") ;;
+esac
+
+if [[ ! -x "$weidu_bin" ]]; then
+  printf '%s\n' "WeiDU executable not found or not executable: $weidu_bin" >&2
+  exit 2
+fi
+
+for command in cp find sha256sum sort xargs /usr/bin/time; do
+  if ! command -v "$command" >/dev/null 2>&1; then
+    printf '%s\n' "Required benchmark command not found: $command" >&2
+    exit 2
+  fi
+done
+
+counts=${BENCH_COUNTS:-"1000 10000 100000"}
+repetition_override=${BENCH_REPETITIONS:-}
+jobs=${BENCH_JOBS:-$(getconf _NPROCESSORS_ONLN 2>/dev/null || printf '1')}
+case "$jobs" in
+  ''|*[!0-9]*|0) printf '%s\n' "BENCH_JOBS must be a positive integer: $jobs" >&2; exit 2 ;;
+esac
+
+previous_count=0
+for count in $counts; do
+  case "$count" in
+    ''|*[!0-9]*|0) printf '%s\n' "BENCH_COUNTS contains an invalid value: $count" >&2; exit 2 ;;
+  esac
+  if (( count <= previous_count )); then
+    printf '%s\n' 'BENCH_COUNTS must be a strictly increasing list.' >&2
+    exit 2
+  fi
+  previous_count=$count
+done
+
+if [[ -n "$repetition_override" ]]; then
+  case "$repetition_override" in
+    *[!0-9]*|0) printf '%s\n' "BENCH_REPETITIONS must be a positive integer: $repetition_override" >&2; exit 2 ;;
+  esac
+fi
+
+if [[ -n ${BENCH_RESULT_DIR:-} ]]; then
+  result_dir=$BENCH_RESULT_DIR
+  if [[ -e "$result_dir" ]] && [[ -n $(find "$result_dir" -mindepth 1 -print -quit 2>/dev/null) ]]; then
+    printf '%s\n' "BENCH_RESULT_DIR is not empty: $result_dir" >&2
+    exit 2
+  fi
+  mkdir -p -- "$result_dir"
+else
+  result_dir=$(mktemp -d "${TMPDIR:-/tmp}/weidu-structured-benchmark-results.XXXXXX")
+fi
+result_dir=$(cd -- "$result_dir" && pwd)
+
+work_dir=$(mktemp -d "${TMPDIR:-/tmp}/weidu-structured-benchmark.XXXXXX")
+cleanup() {
+  rm -rf -- "$work_dir"
+}
+trap cleanup EXIT HUP INT TERM
+
+mkdir -p \
+  "$work_dir/override" \
+  "$work_dir/benchmark-input" \
+  "$work_dir/benchmark-out-field-structured" \
+  "$work_dir/benchmark-out-field-direct" \
+  "$work_dir/benchmark-out-field-bundled" \
+  "$work_dir/benchmark-out-structural-structured" \
+  "$work_dir/benchmark-out-structural-direct"
+cp -- "$script_dir/benchmark.tp2" "$work_dir/benchmark.tp2"
+
+run_weidu() {
+  local component=$1
+  local log_file=$2
+  (
+    cd -- "$work_dir"
+    rm -f -- weidu.log SETUP-BENCHMARK.DEBUG setup-benchmark.debug
+    "$weidu_bin" --nogame --no-exit-pause --force-install "$component" \
+      benchmark.tp2 </dev/null >"$log_file" 2>&1
+  )
+}
+
+if ! run_weidu 0 seed.log; then
+  printf '%s\n' 'Unable to generate the benchmark seed. Full log:' >&2
+  sed -n '1,240p' "$work_dir/seed.log" >&2
+  exit 1
+fi
+seed="$work_dir/override/benchmark_seed.itm"
+if [[ ! -f "$seed" ]] || [[ $(wc -c <"$seed") -ne 2066 ]]; then
+  printf '%s\n' 'Benchmark seed is missing or has an unexpected size.' >&2
+  exit 1
+fi
+
+raw="$result_dir/raw.tsv"
+printf 'workload\tmethod\tfiles\trepetition\twall_seconds\tuser_seconds\tsystem_seconds\tmax_rss_kib\tpatch_user_seconds\n' >"$raw"
+
+methods=(
+  'field|structured|10|benchmark-out-field-structured|bench-field-structured'
+  'field|direct|11|benchmark-out-field-direct|bench-field-direct'
+  'field|bundled|12|benchmark-out-field-bundled|bench-field-bundled'
+  'structural|structured|20|benchmark-out-structural-structured|bench-structural-structured'
+  'structural|direct|21|benchmark-out-structural-direct|bench-structural-direct'
+)
+
+repetitions_for_count() {
+  local count=$1
+  if [[ -n "$repetition_override" ]]; then
+    printf '%s\n' "$repetition_override"
+  elif (( count <= 1000 )); then
+    printf '7\n'
+  elif (( count <= 10000 )); then
+    printf '5\n'
+  else
+    printf '3\n'
+  fi
+}
+
+extend_input() {
+  local from=$1
+  local to=$2
+  if (( from > to )); then
+    return
+  fi
+  seq -f 'f%07g.itm' "$from" "$to" |
+    xargs -r -n 250 -P "$jobs" sh -c '
+      seed=$1
+      destination=$2
+      shift 2
+      for name do
+        cp --reflink=never -- "$seed" "$destination/$name"
+      done
+    ' sh "$seed" "$work_dir/benchmark-input"
+}
+
+run_measurement() {
+  local specification=$1
+  local count=$2
+  local repetition=$3
+  local workload method component output label
+  IFS='|' read -r workload method component output label <<<"$specification"
+  local time_file="$work_dir/time.txt"
+  local log_file="$work_dir/${workload}-${method}.log"
+  local debug_file patch_time wall user system rss
+
+  if ! (
+    cd -- "$work_dir"
+    rm -f -- weidu.log SETUP-BENCHMARK.DEBUG setup-benchmark.debug "$time_file"
+    /usr/bin/time -o "$time_file" -f '%e\t%U\t%S\t%M' \
+      "$weidu_bin" --nogame --no-exit-pause --force-install "$component" \
+      benchmark.tp2 </dev/null >"$log_file" 2>&1
+  ); then
+    printf '%s\n' "Benchmark failed: $workload/$method at $count files" >&2
+    sed -n '1,280p' "$log_file" >&2
+    exit 1
+  fi
+
+  debug_file=$(find "$work_dir" -maxdepth 1 -type f -iname 'setup-benchmark.debug' -print -quit)
+  if [[ -z "$debug_file" ]]; then
+    printf '%s\n' "WeiDU debug log missing for $workload/$method" >&2
+    exit 1
+  fi
+  patch_time=$(awk -v label="$label" '$1 == label { value = $NF } END { print value }' "$debug_file")
+  if [[ ! "$patch_time" =~ ^[0-9]+([.][0-9]+)?$ ]]; then
+    printf '%s\n' "PATCH_TIME metric missing for $label" >&2
+    sed -n '/Mod Timings/,+12p' "$debug_file" >&2
+    exit 1
+  fi
+  IFS=$'\t' read -r wall user system rss <"$time_file"
+  printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n' \
+    "$workload" "$method" "$count" "$repetition" \
+    "$wall" "$user" "$system" "$rss" "$patch_time" >>"$raw"
+}
+
+verify_count() {
+  local directory=$1
+  local expected=$2
+  local actual
+  actual=$(find "$work_dir/$directory" -maxdepth 1 -type f -name '*.itm' -printf '.' | wc -c)
+  if [[ "$actual" -ne "$expected" ]]; then
+    printf '%s\n' "$directory contains $actual files; expected $expected" >&2
+    exit 1
+  fi
+}
+
+write_manifest() {
+  local directory=$1
+  local destination=$2
+  (
+    cd -- "$work_dir/$directory"
+    find . -maxdepth 1 -type f -name '*.itm' -print0 |
+      sort -z |
+      xargs -0 sha256sum
+  ) >"$destination"
+}
+
+verify_outputs() {
+  local count=$1
+  local directory
+  for directory in \
+    benchmark-out-field-structured \
+    benchmark-out-field-direct \
+    benchmark-out-field-bundled \
+    benchmark-out-structural-structured \
+    benchmark-out-structural-direct
+  do
+    verify_count "$directory" "$count"
+    write_manifest "$directory" "$work_dir/$directory.sha256"
+  done
+  cmp "$work_dir/benchmark-out-field-structured.sha256" \
+      "$work_dir/benchmark-out-field-direct.sha256"
+  cmp "$work_dir/benchmark-out-field-structured.sha256" \
+      "$work_dir/benchmark-out-field-bundled.sha256"
+  cmp "$work_dir/benchmark-out-structural-structured.sha256" \
+      "$work_dir/benchmark-out-structural-direct.sha256"
+}
+
+current_count=0
+for count in $counts; do
+  printf 'Preparing %,d physical input files...\n' "$count"
+  extend_input "$((current_count + 1))" "$count"
+  current_count=$count
+  repetitions=$(repetitions_for_count "$count")
+
+  printf 'Warming all methods at %,d files...\n' "$count"
+  for specification in "${methods[@]}"; do
+    run_measurement "$specification" "$count" 0
+  done
+  # Warm-up data exercises the full path but is deliberately excluded.
+  awk -F '\t' 'NR == 1 || $4 != 0' "$raw" >"$raw.tmp"
+  mv -- "$raw.tmp" "$raw"
+
+  for (( repetition = 1; repetition <= repetitions; ++repetition )); do
+    printf 'Measuring %,d files, repetition %d/%d...\n' \
+      "$count" "$repetition" "$repetitions"
+    if (( repetition % 2 == 1 )); then
+      for specification in "${methods[@]}"; do
+        run_measurement "$specification" "$count" "$repetition"
+      done
+    else
+      for (( index = ${#methods[@]} - 1; index >= 0; --index )); do
+        run_measurement "${methods[index]}" "$count" "$repetition"
+      done
+    fi
+  done
+  verify_outputs "$count"
+done
+
+metric_values() {
+  local workload=$1 method=$2 count=$3 column=$4
+  awk -F '\t' -v workload="$workload" -v method="$method" \
+    -v count="$count" -v column="$column" \
+    'NR > 1 && $1 == workload && $2 == method && $3 == count { print $column }' \
+    "$raw" | sort -n
+}
+
+median_metric() {
+  local workload=$1 method=$2 count=$3 column=$4
+  local values=()
+  mapfile -t values < <(metric_values "$workload" "$method" "$count" "$column")
+  local length=${#values[@]}
+  if (( length == 0 )); then
+    printf '%s\n' 'missing'
+  elif (( length % 2 == 1 )); then
+    printf '%s\n' "${values[length / 2]}"
+  else
+    awk -v a="${values[length / 2 - 1]}" -v b="${values[length / 2]}" \
+      'BEGIN { printf "%.3f\n", (a + b) / 2 }'
+  fi
+}
+
+summary="$result_dir/summary.md"
+{
+  printf '# Structured resource benchmark\n\n'
+  printf 'All rows report medians from measured runs after one warm-up. '
+  printf 'The wall-time ratio is relative to the purpose-built direct-offset function for the same workload and scale.\n\n'
+  printf '| Workload | Files | Method | Runs | Median wall (s) | Wall range (s) | Median PATCH_TIME (CPU s) | Files/s | Wall ratio vs direct |\n'
+  printf '|---|---:|---|---:|---:|---:|---:|---:|---:|\n'
+  for count in $counts; do
+    repetitions=$(repetitions_for_count "$count")
+    for workload in field structural; do
+      direct_wall=$(median_metric "$workload" direct "$count" 5)
+      if [[ "$workload" == field ]]; then
+        report_methods=(structured direct bundled)
+      else
+        report_methods=(structured direct)
+      fi
+      for method in "${report_methods[@]}"; do
+        wall=$(median_metric "$workload" "$method" "$count" 5)
+        patch=$(median_metric "$workload" "$method" "$count" 9)
+        mapfile -t wall_values < <(metric_values "$workload" "$method" "$count" 5)
+        minimum=${wall_values[0]}
+        maximum=${wall_values[${#wall_values[@]}-1]}
+        throughput=$(awk -v files="$count" -v seconds="$wall" \
+          'BEGIN { if (seconds == 0) print "inf"; else printf "%.1f", files / seconds }')
+        ratio=$(awk -v measured="$wall" -v baseline="$direct_wall" \
+          'BEGIN { if (baseline == 0) print "n/a"; else printf "%.3f", measured / baseline }')
+        printf '| %s | %s | %s | %s | %s | %s-%s | %s | %s | %s |\n' \
+          "$workload" "$count" "$method" "$repetitions" "$wall" \
+          "$minimum" "$maximum" "$patch" "$throughput" "$ratio"
+      done
+    done
+  done
+} >"$summary"
+
+environment="$result_dir/environment.txt"
+{
+  printf 'timestamp_utc=%s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  printf 'uname=%s\n' "$(uname -a)"
+  printf 'cpu=%s\n' "$(awk -F ': ' '/^model name/ { print $2; exit }' /proc/cpuinfo 2>/dev/null || true)"
+  printf 'logical_cpus=%s\n' "$(getconf _NPROCESSORS_ONLN 2>/dev/null || true)"
+  printf 'memory_kib=%s\n' "$(awk '/^MemTotal:/ { print $2 }' /proc/meminfo 2>/dev/null || true)"
+  printf 'weidu_binary=%s\n' "$weidu_bin"
+  printf 'weidu_sha256=%s\n' "$(sha256sum "$weidu_bin" | awk '{ print $1 }')"
+  printf 'git_head=%s\n' "$(git -C "$repo_root" rev-parse HEAD 2>/dev/null || true)"
+  printf 'counts=%s\n' "$counts"
+  printf 'repetition_override=%s\n' "${repetition_override:-adaptive_7_5_3}"
+  printf 'generation_jobs=%s\n' "$jobs"
+} >"$environment"
+
+printf '\nResults: %s\n' "$result_dir"
+sed -n '1,80p' "$summary"

--- a/test/structured-resources/benchmark.tp2
+++ b/test/structured-resources/benchmark.tp2
@@ -1,0 +1,193 @@
+BACKUP ~benchmark/backup~
+AUTHOR ~WeiDU structured resource benchmark~
+
+DEFINE_PATCH_FUNCTION BENCHMARK_DIRECT_FIELD
+BEGIN
+  READ_LONG 0x64 ability_offset
+  READ_SHORT 0x68 ability_count
+  READ_LONG 0x6a effect_offset
+  READ_SHORT 0x70 global_count
+
+  FOR (effect_index = 0 ; effect_index < global_count ; ++effect_index) BEGIN
+    SET effect = effect_offset + effect_index * 0x30
+    READ_SHORT effect opcode
+    PATCH_IF opcode = 10 BEGIN
+      WRITE_SHORT effect 11
+      WRITE_LONG (effect + 0x04) 12345
+      WRITE_ASCIIE (effect + 0x14) ~BENCHFX~ (8)
+    END
+  END
+
+  FOR (ability_index = 0 ; ability_index < ability_count ; ++ability_index) BEGIN
+    SET ability = ability_offset + ability_index * 0x38
+    WRITE_SHORT (ability + 0x0e) 30
+    READ_SHORT (ability + 0x1e) ability_effect_count
+    READ_SHORT (ability + 0x20) ability_effect_index
+    FOR (local_index = 0 ; local_index < ability_effect_count ; ++local_index) BEGIN
+      SET effect = effect_offset + (ability_effect_index + local_index) * 0x30
+      READ_SHORT effect opcode
+      PATCH_IF opcode = 10 BEGIN
+        WRITE_SHORT effect 11
+        WRITE_LONG (effect + 0x04) 12345
+        WRITE_ASCIIE (effect + 0x14) ~BENCHFX~ (8)
+      END
+    END
+  END
+END
+
+DEFINE_PATCH_FUNCTION BENCHMARK_DIRECT_STRUCTURAL
+BEGIN
+  READ_LONG 0x64 ability_offset
+  READ_SHORT 0x68 original_ability_count
+  READ_LONG 0x6a original_effect_offset
+  READ_SHORT 0x70 global_count
+
+  // Insert copied ability records from the end so every source offset remains
+  // valid until it is read.
+  SET ability_index = original_ability_count - 1
+  WHILE ability_index >= 0 BEGIN
+    SET original = ability_offset + ability_index * 0x38
+    READ_ASCII original cloned_ability (0x38)
+    INSERT_BYTES (original + 0x38) 0x38
+    WRITE_ASCIIE (original + 0x38) ~%cloned_ability%~ (0x38)
+    SET ability_index -= 1
+  END
+
+  SET effect_offset = original_effect_offset + original_ability_count * 0x38
+  WRITE_SHORT 0x68 (original_ability_count * 2)
+  WRITE_LONG 0x6a effect_offset
+
+  // Insert each copied effect block plus one new suffix effect. Descending
+  // order keeps the original effect indices valid during the rewrite.
+  SET ability_index = original_ability_count - 1
+  WHILE ability_index >= 0 BEGIN
+    SET original = ability_offset + ability_index * 2 * 0x38
+    SET clone = original + 0x38
+    READ_SHORT (original + 0x1e) original_effect_count
+    READ_SHORT (original + 0x20) original_effect_index
+    SET source = effect_offset + original_effect_index * 0x30
+    SET copied_size = original_effect_count * 0x30
+    READ_ASCII source cloned_effects (copied_size)
+    SET insertion = source + copied_size
+    INSERT_BYTES insertion (copied_size + 0x30)
+    WRITE_ASCIIE insertion ~%cloned_effects%~ (copied_size)
+    WRITE_SHORT (insertion + copied_size) 99
+    WRITE_LONG (insertion + copied_size + 0x04) 999
+    WRITE_SHORT (clone + 0x0e) 40
+    WRITE_SHORT (clone + 0x1e) (original_effect_count + 1)
+    SET ability_index -= 1
+  END
+
+  // Rebuild every ownership index after all insertions.
+  SET cursor = global_count
+  FOR (ability_index = 0 ;
+       ability_index < original_ability_count ;
+       ++ability_index) BEGIN
+    SET original = ability_offset + ability_index * 2 * 0x38
+    SET clone = original + 0x38
+    READ_SHORT (original + 0x1e) original_effect_count
+    WRITE_SHORT (original + 0x20) cursor
+    SET cursor += original_effect_count
+    WRITE_SHORT (clone + 0x20) cursor
+    SET cursor += original_effect_count + 1
+  END
+END
+
+BEGIN ~Generate benchmark fixture~ DESIGNATED 0
+
+CREATE ITM VERSION ~V1.0~ ~benchmark_seed~
+  PATCH_RESOURCE ITM BEGIN
+    FOR (global_index = 0 ; global_index < 4 ; ++global_index) BEGIN
+      RESOURCE_APPEND global_effects AS global BEGIN
+        RESOURCE_SET global opcode = 10
+        RESOURCE_SET global parameter1 = global_index
+      END
+    END
+    FOR (ability_index = 0 ; ability_index < 4 ; ++ability_index) BEGIN
+      RESOURCE_APPEND abilities AS ability BEGIN
+        RESOURCE_SET ability header_type = 2
+        RESOURCE_SET ability range = 10 + ability_index
+        FOR (effect_index = 0 ; effect_index < 8 ; ++effect_index) BEGIN
+          RESOURCE_APPEND effects OF ability AS effect BEGIN
+            RESOURCE_SET effect opcode = 10
+            RESOURCE_SET effect parameter1 = ability_index * 100 + effect_index
+          END
+        END
+      END
+    END
+  END
+
+BEGIN ~Structured field workload~ DESIGNATED 10
+
+COPY + ~benchmark-input~ ~benchmark-out-field-structured~
+  PATCH_TIME ~bench-field-structured~ BEGIN
+    PATCH_RESOURCE ITM BEGIN
+      RESOURCE_FOR_EACH global_effects AS effect BEGIN
+        RESOURCE_GET effect opcode INTO opcode
+        PATCH_IF opcode = 10 BEGIN
+          RESOURCE_SET effect opcode = 11
+          RESOURCE_SET effect parameter1 = 12345
+          RESOURCE_SPRINT effect resource ~BENCHFX~
+        END
+      END
+      RESOURCE_FOR_EACH abilities AS ability BEGIN
+        RESOURCE_SET ability range = 30
+        RESOURCE_FOR_EACH effects OF ability AS effect BEGIN
+          RESOURCE_GET effect opcode INTO opcode
+          PATCH_IF opcode = 10 BEGIN
+            RESOURCE_SET effect opcode = 11
+            RESOURCE_SET effect parameter1 = 12345
+            RESOURCE_SPRINT effect resource ~BENCHFX~
+          END
+        END
+      END
+    END
+  END
+
+BEGIN ~Purpose-built field workload~ DESIGNATED 11
+
+COPY + ~benchmark-input~ ~benchmark-out-field-direct~
+  PATCH_TIME ~bench-field-direct~ BEGIN
+    LPF BENCHMARK_DIRECT_FIELD END
+  END
+
+BEGIN ~Bundled helper field workload~ DESIGNATED 12
+
+COPY + ~benchmark-input~ ~benchmark-out-field-bundled~
+  PATCH_TIME ~bench-field-bundled~ BEGIN
+    LPF ALTER_ITEM_HEADER INT_VAR range = 30 END
+    LPF ALTER_ITEM_EFFECT
+      INT_VAR
+        check_globals = 1
+        check_headers = 1
+        match_opcode = 10
+        new_opcode = 11
+        parameter1 = 12345
+      STR_VAR
+        resource = ~BENCHFX~
+    END
+  END
+
+BEGIN ~Structured structural workload~ DESIGNATED 20
+
+COPY + ~benchmark-input~ ~benchmark-out-structural-structured~
+  PATCH_TIME ~bench-structural-structured~ BEGIN
+    PATCH_RESOURCE ITM BEGIN
+      RESOURCE_FOR_EACH abilities AS original BEGIN
+        RESOURCE_CLONE original TO abilities AFTER original AS clone BEGIN
+          RESOURCE_SET clone range = 40
+          RESOURCE_APPEND effects OF clone AS suffix BEGIN
+            RESOURCE_SET suffix opcode = 99
+            RESOURCE_SET suffix parameter1 = 999
+          END
+        END
+      END
+    END
+  END
+
+BEGIN ~Purpose-built structural workload~ DESIGNATED 21
+
+COPY + ~benchmark-input~ ~benchmark-out-structural-direct~
+  PATCH_TIME ~bench-structural-direct~ BEGIN
+    LPF BENCHMARK_DIRECT_STRUCTURAL END
+  END

--- a/test/structured-resources/benchmark.tp2
+++ b/test/structured-resources/benchmark.tp2
@@ -1,6 +1,8 @@
 BACKUP ~benchmark/backup~
 AUTHOR ~WeiDU structured resource benchmark~
 
+ALWAYS
+
 DEFINE_PATCH_FUNCTION BENCHMARK_DIRECT_FIELD
 BEGIN
   READ_LONG 0x64 ability_offset
@@ -91,6 +93,8 @@ BEGIN
     WRITE_SHORT (clone + 0x20) cursor
     SET cursor += original_effect_count + 1
   END
+END
+
 END
 
 BEGIN ~Generate benchmark fixture~ DESIGNATED 0

--- a/test/structured-resources/benchmark.tp2
+++ b/test/structured-resources/benchmark.tp2
@@ -95,7 +95,7 @@ END
 
 BEGIN ~Generate benchmark fixture~ DESIGNATED 0
 
-CREATE ITM VERSION ~V1.0~ ~benchmark_seed~
+CREATE ITM VERSION ~V1.0~ ~bseed~
   PATCH_RESOURCE ITM BEGIN
     FOR (global_index = 0 ; global_index < 4 ; ++global_index) BEGIN
       RESOURCE_APPEND global_effects AS global BEGIN

--- a/test/structured-resources/run_tests.sh
+++ b/test/structured-resources/run_tests.sh
@@ -52,7 +52,7 @@ if ! grep -qi 'STRUCTURED_RESOURCE_TESTS_OK' "$test_dir/test.log"; then
 fi
 
 cmp "$test_dir/override/s_equiv.itm" "$test_dir/override/l_equiv.itm"
-cmp "$test_dir/override/complex_rollback_source.spl" \
-  "$test_dir/override/complex_rollback.spl"
+cmp "$test_dir/override/rbsource.spl" \
+  "$test_dir/override/rbresult.spl"
 
 printf '%s\n' 'Structured resource regression tests passed.'

--- a/test/structured-resources/run_tests.sh
+++ b/test/structured-resources/run_tests.sh
@@ -52,5 +52,7 @@ if ! grep -qi 'STRUCTURED_RESOURCE_TESTS_OK' "$test_dir/test.log"; then
 fi
 
 cmp "$test_dir/override/s_equiv.itm" "$test_dir/override/l_equiv.itm"
+cmp "$test_dir/override/complex_rollback_source.spl" \
+  "$test_dir/override/complex_rollback.spl"
 
 printf '%s\n' 'Structured resource regression tests passed.'

--- a/test/structured-resources/run_tests.sh
+++ b/test/structured-resources/run_tests.sh
@@ -1,0 +1,43 @@
+#!/bin/sh
+set -eu
+
+script_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+repo_root=$(CDPATH= cd -- "$script_dir/../.." && pwd)
+weidu_bin=${1:-"$repo_root/weidu"}
+
+case "$weidu_bin" in
+  /*) ;;
+  *) weidu_bin=$(CDPATH= cd -- "$(dirname -- "$weidu_bin")" && pwd)/$(basename -- "$weidu_bin") ;;
+esac
+
+if [ ! -x "$weidu_bin" ]; then
+  printf '%s\n' "WeiDU executable not found or not executable: $weidu_bin" >&2
+  exit 2
+fi
+
+test_dir=$(mktemp -d "${TMPDIR:-/tmp}/weidu-structured-resources.XXXXXX")
+cleanup() {
+  rm -rf -- "$test_dir"
+}
+trap cleanup EXIT HUP INT TERM
+
+mkdir -p "$test_dir/structured-resources" "$test_dir/override"
+cp "$script_dir/structured-resources.tp2" "$test_dir/structured-resources.tp2"
+cp "$script_dir/verify.sh" "$test_dir/structured-resources/verify.sh"
+chmod +x "$test_dir/structured-resources/verify.sh"
+
+(
+  cd "$test_dir"
+  "$weidu_bin" --nogame --no-exit-pause --force-install 0 \
+    structured-resources.tp2 </dev/null >test.log 2>&1
+)
+
+if ! grep -q 'STRUCTURED_RESOURCE_TESTS_OK' "$test_dir/test.log"; then
+  printf '%s\n' 'Structured resource test marker missing. Full WeiDU log:' >&2
+  sed -n '1,240p' "$test_dir/test.log" >&2
+  exit 1
+fi
+
+cmp "$test_dir/override/s_equiv.itm" "$test_dir/override/l_equiv.itm"
+
+printf '%s\n' 'Structured resource regression tests passed.'

--- a/test/structured-resources/run_tests.sh
+++ b/test/structured-resources/run_tests.sh
@@ -15,6 +15,15 @@ if [ ! -x "$weidu_bin" ]; then
   exit 2
 fi
 
+for contextual_word in ITM SPL EFF ABILITIES GLOBAL_EFFECTS EFFECTS OF INTO TO RESOURCE S
+do
+  if grep -Eq "^[[:space:]]*[0-9]+[[:space:]]+:[[:space:]]+$contextual_word;" \
+      "$repo_root/src/trealparserin.gr"; then
+    printf '%s\n' "contextual word was accidentally reserved: $contextual_word" >&2
+    exit 1
+  fi
+done
+
 test_dir=$(mktemp -d "${TMPDIR:-/tmp}/weidu-structured-resources.XXXXXX")
 cleanup() {
   rm -rf -- "$test_dir"
@@ -26,13 +35,17 @@ cp "$script_dir/structured-resources.tp2" "$test_dir/structured-resources.tp2"
 cp "$script_dir/verify.sh" "$test_dir/structured-resources/verify.sh"
 chmod +x "$test_dir/structured-resources/verify.sh"
 
-(
+if ! (
   cd "$test_dir"
   "$weidu_bin" --nogame --no-exit-pause --force-install 0 \
     structured-resources.tp2 </dev/null >test.log 2>&1
-)
+); then
+  printf '%s\n' 'WeiDU regression component failed. Full log:' >&2
+  sed -n '1,320p' "$test_dir/test.log" >&2
+  exit 1
+fi
 
-if ! grep -q 'STRUCTURED_RESOURCE_TESTS_OK' "$test_dir/test.log"; then
+if ! grep -qi 'STRUCTURED_RESOURCE_TESTS_OK' "$test_dir/test.log"; then
   printf '%s\n' 'Structured resource test marker missing. Full WeiDU log:' >&2
   sed -n '1,240p' "$test_dir/test.log" >&2
   exit 1

--- a/test/structured-resources/structured-resources.tp2
+++ b/test/structured-resources/structured-resources.tp2
@@ -121,6 +121,22 @@ CREATE ITM VERSION ~V1.0~ ~life~
   SET caught = 0
   PATCH_TRY
     PATCH_RESOURCE ITM BEGIN
+      RESOURCE_FOR_EACH abilities AS ability BEGIN
+        WRITE_LONG 0x34 1
+      END
+    END
+  WITH
+    DEFAULT
+      SET caught = 1
+  END
+  READ_LONG 0x34 nested_atomic_price
+  PATCH_IF caught != 1 OR nested_atomic_price != 1234 BEGIN
+    PATCH_FAIL ~nested ordinary mutation bypassed the resource guard~
+  END
+
+  SET caught = 0
+  PATCH_TRY
+    PATCH_RESOURCE ITM BEGIN
       PATCH_RESOURCE ITM BEGIN END
     END
   WITH
@@ -231,6 +247,157 @@ CREATE EFF VERSION ~V2.0~ ~effv20~
            NOT (~%eff_resource%~ STRING_EQUAL_CASE ~SPWI112~) OR
            NOT (~%eff_variable%~ STRING_EQUAL_CASE ~structured_test~) BEGIN
     PATCH_FAIL ~EFF V2.0 fields failed~
+  END
+
+// A graph rewrite that would require manual table relocation, ownership
+// bookkeeping, and cascading deletion when expressed with raw offsets.
+CREATE ITM VERSION ~V1.0~ ~complex_graph~
+  INSERT_BYTES 0x72 4
+  WRITE_ASCII 0x72 ~TAIL~
+  PATCH_RESOURCE ITM BEGIN
+    RESOURCE_SET resource price = 777
+    RESOURCE_APPEND global_effects AS global BEGIN
+      RESOURCE_SET global opcode = 5
+      RESOURCE_SET global parameter1 = 50
+    END
+    RESOURCE_APPEND abilities AS ability BEGIN
+      RESOURCE_SET ability header_type = 2
+      RESOURCE_SET ability range = 10
+      RESOURCE_APPEND effects OF ability AS effect BEGIN
+        RESOURCE_SET effect opcode = 10
+        RESOURCE_SET effect parameter1 = 1
+      END
+      RESOURCE_APPEND effects OF ability AS effect BEGIN
+        RESOURCE_SET effect opcode = 20
+        RESOURCE_SET effect parameter1 = 2
+      END
+      RESOURCE_APPEND effects OF ability AS effect BEGIN
+        RESOURCE_SET effect opcode = 30
+        RESOURCE_SET effect parameter1 = 3
+      END
+    END
+    RESOURCE_FOR_EACH abilities AS original BEGIN
+      RESOURCE_CLONE original TO abilities AFTER original AS variant BEGIN
+        RESOURCE_SET variant range = 40
+        RESOURCE_SET variant projectile = 99
+        RESOURCE_FOR_EACH effects OF variant AS candidate BEGIN
+          RESOURCE_GET candidate opcode INTO candidate_opcode
+          PATCH_IF candidate_opcode = 10 BEGIN
+            RESOURCE_INSERT effects OF variant BEFORE candidate AS prefix BEGIN
+              RESOURCE_SET prefix opcode = 9
+              RESOURCE_SET prefix parameter1 = 90
+            END
+          END
+          PATCH_IF candidate_opcode = 20 BEGIN
+            RESOURCE_CLONE candidate TO global_effects AS promoted BEGIN
+              RESOURCE_SET promoted opcode = 21
+              RESOURCE_SET promoted parameter1 = 210
+            END
+            RESOURCE_DELETE candidate
+          END
+          PATCH_IF candidate_opcode = 30 BEGIN
+            RESOURCE_SET candidate opcode = 31
+            RESOURCE_SPRINT candidate resource ~GRAPHFX~
+          END
+        END
+        RESOURCE_APPEND effects OF variant AS suffix BEGIN
+          RESOURCE_SET suffix opcode = 40
+          RESOURCE_SET suffix parameter1 = 400
+        END
+      END
+      RESOURCE_DELETE original
+    END
+  END
+  READ_LONG 0x34 graph_price
+  READ_SHORT 0x68 graph_abilities
+  READ_LONG 0x6a graph_effect_offset
+  READ_SHORT 0x70 graph_globals
+  READ_SHORT 0x80 graph_range
+  READ_SHORT 0x90 graph_effect_count
+  READ_SHORT 0x92 graph_effect_index
+  READ_SHORT 0x9c graph_projectile
+  READ_SHORT 0xaa graph_opcode_1
+  READ_SHORT 0xda graph_opcode_2
+  READ_SHORT 0x10a graph_opcode_3
+  READ_SHORT 0x13a graph_opcode_4
+  READ_SHORT 0x16a graph_opcode_5
+  READ_SHORT 0x19a graph_opcode_6
+  READ_ASCII 0x1ca graph_tail (4)
+  PATCH_IF graph_price != 777 OR graph_abilities != 1 OR
+           graph_effect_offset != 0xaa OR graph_globals != 2 OR
+           graph_range != 40 OR graph_effect_count != 4 OR
+           graph_effect_index != 2 OR graph_projectile != 99 OR
+           graph_opcode_1 != 5 OR graph_opcode_2 != 21 OR
+           graph_opcode_3 != 9 OR graph_opcode_4 != 10 OR
+           graph_opcode_5 != 31 OR graph_opcode_6 != 40 OR
+           NOT (~%graph_tail%~ STRING_EQUAL_CASE ~TAIL~) BEGIN
+    PATCH_FAIL ~complex ITM graph rewrite failed~
+  END
+
+// A complex failed rewrite must roll back the complete graph, not merely
+// the command that raises the final error.
+CREATE SPL VERSION ~V1.0~ ~complex_rollback_source~
+  PATCH_RESOURCE SPL BEGIN
+    RESOURCE_APPEND global_effects AS effect BEGIN
+      RESOURCE_SET effect opcode = 5
+    END
+    RESOURCE_APPEND abilities AS ability BEGIN
+      RESOURCE_SET ability min_level = 1
+      RESOURCE_APPEND effects OF ability AS effect BEGIN
+        RESOURCE_SET effect opcode = 10
+      END
+      RESOURCE_APPEND effects OF ability AS effect BEGIN
+        RESOURCE_SET effect opcode = 11
+      END
+    END
+    RESOURCE_APPEND abilities AS ability BEGIN
+      RESOURCE_SET ability min_level = 2
+      RESOURCE_APPEND effects OF ability AS effect BEGIN
+        RESOURCE_SET effect opcode = 20
+      END
+      RESOURCE_APPEND effects OF ability AS effect BEGIN
+        RESOURCE_SET effect opcode = 21
+      END
+    END
+  END
+
+COPY + ~override/complex_rollback_source.spl~
+       ~override/complex_rollback.spl~
+  SET caught = 0
+  PATCH_TRY
+    PATCH_RESOURCE SPL BEGIN
+      RESOURCE_FOR_EACH global_effects AS template BEGIN
+        RESOURCE_FOR_EACH abilities AS ability BEGIN
+          RESOURCE_CLONE template TO effects OF ability AS injected BEGIN
+            RESOURCE_SET injected opcode = 77
+          END
+        END
+        RESOURCE_DELETE template
+      END
+      RESOURCE_FOR_EACH abilities AS original BEGIN
+        RESOURCE_GET original min_level INTO old_level
+        RESOURCE_CLONE original TO abilities AFTER original AS clone BEGIN
+          RESOURCE_SET clone min_level = old_level + 10
+          RESOURCE_FOR_EACH effects OF clone AS effect BEGIN
+            RESOURCE_GET effect opcode INTO rollback_opcode
+            PATCH_IF rollback_opcode = 11 BEGIN
+              RESOURCE_DELETE effect
+            END
+          END
+        END
+        RESOURCE_DELETE original
+      END
+      RESOURCE_APPEND global_effects AS replacement BEGIN
+        RESOURCE_SET replacement opcode = 88
+      END
+      RESOURCE_SET resource signature = 0
+    END
+  WITH
+    DEFAULT
+      SET caught = 1
+  END
+  PATCH_IF caught != 1 BEGIN
+    PATCH_FAIL ~complex graph rollback error was not caught~
   END
 
 CREATE ITM VERSION ~V1.0~ ~badlay~

--- a/test/structured-resources/structured-resources.tp2
+++ b/test/structured-resources/structured-resources.tp2
@@ -251,7 +251,7 @@ CREATE EFF VERSION ~V2.0~ ~effv20~
 
 // A graph rewrite that would require manual table relocation, ownership
 // bookkeeping, and cascading deletion when expressed with raw offsets.
-CREATE ITM VERSION ~V1.0~ ~complex_graph~
+CREATE ITM VERSION ~V1.0~ ~cgraph~
   INSERT_BYTES 0x72 4
   WRITE_ASCII 0x72 ~TAIL~
   PATCH_RESOURCE ITM BEGIN
@@ -336,7 +336,7 @@ CREATE ITM VERSION ~V1.0~ ~complex_graph~
 
 // A complex failed rewrite must roll back the complete graph, not merely
 // the command that raises the final error.
-CREATE SPL VERSION ~V1.0~ ~complex_rollback_source~
+CREATE SPL VERSION ~V1.0~ ~rbsource~
   PATCH_RESOURCE SPL BEGIN
     RESOURCE_APPEND global_effects AS effect BEGIN
       RESOURCE_SET effect opcode = 5
@@ -361,8 +361,8 @@ CREATE SPL VERSION ~V1.0~ ~complex_rollback_source~
     END
   END
 
-COPY + ~override/complex_rollback_source.spl~
-       ~override/complex_rollback.spl~
+COPY + ~override/rbsource.spl~
+       ~override/rbresult.spl~
   SET caught = 0
   PATCH_TRY
     PATCH_RESOURCE SPL BEGIN

--- a/test/structured-resources/structured-resources.tp2
+++ b/test/structured-resources/structured-resources.tp2
@@ -1,0 +1,241 @@
+BACKUP ~structured-resources/backup~
+AUTHOR ~WeiDU regression tests~
+
+BEGIN ~structured resource editor regression tests~
+
+CREATE ITM VERSION ~V1.0~ ~s_equiv~
+  PATCH_RESOURCE ITM BEGIN
+    RESOURCE_APPEND abilities AS ability BEGIN
+      RESOURCE_SET ability header_type = 2
+      RESOURCE_SET ability range = 30
+      RESOURCE_APPEND effects OF ability AS effect BEGIN
+        RESOURCE_SET effect opcode = 216
+        RESOURCE_SET effect parameter1 = 2
+        RESOURCE_SPRINT effect resource ~EFFTEST~
+      END
+    END
+  END
+
+CREATE ITM VERSION ~V1.0~ ~l_equiv~
+  INSERT_BYTES 0x72 0x68
+  WRITE_SHORT 0x68 1
+  WRITE_LONG 0x6a 0xaa
+  WRITE_BYTE 0x72 2
+  WRITE_SHORT 0x80 30
+  WRITE_SHORT 0x90 1
+  WRITE_SHORT 0x92 0
+  WRITE_SHORT 0xaa 216
+  WRITE_LONG 0xae 2
+  WRITE_ASCII 0xbe ~EFFTEST~ (8)
+
+CREATE ITM VERSION ~V1.0~ ~lifecycle~
+  WRITE_ASCII 0x5f ~Z~
+  READ_ASCII 0 before_noop (BUFFER_LENGTH)
+  PATCH_RESOURCE ITM BEGIN
+    RESOURCE_GET resource price INTO initial_price
+  END
+  READ_ASCII 0 after_noop (BUFFER_LENGTH)
+  PATCH_IF NOT (~%before_noop%~ STRING_EQUAL_CASE ~%after_noop%~) BEGIN
+    PATCH_FAIL ~PATCH_RESOURCE no-op changed an ITM buffer~
+  END
+
+  PATCH_RESOURCE ITM BEGIN
+    RESOURCE_SET resource price = 1234
+    RESOURCE_SPRINT resource inventory_icon ~TICON~
+    RESOURCE_APPEND global_effects AS global BEGIN
+      RESOURCE_SET global opcode = 7
+    END
+    RESOURCE_APPEND abilities AS ability BEGIN
+      RESOURCE_SET ability header_type = 2
+      RESOURCE_SET ability range = 20
+      RESOURCE_APPEND effects OF ability AS effect BEGIN
+        RESOURCE_SET effect opcode = 10
+        RESOURCE_CLONE effect TO effects OF ability AFTER effect AS copy BEGIN
+          RESOURCE_SET copy opcode = 11
+        END
+      END
+      RESOURCE_APPEND effects OF ability AS effect BEGIN
+        RESOURCE_SET effect opcode = 20
+      END
+      RESOURCE_INSERT effects OF ability BEFORE effect AS inserted BEGIN
+        RESOURCE_SET inserted opcode = 15
+      END
+      RESOURCE_FOR_EACH effects OF ability AS candidate BEGIN
+        RESOURCE_GET candidate opcode INTO candidate_opcode
+        PATCH_IF candidate_opcode = 15 BEGIN
+          RESOURCE_DELETE candidate
+        END
+      END
+    END
+    RESOURCE_FOR_EACH abilities AS original BEGIN
+      RESOURCE_CLONE original TO abilities AFTER original AS cloned BEGIN
+        RESOURCE_SET cloned range = 30
+      END
+      RESOURCE_DELETE original
+    END
+    RESOURCE_FOR_EACH global_effects AS global BEGIN
+      RESOURCE_DELETE global
+    END
+  END
+  READ_LONG 0x34 actual_price
+  READ_SHORT 0x68 actual_abilities
+  READ_LONG 0x6a actual_effect_offset
+  READ_SHORT 0x70 actual_globals
+  READ_SHORT 0x90 actual_effect_count
+  READ_SHORT 0x92 actual_effect_index
+  READ_SHORT 0xaa actual_opcode_1
+  READ_SHORT 0xda actual_opcode_2
+  READ_SHORT 0x10a actual_opcode_3
+  PATCH_IF actual_price != 1234 OR actual_abilities != 1 OR
+           actual_effect_offset != 0xaa OR actual_globals != 0 OR
+           actual_effect_count != 3 OR actual_effect_index != 0 OR
+           actual_opcode_1 != 10 OR actual_opcode_2 != 11 OR
+           actual_opcode_3 != 20 OR BUFFER_LENGTH != 0x13a BEGIN
+    PATCH_FAIL ~ITM lifecycle serialization failed~
+  END
+
+  SET caught = 0
+  PATCH_TRY
+    PATCH_RESOURCE ITM BEGIN
+      RESOURCE_SET resource price = 9999
+      WRITE_LONG 0x34 1
+    END
+  WITH
+    DEFAULT
+      SET caught = 1
+  END
+  READ_LONG 0x34 atomic_price
+  PATCH_IF caught != 1 OR atomic_price != 1234 BEGIN
+    PATCH_FAIL ~ordinary buffer mutation was not rejected atomically~
+  END
+
+  SET caught = 0
+  PATCH_TRY
+    PATCH_RESOURCE ITM BEGIN
+      PATCH_RESOURCE ITM BEGIN END
+    END
+  WITH
+    DEFAULT
+      SET caught = 1
+  END
+  PATCH_IF caught != 1 BEGIN
+    PATCH_FAIL ~nested PATCH_RESOURCE was not rejected~
+  END
+
+  SET caught = 0
+  PATCH_TRY
+    PATCH_RESOURCE ITM BEGIN
+      RESOURCE_SET resource stack_amount = 65536
+    END
+  WITH
+    DEFAULT
+      SET caught = 1
+  END
+  PATCH_IF caught != 1 BEGIN
+    PATCH_FAIL ~out-of-range U16 write was not rejected~
+  END
+
+CREATE ITM VERSION ~V1.1~ ~itmv11~
+  PATCH_RESOURCE ITM BEGIN
+    RESOURCE_SPRINT resource pickup_sound ~PICKUP~
+    RESOURCE_SPRINT resource dialog ~DIALOG~
+    RESOURCE_SET resource conversable_label = 42
+  END
+  READ_ASCII 0x58 pickup (8) NULL
+  READ_ASCII 0x72 dialog (8) NULL
+  READ_LONG 0x7a label
+  PATCH_IF NOT (~%pickup%~ STRING_EQUAL_CASE ~PICKUP~) OR
+           NOT (~%dialog%~ STRING_EQUAL_CASE ~DIALOG~) OR label != 42 BEGIN
+    PATCH_FAIL ~ITM V1.1 fields failed~
+  END
+
+CREATE ITM VERSION ~V2.0~ ~itmv20~
+  PATCH_RESOURCE ITM BEGIN
+    RESOURCE_APPEND abilities AS ability BEGIN
+      RESOURCE_SET ability flags = 0x1234
+      RESOURCE_SET ability attack_type_flags = 0x5678
+    END
+  END
+  READ_SHORT 0xa8 v2_flags
+  READ_SHORT 0xaa v2_attack_flags
+  PATCH_IF v2_flags != 0x1234 OR v2_attack_flags != 0x5678 BEGIN
+    PATCH_FAIL ~ITM V2.0 split ability flags failed~
+  END
+
+CREATE SPL VERSION ~V1.0~ ~splv1~
+  PATCH_RESOURCE SPL BEGIN
+    RESOURCE_SET resource spell_level = 5
+    RESOURCE_APPEND global_effects AS effect BEGIN
+      RESOURCE_SET effect opcode = 1
+    END
+    RESOURCE_APPEND abilities AS ability BEGIN
+      RESOURCE_SET ability min_level = 3
+      RESOURCE_SET ability projectile = 77
+      RESOURCE_APPEND effects OF ability AS effect BEGIN
+        RESOURCE_SET effect opcode = 12
+      END
+    END
+  END
+  READ_LONG 0x34 spell_level
+  READ_SHORT 0x68 spell_abilities
+  READ_LONG 0x6a spell_effect_offset
+  READ_SHORT 0x70 spell_globals
+  READ_SHORT 0x82 ability_level
+  READ_SHORT 0x98 ability_projectile
+  READ_SHORT 0x9a global_opcode
+  READ_SHORT 0xca ability_opcode
+  PATCH_IF spell_level != 5 OR spell_abilities != 1 OR
+           spell_effect_offset != 0x9a OR spell_globals != 1 OR
+           ability_level != 3 OR ability_projectile != 77 OR
+           global_opcode != 1 OR ability_opcode != 12 BEGIN
+    PATCH_FAIL ~SPL V1 lifecycle failed~
+  END
+
+CREATE SPL VERSION ~V2.0~ ~splv20~
+  PATCH_RESOURCE SPL BEGIN
+    RESOURCE_SET resource duration_modifier_level = 4
+    RESOURCE_SET resource duration_modifier_rounds = 6
+  END
+  READ_BYTE 0x72 duration_level
+  READ_BYTE 0x73 duration_rounds
+  PATCH_IF duration_level != 4 OR duration_rounds != 6 BEGIN
+    PATCH_FAIL ~SPL V2.0 fields failed~
+  END
+
+CREATE EFF VERSION ~V2.0~ ~effv20~
+  PATCH_RESOURCE EFF BEGIN
+    RESOURCE_SET resource opcode = 321
+    RESOURCE_SET resource timing = 4096
+    RESOURCE_SET resource probability1 = 100
+    RESOURCE_SPRINT resource resource ~SPWI112~
+    RESOURCE_SPRINT resource variable_name ~structured_test~
+    RESOURCE_SET resource caster_level = 17
+  END
+  READ_LONG 0x10 eff_opcode
+  READ_SHORT 0x24 eff_timing
+  READ_SHORT 0x2c eff_probability
+  READ_ASCII 0x30 eff_resource (8) NULL
+  READ_ASCII 0xa8 eff_variable (32) NULL
+  READ_LONG 0xc8 eff_level
+  PATCH_IF eff_opcode != 321 OR eff_timing != 4096 OR
+           eff_probability != 100 OR eff_level != 17 OR
+           NOT (~%eff_resource%~ STRING_EQUAL_CASE ~SPWI112~) OR
+           NOT (~%eff_variable%~ STRING_EQUAL_CASE ~structured_test~) BEGIN
+    PATCH_FAIL ~EFF V2.0 fields failed~
+  END
+
+CREATE ITM VERSION ~V1.0~ ~malformed~
+  WRITE_LONG 0x64 1
+  SET caught = 0
+  PATCH_TRY
+    PATCH_RESOURCE ITM BEGIN END
+  WITH
+    DEFAULT
+      SET caught = 1
+  END
+  PATCH_IF caught != 1 BEGIN
+    PATCH_FAIL ~malformed layout was not rejected~
+  END
+
+AT_NOW ~structured-resources/verify.sh~
+AT_NOW ~sh -c 'printf STRUCTURED_RESOURCE_TESTS_OK'~

--- a/test/structured-resources/structured-resources.tp2
+++ b/test/structured-resources/structured-resources.tp2
@@ -28,7 +28,7 @@ CREATE ITM VERSION ~V1.0~ ~l_equiv~
   WRITE_LONG 0xae 2
   WRITE_ASCII 0xbe ~EFFTEST~ (8)
 
-CREATE ITM VERSION ~V1.0~ ~lifecycle~
+CREATE ITM VERSION ~V1.0~ ~life~
   WRITE_ASCII 0x5f ~Z~
   READ_ASCII 0 before_noop (BUFFER_LENGTH)
   PATCH_RESOURCE ITM BEGIN
@@ -56,9 +56,9 @@ CREATE ITM VERSION ~V1.0~ ~lifecycle~
       END
       RESOURCE_APPEND effects OF ability AS effect BEGIN
         RESOURCE_SET effect opcode = 20
-      END
-      RESOURCE_INSERT effects OF ability BEFORE effect AS inserted BEGIN
-        RESOURCE_SET inserted opcode = 15
+        RESOURCE_INSERT effects OF ability BEFORE effect AS inserted BEGIN
+          RESOURCE_SET inserted opcode = 15
+        END
       END
       RESOURCE_FOR_EACH effects OF ability AS candidate BEGIN
         RESOURCE_GET candidate opcode INTO candidate_opcode
@@ -224,7 +224,7 @@ CREATE EFF VERSION ~V2.0~ ~effv20~
     PATCH_FAIL ~EFF V2.0 fields failed~
   END
 
-CREATE ITM VERSION ~V1.0~ ~malformed~
+CREATE ITM VERSION ~V1.0~ ~badlay~
   WRITE_LONG 0x64 1
   SET caught = 0
   PATCH_TRY

--- a/test/structured-resources/structured-resources.tp2
+++ b/test/structured-resources/structured-resources.tp2
@@ -3,6 +3,15 @@ AUTHOR ~WeiDU regression tests~
 
 BEGIN ~structured resource editor regression tests~
 
+OUTER_SPRINT RESOURCE_GET ~contextual identifier before block~
+OUTER_SPRINT RESOURCE_SET ~contextual identifier before block~
+OUTER_SPRINT RESOURCE_SPRINT ~contextual identifier before block~
+OUTER_SPRINT RESOURCE_FOR_EACH ~contextual identifier before block~
+OUTER_SPRINT RESOURCE_APPEND ~contextual identifier before block~
+OUTER_SPRINT RESOURCE_INSERT ~contextual identifier before block~
+OUTER_SPRINT RESOURCE_CLONE ~contextual identifier before block~
+OUTER_SPRINT RESOURCE_DELETE ~contextual identifier before block~
+
 CREATE ITM VERSION ~V1.0~ ~s_equiv~
   PATCH_RESOURCE ITM BEGIN
     RESOURCE_APPEND abilities AS ability BEGIN
@@ -203,7 +212,7 @@ CREATE SPL VERSION ~V2.0~ ~splv20~
   END
 
 CREATE EFF VERSION ~V2.0~ ~effv20~
-  PATCH_RESOURCE EFF BEGIN
+  PATCH_RESOURCE ~EFF~ BEGIN
     RESOURCE_SET resource opcode = 321
     RESOURCE_SET resource timing = 4096
     RESOURCE_SET resource probability1 = 100
@@ -236,6 +245,8 @@ CREATE ITM VERSION ~V1.0~ ~badlay~
   PATCH_IF caught != 1 BEGIN
     PATCH_FAIL ~malformed layout was not rejected~
   END
+
+OUTER_SPRINT RESOURCE_DELETE ~contextual identifier after block~
 
 AT_NOW ~structured-resources/verify.sh~
 AT_NOW ~sh -c 'printf STRUCTURED_RESOURCE_TESTS_OK'~

--- a/test/structured-resources/verify.sh
+++ b/test/structured-resources/verify.sh
@@ -3,8 +3,8 @@ set -eu
 
 for expected in \
   s_equiv.itm l_equiv.itm life.itm itmv11.itm itmv20.itm \
-  splv1.spl splv20.spl effv20.eff complex_graph.itm \
-  complex_rollback_source.spl complex_rollback.spl badlay.itm
+  splv1.spl splv20.spl effv20.eff cgraph.itm \
+  rbsource.spl rbresult.spl badlay.itm
 do
   if [ ! -f "override/$expected" ]; then
     printf '%s\n' "missing generated fixture: override/$expected" >&2
@@ -15,8 +15,8 @@ done
 test "$(wc -c < override/life.itm)" -eq 314
 test "$(wc -c < override/splv1.spl)" -eq 250
 test "$(wc -c < override/effv20.eff)" -eq 272
-test "$(wc -c < override/complex_graph.itm)" -eq 462
-test "$(wc -c < override/complex_rollback_source.spl)" -eq 434
-test "$(wc -c < override/complex_rollback.spl)" -eq 434
+test "$(wc -c < override/cgraph.itm)" -eq 462
+test "$(wc -c < override/rbsource.spl)" -eq 434
+test "$(wc -c < override/rbresult.spl)" -eq 434
 
 printf '%s\n' 'STRUCTURED_RESOURCE_FILES_OK'

--- a/test/structured-resources/verify.sh
+++ b/test/structured-resources/verify.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+set -eu
+
+for expected in \
+  s_equiv.itm l_equiv.itm lifecycle.itm itmv11.itm itmv20.itm \
+  splv1.spl splv20.spl effv20.eff malformed.itm
+do
+  if [ ! -f "override/$expected" ]; then
+    printf '%s\n' "missing generated fixture: override/$expected" >&2
+    exit 1
+  fi
+done
+
+test "$(wc -c < override/lifecycle.itm)" -eq 314
+test "$(wc -c < override/splv1.spl)" -eq 202
+test "$(wc -c < override/effv20.eff)" -eq 272
+
+printf '%s\n' 'STRUCTURED_RESOURCE_FILES_OK'

--- a/test/structured-resources/verify.sh
+++ b/test/structured-resources/verify.sh
@@ -3,7 +3,8 @@ set -eu
 
 for expected in \
   s_equiv.itm l_equiv.itm life.itm itmv11.itm itmv20.itm \
-  splv1.spl splv20.spl effv20.eff badlay.itm
+  splv1.spl splv20.spl effv20.eff complex_graph.itm \
+  complex_rollback_source.spl complex_rollback.spl badlay.itm
 do
   if [ ! -f "override/$expected" ]; then
     printf '%s\n' "missing generated fixture: override/$expected" >&2
@@ -14,5 +15,8 @@ done
 test "$(wc -c < override/life.itm)" -eq 314
 test "$(wc -c < override/splv1.spl)" -eq 250
 test "$(wc -c < override/effv20.eff)" -eq 272
+test "$(wc -c < override/complex_graph.itm)" -eq 462
+test "$(wc -c < override/complex_rollback_source.spl)" -eq 434
+test "$(wc -c < override/complex_rollback.spl)" -eq 434
 
 printf '%s\n' 'STRUCTURED_RESOURCE_FILES_OK'

--- a/test/structured-resources/verify.sh
+++ b/test/structured-resources/verify.sh
@@ -2,8 +2,8 @@
 set -eu
 
 for expected in \
-  s_equiv.itm l_equiv.itm lifecycle.itm itmv11.itm itmv20.itm \
-  splv1.spl splv20.spl effv20.eff malformed.itm
+  s_equiv.itm l_equiv.itm life.itm itmv11.itm itmv20.itm \
+  splv1.spl splv20.spl effv20.eff badlay.itm
 do
   if [ ! -f "override/$expected" ]; then
     printf '%s\n' "missing generated fixture: override/$expected" >&2
@@ -11,8 +11,8 @@ do
   fi
 done
 
-test "$(wc -c < override/lifecycle.itm)" -eq 314
-test "$(wc -c < override/splv1.spl)" -eq 202
+test "$(wc -c < override/life.itm)" -eq 314
+test "$(wc -c < override/splv1.spl)" -eq 250
 test "$(wc -c < override/effv20.eff)" -eq 272
 
 printf '%s\n' 'STRUCTURED_RESOURCE_FILES_OK'


### PR DESCRIPTION
## Summary

This adds a transactional, schema-aware resource editor for ITM, SPL, and EFF buffers:

```weidu
PATCH_RESOURCE ITM BEGIN
  RESOURCE_FOR_EACH abilities AS ability BEGIN
    RESOURCE_SET ability range = 30
    RESOURCE_APPEND effects OF ability AS effect BEGIN
      RESOURCE_SET effect opcode = 216
    END
  END
END
```

The initial schema set covers ITM V1.0, V1.1, and V2.0; SPL V1.0 and V2.0; and EFF V2.0. It exposes typed root, ability, global-effect, and ability-effect fields, together with stable opaque handles and append, insert, clone, delete, and snapshot iteration operations.

## Why a structured editor

Equivalent ad hoc patch functions must duplicate binary offsets, record sizes, version branches, bounds checks, count/index maintenance, effect ownership rules, and table relocation logic. That duplication is difficult to review and tends to couple each mod to layout details.

The structured editor centralizes those invariants in WeiDU:

- field names and signedness replace repeated literal offsets;
- writes are range-checked and fixed strings/resrefs are length-checked;
- derived offsets, counts, and effect indices are rebuilt on commit;
- ability clones include owned effects, and ability deletion cascades to them;
- malformed, overlapping, out-of-bounds, or ambiguously owned tables are rejected before the body runs;
- any structured failure discards all resource-buffer edits;
- unexposed bytes, gaps, and trailing data are preserved byte-for-byte;
- a no-op transaction returns the original buffer exactly.

This makes intent visible in mod code and places format correctness in one implementation with one regression suite.

## Compatibility

- Existing patch behavior is unchanged outside `PATCH_RESOURCE`.
- Only `PATCH_RESOURCE` is a new global keyword. The eight `RESOURCE_*` operation names are lexer-scoped to editor bodies and remain usable as uppercase unquoted identifiers elsewhere; regression coverage checks entry to and exit from that scope.
- Ordinary buffer-mutating patches and nested resource transactions are rejected inside an active editor rather than producing incoherent mixed state.
- Variable and log side effects retain existing WeiDU behavior and are documented as non-transactional.

## Validation

A disposable Ubuntu 22.04 workflow used the archived OCaml 4.08.1 unsafe-string configuration from PR #381 and passed:

- full `make` build with Elkhound 1.0.3;
- `make test-structured-resources`;
- manual generation;
- Linux distribution build and ZIP integrity verification;
- generated-source rewrite audit;
- validation artifact upload.

The regression suite covers every supported format/version, structured-versus-legacy byte equivalence, no-op identity, append/insert/clone/delete lifecycle behavior, deep ability cloning, snapshot iteration, contextual keyword compatibility, quoted resource formats, malformed layouts, range failures, nested transaction rejection, and atomic rollback of forbidden raw mutations.

Validation run: https://github.com/4Luke4/weidu/actions/runs/33114394728

The disposable workflow was removed from both the final tree and reachable branch history after the successful run, as intended.
