### PR TITLE
Reduce patching overhead with opt-in detailed timings

### DIFF
--- a/README-WeiDU-Changes.txt
+++ b/README-WeiDU-Changes.txt
@@ -1,3 +1,8 @@
+Unreleased:
+  * Fine-grained interpreter timings are opt-in to reduce patching
+    overhead. Use --debug-timings to include them in the debug log.
+    Coarse operation timings and explicit mod timings remain enabled.
+
 Version 251:
   * CREATE called within CREATE works as expected.
   * CREATE sets SOURCE_* and DEST_* variables.

--- a/doc/base.tex
+++ b/doc/base.tex
@@ -1058,6 +1058,15 @@ but in WeiDU.log with case-folding. \\
 previously been used (Linux only). This option is saved in the file
 weidu.conf, located in the root game directory. Note caveats described
 under \ttref{--lowercase}. \\
+\DEFINE{--debug-timings} & Include fine-grained interpreter timings
+(\t{READ\_*}, \t{process\_patch2}, \t{eval\_pe}, and
+\t{function overhead}) in the debug log. These measurements can
+substantially slow patching and are disabled by default. Coarse
+operation timings and explicit mod timings remain enabled; without
+this option, interpreter time is included in the enclosing operation.
+Timings measure user CPU time, not elapsed time or time waiting for
+I/O. Use \ttref{--log} to select a debug log when one is not opened
+automatically. \\
 \DEFINE{--debug-assign} & Print out all values assigned to \ttref{TP2}
 variables (even implicit ones created by \t{WeiDU}). \\
 \DEFINE{--debug-value} & Print out all \ttref{value}s encountered in

--- a/src/main.ml
+++ b/src/main.ml
@@ -1682,6 +1682,7 @@ let main () =
     "--log-extern", Myarg.Set log_extern,"\talso log output from commands invoked by WeiDU " ;
     "--debug-assign", Myarg.Set Var.debug_assign,"\tPrint out all values assigned to TP2 variables" ;
     "--debug-value", Myarg.Set Tp.debug_pe,"\tPrint out all value expressions" ;
+    "--debug-timings", Myarg.Set Stats.debug_timings,"\tInclude fine-grained interpreter timings in the debug log (slows patching)" ;
     "--continue", Myarg.Set Tp.continue_on_error,"\tcontinue despite TP2 action errors" ;
 
     "", Myarg.Unit (fun a -> a), "\nHelp Options:\n" ;

--- a/src/stats.ml
+++ b/src/stats.ml
@@ -20,6 +20,10 @@ let stack : t list ref = ref [top]
 let record = Hashtbl.create 127
 let extra = Hashtbl.create 10
 
+(* Per-expression and per-patch measurements are expensive in tight loops.
+   Coarse operation timings and explicit mod timings remain enabled. *)
+let debug_timings = ref false
+
 let update_table table name duration =
   let sofar =
     if Hashtbl.mem table name then
@@ -52,6 +56,9 @@ let time name f a =
     update_table record name duration ;
     raise e
   end
+
+let time_detail name f a =
+  if !debug_timings then time name f a else f a
 
 let inclusive_time name f a =
   let now = (Unix.times ()).Unix.tms_utime in

--- a/src/tppatch.ml
+++ b/src/tppatch.ml
@@ -14,7 +14,7 @@ open Tppe
  * change location "where" in "buff" to point to str-ref "what"
  ************************************************************************)
 let rec process_patch1 patch_filename game buff p =
-  Stats.time "READ_*" (fun () ->
+  Stats.time_detail "READ_*" (fun () ->
     let bounds_check idx size retfun eo ef =
       let len = String.length buff in
       let out_of_bounds = (idx < 0 || (idx + size) > len) in
@@ -189,7 +189,7 @@ let rec process_patch2_real process_action tp our_lang patch_filename game buff 
   let process_patch2 = process_patch2_real process_action tp our_lang in
   process_patch1 patch_filename game buff p ;
 
-  Stats.time "process_patch2" (fun () ->
+  Stats.time_detail "process_patch2" (fun () ->
     let bounds_check_write idx size (str : string) =
       let len = String.length buff in
       let out_of_bounds = (idx < 0 || (idx + size) > len) in
@@ -490,7 +490,7 @@ let rec process_patch2_real process_action tp our_lang patch_filename game buff 
 
     | TP_Launch_Patch_Function (str,is_patch,int_var,str_var,rets,retas) ->
         let the_buff = ref buff in
-        Stats.time "function overhead" (fun () ->
+        Stats.time_detail "function overhead" (fun () ->
           let str = Var.get_string str in
           let (f_int_args,f_str_args,f_rets,f_retas,f_code) = try
             Hashtbl.find functions (str, is_patch)

--- a/src/tppe.ml
+++ b/src/tppe.ml
@@ -732,7 +732,7 @@ let rec eval_pe buff game p =
         1l else 0l)
 
 let eval_pe buff game pe =
-  let res = Stats.time "eval_pe" (fun () -> eval_pe buff game pe) () in
+  let res = Stats.time_detail "eval_pe" (fun () -> eval_pe buff game pe) () in
   (if !debug_pe then log_and_print "Value [%s] = %ld\n"
       (pe_to_str pe) res ) ;
   res

--- a/test/performance/README.md
+++ b/test/performance/README.md
@@ -1,0 +1,55 @@
+# Patch timing regression tests and benchmarks
+
+These tests require Python 3 and native baseline/candidate WeiDU executables.
+They generate their own resources and use `--nogame`. No installed game or
+third-party mod is needed. Run from the candidate checkout:
+
+```sh
+python3 test/performance/run_stats_test.py
+python3 test/performance/patch_timings.py \
+  --baseline /path/to/baseline/weidu \
+  --candidate /path/to/candidate/weidu \
+  --output /path/to/new-results-directory
+```
+
+The Stats test also requires the build's OCaml compiler on PATH. `--build`
+selects an alternative object directory. It links the actual Stats module and
+checks nested success/failure, single callback execution, stack restoration,
+and coarse/explicit timing retention in both modes.
+
+The Python harness checks baseline, candidate default, and candidate with
+`--debug-timings`. It compares complete resource bytes against independently
+constructed expected outputs for ALTER_EFFECT, CLONE_EFFECT, and DELETE_EFFECT.
+Fixtures cover SPL/ITM global and ability effects and CRE V1/V2 effect records,
+including nonmatches and repeated alteration. It also verifies backup contents,
+reinstallation, uninstallation, nested function scope restoration, explicit
+PATCH_TIME output, and uncaught read errors. Five existing game-independent
+TP2 regression files run with unsuccessful results converted into fatal errors.
+
+Use `--skip-benchmark` for correctness alone. Benchmark defaults are configurable:
+`--files 1000 --effects 10 --iterations 1000 --samples 10`. At most 999 effects
+are allowed so ALTER_EFFECT's default match limit cannot silently leave part of
+the workload unchanged. `--scenarios memory many copy` selects in-memory repeated
+patches, directory-wide patches, and an unpatched COPY control.
+
+Each scenario measures fresh installation and reinstallation separately. Each
+phase has one warm-up pair and at least ten alternating baseline/candidate pairs.
+Fixture creation, reinstall preparation, and output validation are outside the
+timed process. Repeated runs use the host's normal filesystem cache; these are
+not cold-storage throughput measurements. Use identical toolchains and flags for
+both revisions and avoid competing jobs on the same machine.
+
+`results.json` contains executable hashes, host metadata, output hashes, raw wall
+times, and Unix child CPU/block counters where available. CPU/block counters are
+omitted on Windows, rather than reported as zero. Speedup summaries use paired
+log ratios with a conservative Student-t 95% interval for ten or more pairs.
+The interval describes observed run variability, not all hardware or workloads.
+Performance is reported rather than used as a flaky fixed-percentage test gate.
+Inspect every scenario for improvement or unexplained regressions before merging.
+Correctness failures always produce a nonzero exit status.
+
+Logs remain below the new output directory. Large benchmark resource/backup
+directories are removed after validation. The correctness fixtures are retained.
+Record source revisions and compiler/runner versions alongside the results;
+binary hashes alone do not establish source provenance. Run syscall tracing
+separately, since tracing strongly perturbs execution time.

--- a/test/performance/patch_timings.py
+++ b/test/performance/patch_timings.py
@@ -1,0 +1,342 @@
+#!/usr/bin/env python3
+"""Game-independent correctness checks and paired WeiDU patch benchmarks.
+
+Uses only the Python standard library. All generated game data, installations,
+and logs live under a new --output directory, never in a real game directory.
+"""
+
+import argparse
+import hashlib
+import json
+import math
+import os
+from pathlib import Path
+import platform
+import re
+import shutil
+import statistics
+import struct
+import subprocess
+import time
+
+try:
+    import resource
+except ImportError:
+    resource = None
+
+
+DETAILS = ("READ_*", "process_patch2", "eval_pe", "function overhead")
+# Infinity Engine V1 SPL/ITM/CRE layouts, including CRE's V2 effect records.
+FORMATS = {
+    "spl": (b"SPL V1  ", 0x72, 0x28, 0),
+    "itm": (b"ITM V1  ", 0x72, 0x38, 0),
+    "cre": (b"CRE V1.0", 0x2D4, 0, 0),
+    "cre-v2": (b"CRE V1.0", 0x2D4, 0, 1),
+}
+MOD_HEADER = 'BACKUP ~backup~\nAUTHOR ~WeiDU regression tests~\n'
+MOD_HEADER += 'VERSION ~synthetic~\nBEGIN ~Patch timing tests~\n'
+
+
+def digest(data):
+    return hashlib.sha256(data).hexdigest()
+
+
+def effect(opcode, parameter, extended):
+    result = bytearray(0x108 if extended else 0x30)
+    if extended:
+        result[:8] = b"EFF V2.0"
+    struct.pack_into("<H", result, 0x08 if extended else 0, opcode)
+    struct.pack_into("<I", result, 0x14 if extended else 4, parameter)
+    result[0x24 if extended else 0x12] = 100
+    offset = 0x28 if extended else 0x14
+    result[offset:offset + 8] = b"testres\0"
+    return bytes(result)
+
+
+def render(kind, globals_, ability=()):
+    """Build expected resources from record lists, independently of TP2 patches."""
+    signature, header_size, ability_size, extended = FORMATS[kind]
+    has_ability = bool(ability_size and ability)
+    effect_offset = header_size + (ability_size if has_ability else 0)
+    header = bytearray(effect_offset)
+    header[:8] = signature
+    if ability_size:
+        struct.pack_into("<I", header, 0x64, header_size)
+        struct.pack_into("<H", header, 0x68, int(has_ability))
+        struct.pack_into("<I", header, 0x6A, effect_offset)
+        struct.pack_into("<H", header, 0x70, len(globals_))
+        if has_ability:
+            header[header_size] = 1
+            struct.pack_into("<HH", header, header_size + 0x1E,
+                             len(ability), len(globals_))
+    else:
+        header[0x33] = extended
+        struct.pack_into("<II", header, 0x2C4, effect_offset, len(globals_))
+    return bytes(header) + b"".join(effect(o, p, extended)
+                                    for o, p in [*globals_, *ability])
+
+
+def write_mod(directory, body):
+    (directory / "test.tp2").write_text(MOD_HEADER + body, encoding="utf-8")
+
+
+def invoke(binary, directory, label, detail=False, uninstall=False,
+           tp2="test.tp2", expect_failure=False):
+    log = directory / (label + ".debug")
+    command = [str(binary), tp2, "--nogame", "--noautoupdate",
+               "--no-exit-pause", "--log", str(log)]
+    if detail:
+        command.append("--debug-timings")
+    command += ["--force-uninstall-list" if uninstall else
+                "--force-install-list", "0"]
+    before = resource.getrusage(resource.RUSAGE_CHILDREN) if resource else None
+    start = time.perf_counter()
+    process = subprocess.run(command, cwd=directory, stdout=subprocess.PIPE,
+                             stderr=subprocess.STDOUT, timeout=300)
+    elapsed = time.perf_counter() - start
+    after = resource.getrusage(resource.RUSAGE_CHILDREN) if resource else None
+    (directory / (label + ".stdout")).write_bytes(process.stdout)
+    text = process.stdout.decode("utf-8", errors="replace")
+    if (process.returncode != 0) != expect_failure:
+        raise AssertionError(f"{label}: exit {process.returncode}\n{text}")
+    if not expect_failure and not uninstall:
+        if "SUCCESSFULLY INSTALLED" not in text or "SUPPRESSED ERROR" in text:
+            raise AssertionError(f"{label}: installation did not pass\n{text}")
+    result = {"wall_s": elapsed, "exit": process.returncode}
+    if resource:
+        result.update(user_s=after.ru_utime - before.ru_utime,
+                      system_s=after.ru_stime - before.ru_stime,
+                      input_blocks=after.ru_inblock - before.ru_inblock,
+                      output_blocks=after.ru_oublock - before.ru_oublock)
+    return result, log.read_text(encoding="utf-8", errors="replace")
+
+
+def check_timings(log, detail):
+    table = log.rsplit("WeiDU Timings", 1)[-1]
+    if "WeiDU Timings" not in log:
+        raise AssertionError("Missing timing summary")
+    for name in DETAILS:
+        found = re.search(r"^" + re.escape(name) + r"\s+\d", table, re.M)
+        if bool(found) != detail:
+            raise AssertionError(f"Unexpected timing presence: {name}: {detail}")
+    for name in ("COPY", "TOTAL"):
+        if not re.search(r"^" + name + r"\s+\d", table, re.M):
+            raise AssertionError(f"Missing coarse timing: {name}")
+    if "Mod Timings" not in log or "fixture-time" not in log:
+        raise AssertionError("Explicit mod timing was lost")
+
+
+def verify_outputs(directory, expected):
+    actual = {p.name: p.read_bytes() for p in (directory / "output").iterdir()}
+    if actual != expected:
+        different = sorted(k for k in actual.keys() | expected.keys()
+                           if actual.get(k) != expected.get(k))
+        raise AssertionError(f"Output mismatch in {directory}: {different[:10]}")
+    return {name: digest(data) for name, data in sorted(actual.items())}
+
+
+def correctness(binary, directory, detail, baseline=False):
+    directory.mkdir(parents=True)
+    (directory / "input").mkdir()
+    (directory / "output").mkdir()
+    original = [(12, 7), (13, 8)]
+    expected, originals = {}, {}
+    body = '''DEFINE_PATCH_FUNCTION nested BEGIN
+      LPF ALTER_EFFECT INT_VAR match_opcode=12 parameter1=42 silent=1 END
+    END
+    DEFINE_PATCH_FUNCTION failing BEGIN
+      SET scope_witness = 999
+      PATCH_FAIL ~expected nested failure~
+    END
+    '''
+    operations = {
+        "alter": ("LPF nested END\nLPF nested END", [(12, 42), (13, 8)]),
+        "clone": ("LPF CLONE_EFFECT INT_VAR match_opcode=12 opcode=14 "
+                  "parameter1=42 silent=1 STR_VAR insert=below END",
+                  [(12, 7), (14, 42), (13, 8)]),
+        "delete": ("LPF DELETE_EFFECT INT_VAR match_opcode=12 END", [(13, 8)]),
+        "no-match": ("LPF ALTER_EFFECT INT_VAR match_opcode=65534 "
+                     "parameter1=42 silent=1 END\n"
+                     "LPF CLONE_EFFECT INT_VAR match_opcode=65534 silent=1 END\n"
+                     "LPF DELETE_EFFECT INT_VAR match_opcode=65534 END", original),
+    }
+    for kind in FORMATS:
+        ability = original if FORMATS[kind][2] else []
+        for operation, (patch, records) in operations.items():
+            filename = f"{kind}-{operation}.{kind.split('-')[0]}"
+            data = render(kind, original, ability)
+            (directory / "input" / filename).write_bytes(data)
+            # Pre-existing destinations exercise real backups and restoration.
+            (directory / "output" / filename).write_bytes(data)
+            originals[filename] = data
+            expected[filename] = render(kind, records, records if ability else [])
+            body += f'COPY ~input/{filename}~ ~output/{filename}~\n'
+            body += '  PATCH_TIME ~fixture-time~ BEGIN\n' + patch + '\nEND\n'
+    body += '''COPY ~input/spl-alter.spl~ ~output/new.spl~
+      SET scope_witness = 17
+      SET caught = 0
+      PATCH_TRY
+        LPF failing END
+      WITH
+        DEFAULT
+          SET caught = 1
+      END
+      PATCH_IF scope_witness != 17 OR caught != 1 BEGIN
+        PATCH_FAIL ~Function failure did not restore scope~
+      END
+      LPF nested END
+    '''
+    expected["new.spl"] = render("spl", [(12, 42), (13, 8)], [(12, 42), (13, 8)])
+    write_mod(directory, body)
+    _, log = invoke(binary, directory, "install", detail)
+    check_timings(log, baseline or detail)
+    hashes = verify_outputs(directory, expected)
+    backups = [p.read_bytes() for p in (directory / "backup").rglob("*")
+               if p.is_file()]
+    if not all(data in backups for data in originals.values()):
+        raise AssertionError("Original resource backup is missing")
+    invoke(binary, directory, "reinstall", detail)
+    verify_outputs(directory, expected)
+    invoke(binary, directory, "uninstall", detail, uninstall=True)
+    verify_outputs(directory, originals)
+
+    # An uncaught bounds error must retain its exit status and roll back.
+    (directory / "short.bin").write_bytes(b"x")
+    write_mod(directory, 'COPY ~short.bin~ ~output/failed.bin~\nREAD_LONG 0 value\n')
+    failure, log = invoke(binary, directory, "failure", detail, expect_failure=True)
+    if "read out of bounds" not in log or (directory / "output/failed.bin").exists():
+        raise AssertionError("Bounds failure or rollback changed")
+    return {"hashes": hashes, "failure_exit": failure["exit"]}
+
+
+def regressions(binary, directory, detail):
+    source = Path(__file__).resolve().parents[1] / "tp2/tp2_regression_tests"
+    target = directory / "tp2_regression_tests"
+    shutil.copytree(source, target)
+    # These existing tests require no installed game or game-specific IDS.
+    names = ("fun_eval", "array_tests", "test_sprintf", "variable_is_star", "read_2da")
+    body = MOD_HEADER
+    for name in names:
+        body += f'INCLUDE ~%MOD_FOLDER%/lib/tests/{name}.tpa~\n'
+        body += 'LAF run RET success message END\n'
+        body += 'ACTION_IF !success BEGIN FAIL ~%message%~ END\n'
+    (target / "tp2_regression_tests.tp2").write_text(body, encoding="utf-8")
+    invoke(binary, directory, "regressions", detail,
+           tp2="tp2_regression_tests/tp2_regression_tests.tp2")
+    return list(names)
+
+
+def prepare_benchmark(directory, scenario, args):
+    directory.mkdir(parents=True)
+    (directory / "input").mkdir()
+    (directory / "output").mkdir()
+    count = args.files if scenario != "memory" else 1
+    records = [(12, 7)] * args.effects
+    source = render("spl", records)
+    expected_data = source if scenario == "copy" else render("spl", [(12, 42)] * args.effects)
+    expected = {}
+    for i in range(count):
+        name = f"p{i:07d}.spl"
+        (directory / "input" / name).write_bytes(source)
+        expected[name] = expected_data
+    patch = ""
+    if scenario != "copy":
+        repeats = args.iterations if scenario == "memory" else 1
+        patch = f'''FOR (iteration = 0; iteration < {repeats}; ++iteration) BEGIN
+          LPF ALTER_EFFECT INT_VAR match_opcode=12 parameter1=42 silent=1 END
+        END
+        '''
+    write_mod(directory, 'COPY ~input~ ~output~\n' + patch)
+    return expected
+
+
+def summarize(samples):
+    """Paired log ratios with a Student-t 95% interval (10+ samples)."""
+    ratios = [math.log(pair["baseline"]["wall_s"] / pair["candidate"]["wall_s"])
+              for pair in samples]
+    # Conservative t bound for >=10 pairs (df >=9), avoiding a scipy dependency.
+    radius = 2.263 * statistics.stdev(ratios) / math.sqrt(len(ratios))
+    mean = statistics.mean(ratios)
+    return {"geometric_speedup": math.exp(mean),
+            "speedup_95pct_interval": [math.exp(mean - radius), math.exp(mean + radius)],
+            "baseline_median_s": statistics.median(p["baseline"]["wall_s"] for p in samples),
+            "candidate_median_s": statistics.median(p["candidate"]["wall_s"] for p in samples)}
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--baseline", type=Path, required=True)
+    parser.add_argument("--candidate", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--samples", type=int, default=10)
+    parser.add_argument("--files", type=int, default=1000)
+    parser.add_argument("--effects", type=int, default=10)
+    parser.add_argument("--iterations", type=int, default=1000)
+    parser.add_argument("--skip-benchmark", action="store_true")
+    parser.add_argument("--scenarios", nargs="+", choices=("memory", "many", "copy"),
+                        default=("memory", "many", "copy"))
+    args = parser.parse_args()
+    if min(args.files, args.effects, args.iterations) < 1 or args.samples < 10:
+        parser.error("Use positive workload sizes and at least ten measured pairs")
+    if args.effects > 999 or args.files > 10000000:
+        parser.error("Keep effects within the function's default match limit and resrefs within eight characters")
+    args.baseline = args.baseline.resolve(strict=True)
+    args.candidate = args.candidate.resolve(strict=True)
+    args.output = args.output.resolve()
+    args.output.mkdir(parents=True, exist_ok=False)
+    report = {"platform": platform.platform(), "machine": platform.machine(),
+              "python": platform.python_version(), "cpu_count": os.cpu_count(),
+              "configuration": {k: str(v) if isinstance(v, Path) else v
+                                for k, v in vars(args).items()},
+              "binary_sha256": {"baseline": digest(args.baseline.read_bytes()),
+                                "candidate": digest(args.candidate.read_bytes())},
+              "correctness": {}, "benchmarks": {}}
+
+    def save():
+        (args.output / "results.json").write_text(json.dumps(report, indent=2) + "\n")
+
+    for label, binary, detail in (("baseline", args.baseline, False),
+                                   ("candidate", args.candidate, False),
+                                   ("candidate-detail", args.candidate, True)):
+        report["correctness"][label] = correctness(binary, args.output / label, detail,
+                                                   baseline=label == "baseline")
+        regressions(binary, args.output / (label + "-regressions"), detail)
+        save()
+        print(f"{label}: correctness and existing regressions passed", flush=True)
+    if not (report["correctness"]["baseline"] == report["correctness"]["candidate"] ==
+            report["correctness"]["candidate-detail"]):
+        raise AssertionError("Baseline/candidate correctness results differ")
+
+    if not args.skip_benchmark:
+        for scenario in args.scenarios:
+            report["benchmarks"][scenario] = {}
+            for phase in ("install", "reinstall"):
+                pairs = []
+                for sample in range(-1, args.samples):
+                    pair = {}
+                    order = ("baseline", "candidate") if sample % 2 == 0 else ("candidate", "baseline")
+                    for label in order:
+                        directory = args.output / "work" / f"{scenario}-{phase}-{sample}-{label}"
+                        expected = prepare_benchmark(directory, scenario, args)
+                        binary = getattr(args, label)
+                        if phase == "reinstall":
+                            invoke(binary, directory, "prepare")
+                        pair[label], _ = invoke(binary, directory, "measured")
+                        verify_outputs(directory, expected)
+                        # Keep logs while avoiding tens of thousands of artifacts.
+                        shutil.rmtree(directory / "input")
+                        shutil.rmtree(directory / "output")
+                        shutil.rmtree(directory / "backup")
+                    if sample >= 0:
+                        pairs.append(pair)
+                    report["benchmarks"][scenario][phase] = {"samples": pairs}
+                    save()
+                summary = summarize(pairs)
+                report["benchmarks"][scenario][phase]["summary"] = summary
+                save()
+                print(f"{scenario}/{phase}: {json.dumps(summary)}", flush=True)
+    print(f"Results: {args.output / 'results.json'}", flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/test/performance/run_stats_test.py
+++ b/test/performance/run_stats_test.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python3
+"""Compile Stats tests against an existing WeiDU native build, in a temp dir."""
+import argparse
+from pathlib import Path
+import shutil
+import subprocess
+import tempfile
+
+parser = argparse.ArgumentParser(description=__doc__)
+parser.add_argument("--build", type=Path, default=Path("obj"))
+args = parser.parse_args()
+matches = list(args.build.resolve().rglob("stats.cmx"))
+if len(matches) != 1:
+    parser.error("Expected exactly one built stats.cmx below --build")
+objects = matches[0].parent
+with tempfile.TemporaryDirectory(prefix="weidu-stats-test-") as temporary:
+    work = Path(temporary)
+    source = Path(__file__).with_name("stats_test.ml").resolve()
+    shutil.copyfile(source, work / source.name)
+    modules = ("batList", "batteriesInit", "myhashtbl", "hashtblinit", "stats")
+    command = ["ocamlopt", "-unsafe-string", "-I", str(objects), "unix.cmxa"]
+    command += [str(objects / (module + ".cmx")) for module in modules]
+    command += [source.name, "-o", "stats_test.exe"]
+    subprocess.run(command, cwd=work, check=True)
+    subprocess.run([str(work / "stats_test.exe")], cwd=work, check=True)

--- a/test/performance/stats_test.ml
+++ b/test/performance/stats_test.ml
@@ -1,0 +1,43 @@
+(* Run against the built Stats module; see README.md in this directory. *)
+open Hashtblinit
+
+exception Expected_failure
+
+let check enabled =
+  Stats.debug_timings := enabled;
+  Hashtbl.clear Stats.record;
+  Hashtbl.clear Stats.extra;
+  let initial_stack = !Stats.stack in
+  let calls = ref 0 in
+  let value = Stats.time "coarse" (fun () ->
+    Stats.time_detail "detail" (fun value ->
+      incr calls;
+      Stats.inclusive_time "explicit" (fun () -> value) ()) 42) () in
+  assert (value = 42 && !calls = 1);
+  assert (!Stats.stack == initial_stack);
+  assert (Hashtbl.mem Stats.record "coarse");
+  assert (Hashtbl.mem Stats.record "detail" = enabled);
+  assert (Hashtbl.mem Stats.extra "explicit");
+  (try
+    Stats.time "failed coarse" (fun () ->
+      Stats.time_detail "failed detail" (fun () ->
+        incr calls;
+        Stats.time_detail "nested failure" (fun () ->
+          raise Expected_failure) ()) ()) ();
+    assert false
+  with Expected_failure -> ());
+  assert (!calls = 2);
+  assert (!Stats.stack == initial_stack);
+  assert (Hashtbl.mem Stats.record "failed coarse");
+  assert (Hashtbl.mem Stats.record "failed detail" = enabled);
+  assert (Hashtbl.mem Stats.record "nested failure" = enabled);
+  (* A recovered failure must not poison subsequent timing scopes. *)
+  assert (Stats.time "after failure" (fun () -> 7) () = 7);
+  assert (!Stats.stack == initial_stack)
+
+let () =
+  assert (not !Stats.debug_timings);
+  check false;
+  check true;
+  check false;
+  print_endline "Stats tests passed"


### PR DESCRIPTION
Effect-heavy patch loops call `Stats.time` around individual reads, patches, expression evaluations, and function calls, even when no debug log is open. These measurements impose substantial process-timing overhead: a diagnostic case with 1,000 effect visits made 543,608 `getrusage` calls on Linux.

Fine-grained interpreter timings are now opt-in through `--debug-timings`. The four detailed categories use a shared helper that invokes the callback directly when disabled. Coarse operation timings and explicit `PATCH_TIME` measurements remain enabled, with interpreter CPU time attributed to enclosing operations. The flag restores detailed diagnostics. CLI help, documentation, and the changelog describe the change.

### Validation

Baseline: `13f207b12833ce9bbbb119625a9b43b287738c52`  
Candidate: `410d579f0d57a70389b2ccabb45304a9f295fadd`

The synthetic suite compares the baseline, candidate default, and candidate with detailed timing enabled against independent expected resource bytes. It covers ALTER_EFFECT, CLONE_EFFECT, DELETE_EFFECT, SPL/ITM global and ability effects, CRE V1/V2 effect records, nonmatches, repeated alteration, backups, reinstall/uninstall, nested function failures, scope restoration, and uncaught bounds errors. Resource hashes and failure exit codes agree across all four platforms.

Native Stats tests verify single callback execution, return values, exception propagation, nested stack restoration, and retention of coarse/explicit timers. Five existing game-independent TP2 regression files also pass with unsuccessful results converted into fatal errors.

### Measured performance

Fresh-install paired geometric-mean speedups, using one warm-up pair and ten alternating baseline/candidate pairs:

| Platform | In-memory effect patching | 1,000-file effect patching |
| --- | ---: | ---: |
| Linux x64 | 10.36× | 2.48× |
| macOS ARM | 5.99× | 4.04× |
| macOS Intel | 5.73× | 3.69× |
| Windows x64 | 2.56× | 1.93× |

The in-memory case makes 1,000 ALTER_EFFECT calls over ten effects in one loaded resource; the many-file case patches ten effects in each of 1,000 resources. Reinstallation was measured separately and also improves on every platform. Unpatched COPY controls show no statistically significant regression. Fixture preparation and output validation are outside the measured process; hosts use their normal filesystem caches. These results characterize the stated generated workloads and recorded runners.

A separate Linux trace reduces `getrusage` calls from 543,608 to 772 while retaining identical read/write syscall counts. Traced elapsed time is excluded from performance measurements.

[Reproduction instructions](https://github.com/4Luke4/weidu/blob/410d579f0d57a70389b2ccabb45304a9f295fadd/test/performance/README.md) describe the configurable suite and its reporting. Artifacts include raw samples, confidence intervals, logs, executable hashes, compiler configurations, source revisions, and prerequisite provenance.

### CI evidence and prerequisites

- [Measurements and correctness on all four platforms](https://github.com/4Luke4/weidu/actions/runs/34244579088). Both macOS jobs subsequently failed because the temporary archive validator incorrectly required `tolower`, which the macOS packaging target does not ship.
- [Corrected validation and packaged-executable correctness checks](https://github.com/4Luke4/weidu/actions/runs/34247680536). This follow-up uses each packaging target's declared tools and repeats builds, correctness checks, packaging, and resource correctness checks through the packaged executables against the same candidate. Completed benchmark measurements are retained from the first run.
- Linux uses #381's exact archived compiler package and official archive repository. Windows applies #382 (`92a77d3cd9fc2c43929ac9a2b8bc594cd9b4f220`) equally to both build copies. These prerequisites are excluded from this PR; the unchanged `main` workflow still encounters their pre-existing failures.
- The disposable workflow and driver commits are removed from this branch's history. Both runs explicitly build the candidate SHA above; their provenance identifies the tested source independently of the temporary workflow commit.
